### PR TITLE
Implement extension for `ValidatingBuilder` that returns the implementation of `MessageDef`

### DIFF
--- a/codegen-runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt
+++ b/codegen-runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt
@@ -40,6 +40,14 @@ import com.google.protobuf.Message
  */
 public interface MessageDef<T : Message> {
 
+    public companion object {
+        /**
+         * Defines a suffix for the generated `MessageDef` implementations
+         * so that other parts of the system can rely on it.
+         */
+        public const val MESSAGE_DEF_CLASS_SUFFIX: String = "Def"
+    }
+
     /**
      * Returns collection of [MessageField]s generated for the fields of [T] Proto message.
      */

--- a/codegen-runtime/src/main/kotlin/io/spine/chords/runtime/ValidatingBuilderExts.kt
+++ b/codegen-runtime/src/main/kotlin/io/spine/chords/runtime/ValidatingBuilderExts.kt
@@ -27,6 +27,7 @@
 package io.spine.chords.runtime
 
 import com.google.protobuf.Message
+import io.spine.chords.runtime.MessageDef.Companion.MESSAGE_DEF_CLASS_SUFFIX
 import io.spine.protobuf.ValidatingBuilder
 
 /**
@@ -42,7 +43,8 @@ public fun <M : Message> ValidatingBuilder<M>.messageDef(): MessageDef<M> {
     val messageDefClassName = builderClass.name
         .substringBeforeLast("$")
         .replace("$", "")
-        .plus("DefKt")
+        .plus(MESSAGE_DEF_CLASS_SUFFIX)
+        .plus("Kt")
     val messageDefClass = Class.forName(messageDefClassName)
     val getMessageDefMethod = messageDefClass
         .getMethod("getMessageDef", builderClass)

--- a/codegen-runtime/src/main/kotlin/io/spine/chords/runtime/ValidatingBuilderExts.kt
+++ b/codegen-runtime/src/main/kotlin/io/spine/chords/runtime/ValidatingBuilderExts.kt
@@ -24,7 +24,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package io.spine.chords.runtime
+
+import com.google.protobuf.Message
+import io.spine.protobuf.ValidatingBuilder
+
 /**
-  * The version of all Chords libraries.
-  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.8")
+ * Returns the generated implementation of [MessageDef] for the [M] Proto message.
+ *
+ * Uses Reflection API to read the `messageDef` property on a message builder instance.
+ *
+ * @param M The type of Proto message.
+ */
+@Suppress("Unchecked_cast")
+public fun <M : Message> ValidatingBuilder<M>.messageDef(): MessageDef<M> {
+    val builderClass = this::class.java
+    val messageDefClassName = builderClass.name
+        .substringBeforeLast("$")
+        .replace("$", "")
+        .plus("DefKt")
+    val messageDefClass = Class.forName(messageDefClassName)
+    val getMessageDefMethod = messageDefClass
+        .getMethod("getMessageDef", builderClass)
+    return getMessageDefMethod.invoke(builderClass, this) as MessageDef<M>
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.7`
+# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -833,12 +833,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 11:22:52 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 15:25:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.7`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2006,4 +2006,4 @@ This report was generated on **Tue Sep 10 11:22:52 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 10 11:22:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 13 15:25:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.7</version>
+<version>2.0.0-SNAPSHOT.8</version>
 
 <inceptionYear>2015</inceptionYear>
 


### PR DESCRIPTION
This PR adds an extension to `ValidatingBuilder` that allows reading the `messageDef` property generated for the message builder.