### PR TITLE
Fix version increment check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.KotlinX
-import io.spine.internal.gradle.publish.IncrementGuard
 import io.spine.internal.gradle.publish.PublishingRepos
 import io.spine.internal.gradle.publish.spinePublishing
 import io.spine.internal.gradle.report.license.LicenseReporter
@@ -85,6 +84,5 @@ spinePublishing {
     artifactPrefix = "spine-chords-"
 }
 
-apply<IncrementGuard>()
 PomGenerator.applyTo(project)
 LicenseReporter.mergeAllReports(project)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.KotlinX
+import io.spine.internal.gradle.publish.ChordsPublishing
 import io.spine.internal.gradle.publish.PublishingRepos
 import io.spine.internal.gradle.publish.spinePublishing
 import io.spine.internal.gradle.report.license.LicenseReporter
@@ -81,7 +82,7 @@ spinePublishing {
         PublishingRepos.gitHub("Chords"),
         PublishingRepos.cloudArtifactRegistry
     )
-    artifactPrefix = "spine-chords-"
+    artifactPrefix = ChordsPublishing.artifactPrefix
 }
 
 PomGenerator.applyTo(project)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
@@ -88,7 +88,7 @@ open class CheckVersionIncrement : DefaultTask() {
 
     private fun Project.artifactPath(): String {
         val group = this.group as String
-        val name = "spine-${this.name}"
+        val name = "spine-chords-${this.name}"
 
         val pathElements = ArrayList(group.split('.'))
         pathElements.add(name)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
@@ -29,6 +29,7 @@ package io.spine.internal.gradle.publish
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import io.spine.internal.gradle.Repository
+import io.spine.internal.gradle.publish.ChordsPublishing.artifactPrefix
 import java.io.FileNotFoundException
 import java.net.URL
 import org.gradle.api.DefaultTask
@@ -88,7 +89,7 @@ open class CheckVersionIncrement : DefaultTask() {
 
     private fun Project.artifactPath(): String {
         val group = this.group as String
-        val name = "spine-chords-${this.name}"
+        val name = "$artifactPrefix${this.name}"
 
         val pathElements = ArrayList(group.split('.'))
         pathElements.add(name)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ChordsPublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ChordsPublishing.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publish
+
+@Suppress("unused", "ConstPropertyName")
+object ChordsPublishing {
+    /**
+     * The artifact prefix that should be used for all the Chords modules
+     * before the artifact name to publish/read it to/from repositories.
+     */
+    const val artifactPrefix = "spine-chords-"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ChordsPublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ChordsPublishing.kt
@@ -30,7 +30,7 @@ package io.spine.internal.gradle.publish
 object ChordsPublishing {
     /**
      * The artifact prefix that should be used for all the Chords modules
-     * before the artifact name to publish/read it to/from repositories.
+     * before the artifact name for publishing/reading artifacts to/from repositories.
      */
     const val artifactPrefix = "spine-chords-"
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.8`
+# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.9`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -833,12 +833,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 13 15:25:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 12:43:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.8`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.9`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2006,4 +2006,4 @@ This report was generated on **Fri Sep 13 15:25:20 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 13 15:25:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 12:43:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -833,7 +833,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 16 12:43:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 13:24:31 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2006,4 +2006,4 @@ This report was generated on **Mon Sep 16 12:43:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 16 12:43:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Sep 16 13:24:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.8</version>
+<version>2.0.0-SNAPSHOT.9</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.8")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.9")


### PR DESCRIPTION
This PR fixes the version increment check. Actually, fixed the module prefix when fetching the metadata of the remote Maven repository while checking for the versions already published.

Also, the increment version check is disabled for the root module.

P.S. Added constant for artifact prefix for publishing/reading artifacts to/from repositories.