### PR TITLE
Update version to `2.0.0-SNAPSHOT.6` and restore publishing

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.5`
+# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -833,12 +833,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 09 17:06:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 09 18:45:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.5`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.6`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2006,4 +2006,4 @@ This report was generated on **Mon Sep 09 17:06:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 09 17:06:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 09 18:45:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.5</version>
+<version>2.0.0-SNAPSHOT.6</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.5")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.6")


### PR DESCRIPTION
This changeset updates the version to `2.0.0-SNAPSHOT.6` and triggers the publishing, which failed for the previous version.