### PR TITLE
Update `README.md`

### DIFF
--- a/codegen-plugins/README.md
+++ b/codegen-plugins/README.md
@@ -1,26 +1,65 @@
-## `codegen-plugins` — a separate Gradle project that generates the Kotlin extensions for the Proto messages.
+## `codegen-plugins` — a separate Gradle project that generates `MessageField` and `MessageOneof` implementations for the fields of  Proto messages.
 
-The separate Gradle project is needed because the ProtoData plugin, 
+> The separate Gradle project is needed because the ProtoData plugin, 
 that generates the code, requires the newer version of Gradle 
-comparing to 1DAM project.
+comparing to 1DAM and Chords projects.
 
-It is assumed that the build of this project will be triggered
-from the 1DAM project build, specifically before the `compileKotlin`
-task of the `model` subproject of 1DAM, and executed 
-in a separate process.
+### Run code generation
 
-If the build of the `codegen-plugins` project fails, this also
+The following steps of configuration should be completed in order 
+to run the code generation:
+
+* Add Git submodule that refers [codegen_plugins](https://github.com/SpineEventEngine/Chords/tree/codegen_plugins) 
+branch of [Chords](https://github.com/SpineEventEngine/Chords) repository 
+to the main project repository.
+
+* Copy [RunCodegenPlugins](buildSrc/src/main/kotlin/io/spine/internal/gradle/RunCodegenPlugins.kt) 
+Gradle task to the main project.
+
+* Configure and execute this task in the module, which requires the code generation,
+before `compileKotlin` in the way like following:
+
+```kotlin
+val runCodegenPlugins = tasks.register<RunCodegenPlugins>("runCodegenPlugins") {
+    // Path to the directory where the `codegen-plugins` project is located.
+    pluginsDir = "${rootDir}/chords-codegen/codegen-plugins"
+    // Path to the module which requires the code generation.
+    sourceModuleDir = "${rootDir}/model"
+    // Dependencies that are required to load the Proto files from.
+    dependencies(
+        Spine.Money.lib,
+        Projects.Users.lib,
+        OneDam.DesktopAuth.lib,
+        OneDam.ChordsProtoExt.lib
+    )
+    task("build")
+
+    // Publish to `mavenLocal` required dependencies.
+    dependsOn(
+        project(":desktop-auth")
+            .tasks.named("publishToMavenLocal"),
+        project(":chords-proto-ext")
+            .tasks.named("publishToMavenLocal")
+    )
+}
+
+// Run the code generation before `compileKotlin` task.
+tasks.named("compileKotlin") {
+    dependsOn(
+        runCodegenPlugins
+    )
+}
+
+```
+
+> If the build of `codegen-plugins` project fails, this also
 causes the main build to fail.
 
 ### Modules
 
-* `message-fields` — contains implementation of the ProtoData
-plugin, that generates implementations of MessageField interface for 
-the fields of command Proto messages. The code is also generated for 
-types of command message fields, except for the types provided by Protobuf.
+* `message-fields` — contains implementation of the ProtoData plugin that 
+generates the code.
 
-* `model` — the placeholder where the source code of the `model` 
-subproject of 1DAM will be copied during the build in order to run
-ProtoData plugins and generate the required code. The generated code 
-will be copied back to the `generatedSources` folder of the `model`
-subproject of 1DAM.
+* `model` — the placeholder where the Proto sources of the module, which requires 
+code generation, will be copied during the build. The generated code 
+will be copied back to the `generatedSources` folder of the source module.

--- a/codegen-plugins/README.md
+++ b/codegen-plugins/README.md
@@ -1,10 +1,12 @@
-## `codegen-plugins` — a separate Gradle project that generates `MessageField` and `MessageOneof` implementations for the fields of  Proto messages.
+# `codegen-plugins`
+
+A Gradle project that generates `MessageField` and `MessageOneof` implementations for the fields of  Proto messages.
 
 > The separate Gradle project is needed because the ProtoData plugin, 
 that generates the code, requires the newer version of Gradle 
 comparing to 1DAM and Chords projects.
 
-### Run code generation
+### How to use
 
 The following steps of configuration should be completed in order 
 to run the code generation:
@@ -22,11 +24,15 @@ before `compileKotlin` in the way like following:
 ```kotlin
 val runCodegenPlugins = tasks.register<RunCodegenPlugins>("runCodegenPlugins") {
     // Path to the directory where the `codegen-plugins` project is located.
+    // `chords-codegen` — the name of Git submodule. Set the proper value for your case.
     pluginsDir = "${rootDir}/chords-codegen/codegen-plugins"
     // Path to the module which requires the code generation.
+    // `model` — the name of the module. Put the proper valur for your case.
     sourceModuleDir = "${rootDir}/model"
     // Dependencies that are required to load the Proto files from.
     dependencies(
+        // These ones are just an example.
+        // Pass the libraries that provides Proto files your code depended on.
         Spine.Money.lib,
         Projects.Users.lib,
         OneDam.DesktopAuth.lib,
@@ -36,6 +42,8 @@ val runCodegenPlugins = tasks.register<RunCodegenPlugins>("runCodegenPlugins") {
 
     // Publish to `mavenLocal` required dependencies.
     dependsOn(
+        // These ones are just an example.
+        // Set the modules from your project that are specified as dependencies.
         project(":desktop-auth")
             .tasks.named("publishToMavenLocal"),
         project(":chords-proto-ext")
@@ -49,7 +57,6 @@ tasks.named("compileKotlin") {
         runCodegenPlugins
     )
 }
-
 ```
 
 > If the build of `codegen-plugins` project fails, this also

--- a/codegen-plugins/README.md
+++ b/codegen-plugins/README.md
@@ -2,7 +2,7 @@
 
 A Gradle project that generates `MessageField` and `MessageOneof` implementations for the fields of Proto messages.
 
-> The separate Gradle project is needed because the ProtoData plugin, 
+The separate Gradle project is needed because the ProtoData plugin, 
 that generates the code, requires the newer version of Gradle 
 comparing to 1DAM and Chords projects.
 
@@ -24,27 +24,41 @@ before `compileKotlin` in the way like following:
 ```kotlin
 val runCodegenPlugins = tasks.register<RunCodegenPlugins>("runCodegenPlugins") {
     // Path to the directory where the `codegen-plugins` project is located.
-    // `chords-codegen` — the name of Git submodule. Set the proper value for your case.
+    //
+    // `chords-codegen` — the name of Git submodule. 
+    // Set the proper value for your case.
+    //
     pluginsDir = "${rootDir}/chords-codegen/codegen-plugins"
     
     // Path to the module which requires the code generation.
-    // `model` — the name of the module. Put the proper valur for your case.
+    //
+    // `model` — the name of the module. 
+    // Put the proper valur for your case.
+    //
     sourceModuleDir = "${rootDir}/model"
     
     // Dependencies that are required to load the Proto files from.
     dependencies(
-        // These ones are just an example.
-        // Pass the libraries that provides Proto files your code depended on.
+        // Below is an declaration example.
+        //
+        // This is a list the external dependencies,
+        // onto which the processed Proto sources depend.
+        //
         Spine.Money.lib,
         Projects.Users.lib,
         OneDam.DesktopAuth.lib,
         OneDam.ChordsProtoExt.lib
     )
 
-    // Publish to `mavenLocal` required dependencies.
+    // Publish the local Gradle modules, onto which the original 
+    // Proto source code depends, to `mavenLocal`.
     dependsOn(
-        // These ones are just an example.
-        // Set the modules from your project that are specified as dependencies.
+        // These ones are just an example. In scope of this example,
+        // several local Gradle modules are published to `mavenLocal`,
+        // so that the codegen process is able to access them.
+        //
+        // In your use-case, the list of local modules will differ.
+        //
         project(":desktop-auth")
             .tasks.named("publishToMavenLocal"),
         project(":chords-proto-ext")
@@ -60,8 +74,8 @@ tasks.named("compileKotlin") {
 }
 ```
 
-> If the build of `codegen-plugins` project fails, this also
-> causes the main build to fail.
+If the build of `codegen-plugins` project fails, 
+this also causes the main build to fail.
 
 ### Modules
 
@@ -78,8 +92,8 @@ are copied back to the `generatedSources` folder of the source module.
 
 The same logic applies to `test` sources.
 
-> Please note that the `compileKotlin` and `compileTestKotlin` tasks are disabled
-> in the `model` module due to dependency on `ValidatingBuilder` from Spine 1.9.x. 
-> And therefore there are no tests to check the correctness of the generated files.
+:warning: Please note that the `compileKotlin` and `compileTestKotlin` tasks are disabled
+in the `model` module due to dependency on `ValidatingBuilder` from Spine 1.9.x. 
+And therefore there are no tests to check the correctness of the generated files.
 
 See the [model/build.gradle.kts](model/build.gradle.kts) for details.

--- a/codegen-plugins/README.md
+++ b/codegen-plugins/README.md
@@ -26,9 +26,11 @@ val runCodegenPlugins = tasks.register<RunCodegenPlugins>("runCodegenPlugins") {
     // Path to the directory where the `codegen-plugins` project is located.
     // `chords-codegen` — the name of Git submodule. Set the proper value for your case.
     pluginsDir = "${rootDir}/chords-codegen/codegen-plugins"
+    
     // Path to the module which requires the code generation.
     // `model` — the name of the module. Put the proper valur for your case.
     sourceModuleDir = "${rootDir}/model"
+    
     // Dependencies that are required to load the Proto files from.
     dependencies(
         // These ones are just an example.
@@ -38,7 +40,6 @@ val runCodegenPlugins = tasks.register<RunCodegenPlugins>("runCodegenPlugins") {
         OneDam.DesktopAuth.lib,
         OneDam.ChordsProtoExt.lib
     )
-    task("build")
 
     // Publish to `mavenLocal` required dependencies.
     dependsOn(
@@ -60,13 +61,25 @@ tasks.named("compileKotlin") {
 ```
 
 > If the build of `codegen-plugins` project fails, this also
-causes the main build to fail.
+> causes the main build to fail.
 
 ### Modules
 
-* `message-fields` — contains implementation of the ProtoData plugin that 
-generates the code.
+* `message-fields` — the ProtoData plugin generating the code.
+* `model` — a working-directory module; it is used as a container for the Proto source code,
+  for which the codegen is to be performed.
 
-* `model` — the placeholder where the Proto sources of the module, which requires 
-code generation, will be copied during the build. The generated code 
-will be copied back to the `generatedSources` folder of the source module.
+### How it works
+
+Before executing the `generateProto` task, the Proto source code 
+of the specified module is copied to the `model/src/main/proto` folder.
+Once `launchProtoData` task is executed, the generated Kotlin sources
+are copied back to the `generatedSources` folder of the source module.
+
+The same logic applies to `test` sources.
+
+> Please note that the `compileKotlin` and `compileTestKotlin` tasks are disabled
+> in the `model` module due to dependency on `ValidatingBuilder` from Spine 1.9.x. 
+> And therefore there are no tests to check the correctness of the generated files.
+
+See the [model/build.gradle.kts](model/build.gradle.kts) for details.

--- a/codegen-plugins/README.md
+++ b/codegen-plugins/README.md
@@ -1,6 +1,6 @@
 # `codegen-plugins`
 
-A Gradle project that generates `MessageField` and `MessageOneof` implementations for the fields of  Proto messages.
+A Gradle project that generates `MessageField` and `MessageOneof` implementations for the fields of Proto messages.
 
 > The separate Gradle project is needed because the ProtoData plugin, 
 that generates the code, requires the newer version of Gradle 

--- a/codegen-plugins/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunCodegenPlugins.kt
+++ b/codegen-plugins/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunCodegenPlugins.kt
@@ -57,8 +57,10 @@ open class RunCodegenPlugins : DefaultTask() {
 
     /**
      * The names of the tasks to be passed to the Gradle Wrapper script.
+     *
+     * The "build" task will be executed by default.
      */
-    private lateinit var taskNames: List<String>
+    private var taskNames: MutableList<String> = mutableListOf("build")
 
     /**
      * For how many minutes to wait for the Gradle build to complete.
@@ -81,7 +83,8 @@ open class RunCodegenPlugins : DefaultTask() {
      * Specifies task names to be passed to the Gradle Wrapper script.
      */
     fun task(vararg tasks: String) {
-        taskNames = tasks.asList()
+        taskNames.clear()
+        taskNames.addAll(tasks)
     }
 
     /**
@@ -96,7 +99,8 @@ open class RunCodegenPlugins : DefaultTask() {
      * and specifies task names to be passed to the Gradle Wrapper script.
      */
     fun task(maxDurationMins: Long, vararg tasks: String) {
-        taskNames = tasks.asList()
+        taskNames.clear()
+        taskNames.addAll(tasks)
         this.maxDurationMins = maxDurationMins
     }
 


### PR DESCRIPTION
This PR includes updates on `README.md` that describe how to use code generation.

Also, the "build" task is now the default task to execute in `RunCodegenPlugins`, so there is no need to specify it in the configuration.