### PR TITLE
Migrate to newer version of `codegen-runtime`

### DIFF
--- a/codegen-plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/Chords.kt
+++ b/codegen-plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/Chords.kt
@@ -31,7 +31,7 @@ object Chords {
 
     private const val group = "io.spine.chords"
     private const val prefix = "spine-chords-"
-    private const val version = "2.0.0-SNAPSHOT.6"
+    private const val version = "2.0.0-SNAPSHOT.8"
 
     object CodegenRuntime {
         const val lib = "$group:${prefix}codegen-runtime:$version"

--- a/codegen-plugins/message-fields/src/main/kotlin/io/spine/chords/protodata/plugin/MessageDefFileGenerator.kt
+++ b/codegen-plugins/message-fields/src/main/kotlin/io/spine/chords/protodata/plugin/MessageDefFileGenerator.kt
@@ -30,6 +30,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.asClassName
 import io.spine.chords.runtime.MessageDef
+import io.spine.chords.runtime.MessageDef.Companion.MESSAGE_DEF_CLASS_SUFFIX
 import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageFieldValue
 import io.spine.chords.runtime.MessageOneof
@@ -121,7 +122,7 @@ internal fun TypeName.messageOneofClassName(fieldName: String): String {
  * Generates a simple class name for the [TypeName].
  */
 internal fun TypeName.messageDefClassName(): String {
-    return generateClassName("", "Def")
+    return generateClassName("", MESSAGE_DEF_CLASS_SUFFIX)
 }
 
 /**

--- a/codegen-plugins/message-fields/src/main/kotlin/io/spine/chords/protodata/plugin/MessageFieldsRenderer.kt
+++ b/codegen-plugins/message-fields/src/main/kotlin/io/spine/chords/protodata/plugin/MessageFieldsRenderer.kt
@@ -28,6 +28,7 @@ package io.spine.chords.protodata.plugin
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
+import io.spine.chords.runtime.MessageDef.Companion.MESSAGE_DEF_CLASS_SUFFIX
 import io.spine.protodata.Field
 import io.spine.protodata.TypeName
 import io.spine.protodata.java.javaPackage
@@ -50,7 +51,6 @@ public class MessageFieldsRenderer : Renderer<Kotlin>(Kotlin.lang()) {
     private companion object {
         private const val KOTLIN_SOURCE_ROOT = "kotlin"
         private const val REJECTIONS_PROTO_FILE_NAME = "rejections.proto"
-        private const val FILE_NAME_SUFFIX = "Def"
     }
 
     /**
@@ -116,7 +116,7 @@ public class MessageFieldsRenderer : Renderer<Kotlin>(Kotlin.lang()) {
      */
     private fun TypeName.generateFileName(): String {
         return nestingTypeNameList.joinToString(
-            "", "", "${simpleName}$FILE_NAME_SUFFIX.kt"
+            "", "", "${simpleName}$MESSAGE_DEF_CLASS_SUFFIX.kt"
         )
     }
 }


### PR DESCRIPTION
This PR includes migration to the latest version of `codegen-runtime`.

The `MessageDef.MESSAGE_DEF_CLASS_SUFFIX` constant is used in code generation.
