### PR TITLE
Add `client` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This suite contains the following libraries:
   as Protobuf messages.
 - [proto-model](proto-model/README.md) — Protobuf messages and extensions that complement the ones
   found in standard Spine libraries, and are required by the `protobuf` library.
+- [client](client/README.md) — components that support server connectivity using
+  the [Spine Event Engine](https://spine.io/).

--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,7 @@
 ## Chords Spine
 
-This module extends the set of components and facilities provided by the Chords
-and Chords Proto modules with components that support server connectivity using
+Extends the set of components and facilities provided by the Chords Core
+and Chords Protobuf libraries with components that support server connectivity using
 the [Spine Event Engine](https://spine.io/).
 
 This involves such facilities and components as:

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,22 @@
+## Chords Spine
+
+This module extends the set of components and facilities provided by the Chords
+and Chords Proto modules with components that support server connectivity using
+the [Spine Event Engine](https://spine.io/).
+
+This involves such facilities and components as:
+- [Client](src/main/kotlin/io/spine/chords/Client.kt) — an API for
+  interacting with the application server, and the respective 
+  [DesktopClient](src/main/kotlin/io/spine/chords/DesktopClient.kt)
+  implementation.
+- [ClientApplication](src/main/kotlin/io/spine/chords/appshell/ClientApplication.kt) —
+  an extension of `Application` (introduced in the Chords module), which also has
+  a server connection.
+- [CommandMessageForm](src/main/kotlin/io/spine/chords/form/CommandMessageForm.kt) —
+  a variant of the `MessageForm` component (introduced in the Chords Proto 
+  module), which allows editing a posting a command message to the server.
+- [CommandWizard](src/main/kotlin/io/spine/chords/form/CommandMessageForm.kt) —
+  a variant of the `Wizard` component introduced in the Chords module, which
+  represents a multipage editor for a command message, and allows posting the
+  resulting command to the application server.
+- etc.

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+plugins {
+    id("io.spine.tools.gradle.bootstrap")
+    id("org.jetbrains.compose") version "1.5.12"
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    spineSnapshots()
+}
+
+dependencies {
+    implementation(Kotlin.Reflect.lib)
+    implementation(compose.desktop.currentOs)
+    implementation(Material3.Desktop.lib)
+    implementation(Spine.Server.lib)
+    implementation(Projects.Users.lib)
+    implementation(Spine.Chords.core)
+    implementation(project(":chords-proto"))
+    implementation(project(":chords-proto-ext"))
+    implementation(Spine.Chords.CodegenRuntime.lib)
+}

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -9,12 +9,6 @@ plugins {
     id("org.jetbrains.compose") version "1.5.12"
 }
 
-repositories {
-    mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-    spineSnapshots()
-}
-
 dependencies {
     implementation(Kotlin.Reflect.lib)
     implementation(compose.desktop.currentOs)

--- a/client/src/main/kotlin/io/spine/chords/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/Client.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords
+
+import androidx.compose.runtime.MutableState
+import com.google.protobuf.Message
+import io.spine.base.CommandMessage
+import io.spine.base.EntityState
+import io.spine.base.EventMessage
+import io.spine.base.EventMessageField
+import io.spine.core.UserId
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Provides an API for interacting with the application server.
+ */
+ public interface Client {
+
+    /**
+     * The ID of the user on whose behalf this `Client` should send requests to the server.
+     */
+    public val userId: UserId?
+
+    /**
+     * Reads the list of entities with the [entityClass] class into [targetList]
+     * and ensures that future updates to the list are reflected in [targetList]
+     * as well.
+     *
+     * @param entityClass A class of entities that should be read and observed.
+     * @param targetList A [MutableState] that contains a list whose content should be
+     *   populated and kept up to date by this function.
+     * @param entityIdField Reads the value of the entity's field that can uniquely identify
+     *   an entity.
+     */
+    public fun <E : EntityState> readAndObserve(
+        entityClass: Class<E>,
+        targetList: MutableState<List<E>>,
+        entityIdField: (E) -> Any
+    )
+
+    /**
+     * Posts a command to the server.
+     *
+     * @param cmd A command that has to be posted.
+     */
+    public fun command(cmd: CommandMessage)
+
+    /**
+     * Posts a command to the server and awaits for the specified event
+     * to arrive.
+     *
+     * @param cmd A command that has to be posted.
+     * @param event A class of event that has to be waited for after posting
+     *   the command.
+     * @param field A field that should be used for identifying the event to be
+     *   awaited for.
+     * @param fieldValue A value of the field that identifies the event to be
+     *   awaited for.
+     * @return An event specified in the parameters, which was emitted in
+     *   response to the command.
+     * @throws kotlinx.coroutines.TimeoutCancellationException
+     *   If the event doesn't arrive within a reasonable timeout defined
+     *   by the implementation.
+     */
+    public suspend fun <E : EventMessage> command(
+        cmd: CommandMessage,
+        event: Class<E>,
+        field: EventMessageField,
+        fieldValue: Message
+    ): E
+
+    /**
+     * Subscribes to an event with a given class and a given field value (which
+     * would typically be the event's unique identifier field).
+     *
+     * @param event A class of event that has to be subscribed to.
+     * @param field A field that should be used for identifying the event to be
+     *   subscribed to.
+     * @param fieldValue A value of the field that identifies the event to be
+     *   subscribed to.
+     * @return A [CompletableFuture] instance that is completed when the event
+     *   specified by the parameters arrives.
+     */
+    public fun <E : EventMessage> subscribeToEvent(
+        event: Class<E>,
+        field: EventMessageField,
+        fieldValue: Message
+    ): EventSubscription<E>
+
+    /**
+     * Observes the provided event.
+     *
+     * @param event A class of event to observe.
+     * @param onEmit A callback triggered when the desired event is emitted.
+     * @param field A field used for identifying the observed event.
+     * @param fieldValue An identifying field value of the observed event.
+     */
+    public fun <E : EventMessage> observeEvent(
+        event: Class<E>,
+        onEmit: (E) -> Unit,
+        field: EventMessageField,
+        fieldValue: Message
+    )
+}
+
+/**
+ * A subscription for an event.
+ *
+ * @param E Type of subscribed event message.
+ */
+public interface EventSubscription<E: EventMessage> {
+
+    /**
+     * Awaits for the event to arrive, and returns the respective event.
+     *
+     * If invoked after the event has already arrived, this method returns
+     * immediately with the respective event.
+     *
+     * @return An event that is expected to arrive with this subscription.
+     * @throws kotlinx.coroutines.TimeoutCancellationException
+     *   If the event doesn't arrive within a reasonable timeout defined
+     *   by the implementation.
+     */
+    public suspend fun awaitEvent(): E
+}

--- a/client/src/main/kotlin/io/spine/chords/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/DesktopClient.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords
+
+import androidx.compose.runtime.MutableState
+import com.google.protobuf.Message
+import io.grpc.ManagedChannelBuilder
+import io.spine.base.CommandMessage
+import io.spine.base.EntityState
+import io.spine.base.EventMessage
+import io.spine.base.EventMessageField
+import io.spine.client.ClientRequest
+import io.spine.client.EventFilter.eq
+import io.spine.core.UserId
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeout
+
+/**
+ * A period during which a server should provide a reaction in a normally
+ * functioning system (e.g., emit an event in response to a command).
+ */
+private const val ReactionTimeoutMillis = 15_000L
+
+/**
+ * Provides API to interact with the application server via gRPC.
+ *
+ * @param host The host of the application server to which client should connect.
+ * @param port The port on which the application server is listening for gRPC connections.
+ * @param user The callback that should return the user ID on whose behalf
+ *   the `DesktopClient` should send requests to the server.
+ *   If the callback return `null` the client will send requests
+ *   to the server on behalf of the guest user.
+ */
+public class DesktopClient(
+    host: String,
+    port: Int,
+    private val user: () -> UserId? = { null }
+) : Client {
+    private val spineClient: io.spine.client.Client
+
+    init {
+        val channel = ManagedChannelBuilder
+            .forAddress(
+                host,
+                port
+            )
+            .usePlaintext()
+            .build()
+        spineClient = io.spine.client.Client.usingChannel(channel).build()
+    }
+
+    public override val userId: UserId?
+        get() = user()
+
+    /**
+     * Reads the list of entities with the [entityClass] class into [targetList]
+     * and ensures that future updates to the list are reflected in [targetList]
+     * as well.
+     *
+     * @param entityClass A class of entities that should be read and observed.
+     * @param targetList A [MutableState] that contains a list whose content should be
+     *   populated and kept up to date by this function.
+     * @param entityIdField Reads the value of the entity's field that can uniquely identify
+     *   an entity.
+     */
+    public override fun <E : EntityState> readAndObserve(
+        entityClass: Class<E>,
+        targetList: MutableState<List<E>>,
+        entityIdField: (E) -> Any
+    ) {
+        targetList.value = clientRequest().select(entityClass).run()
+
+        clientRequest()
+            .subscribeTo(entityClass)
+            .observe { entity ->
+                updateList(targetList, entity, entityIdField)
+            }
+            .post()
+    }
+
+    /**
+     * Posts a command to the server.
+     *
+     * @param cmd A command that has to be posted.
+     */
+    override fun command(cmd: CommandMessage) {
+        clientRequest()
+            .command(cmd)
+            .postAndForget()
+    }
+
+    /**
+     * Posts a command to the server and awaits for the specified event
+     * to arrive.
+     *
+     * @param cmd A command that has to be posted.
+     * @param event A class of event that has to be waited for after posting
+     *   the command.
+     * @param field A field that should be used for identifying the event to be
+     *   awaited for.
+     * @param fieldValue A value of the field that identifies the event to be awaited for.
+     * @return An event specified in the parameters, which was emitted in
+     *   response to the command.
+     * @throws kotlinx.coroutines.TimeoutCancellationException
+     *   If the event doesn't arrive within a reasonable timeout defined
+     *   by the implementation.
+     */
+    override suspend fun <E : EventMessage> command(
+        cmd: CommandMessage,
+        event: Class<E>,
+        field: EventMessageField,
+        fieldValue: Message
+    ): E = coroutineScope {
+        val eventSubscription = subscribeToEvent(event, field, fieldValue)
+        command(cmd)
+        eventSubscription.awaitEvent()
+    }
+
+    /**
+     * Subscribes to an event with a given class and a given field value (which
+     * would typically be the event's unique identifier field).
+     *
+     * @param event A class of event that has to be subscribed to.
+     * @param field A field that should be used for identifying the event to be
+     *   subscribed to.
+     * @param fieldValue A value of the field that identifies the event to be
+     *   subscribed to.
+     * @return A [CompletableFuture] instance that is completed when the event
+     *   specified by the parameters arrives.
+     */
+    override fun <E : EventMessage> subscribeToEvent(
+        event: Class<E>,
+        field: EventMessageField,
+        fieldValue: Message
+    ): EventSubscription<E> {
+        val eventReceival = CompletableFuture<E>()
+        observeEvent(
+            event = event,
+            onEmit = { evt ->
+                eventReceival.complete(evt)
+            },
+            field = field,
+            fieldValue = fieldValue
+        )
+        return FutureEventSubscription(eventReceival)
+    }
+
+    /**
+     * Observes the provided event.
+     *
+     * @param event A class of event to observe.
+     * @param onEmit A callback triggered when the desired event is emitted.
+     * @param field A field used for identifying the observed event.
+     * @param fieldValue An identifying field value of the observed event.
+     */
+    override fun <E : EventMessage> observeEvent(
+        event: Class<E>,
+        onEmit: (E) -> Unit,
+        field: EventMessageField,
+        fieldValue: Message
+    ) {
+        clientRequest()
+            .subscribeToEvent(event)
+            ?.where(eq(field, fieldValue))
+            ?.observe { evt ->
+                onEmit(evt)
+            }
+            ?.post()
+    }
+
+    /**
+     * A [ClientRequest] instance that can be used for building client's
+     * requests to the server.
+     */
+    private fun clientRequest(): ClientRequest {
+        if (userId != null) {
+            return spineClient.onBehalfOf(userId!!)
+        }
+        return spineClient.asGuest()
+    }
+
+    /**
+     * Updates the content of [targetList] by merging in the given [entity]
+     * into it.
+     *
+     * The merging here is either an addition of the new item specified by
+     * the [entity] parameter, or, if there's already an item that has the same
+     * ID in the field identified by [entityIdField], a replacement of
+     * the corresponding item with the one passed in [entity].
+     *
+     * @param targetList A [MutableState] that contains a list to be updated.
+     * @param entity An item that has to be merged into the list.
+     * @param entityIdField A function that, given a list item, or a value of [entity],
+     *   returns the value of its field, which uniquely identifies
+     *   the respective instance.
+     */
+    private fun <E : EntityState> updateList(
+        targetList: MutableState<List<E>>,
+        entity: E,
+        entityIdField: (E) -> Any
+    ) {
+        val prevList = targetList.value
+        val existingItemIndex = prevList.indexOfFirst { e ->
+            entityIdField(e) == entityIdField(entity)
+        }
+
+        val newList = if (existingItemIndex != -1) {
+            prevList.subList(0, existingItemIndex - 1) +
+                    entity +
+                    prevList.subList(existingItemIndex + 1, prevList.size)
+        } else {
+            prevList + entity
+        }
+
+        targetList.value = newList
+    }
+}
+
+/**
+ * An [EventSubscription] implementation that is based on
+ * a [CompletableFuture] instance.
+ *
+ * @param future A `CompletableFuture`, which is expected to provide
+ *   the respective event.
+ */
+private class FutureEventSubscription<E: EventMessage>(
+    private val future: CompletableFuture<E>
+) : EventSubscription<E> {
+
+    override suspend fun awaitEvent(): E {
+        return withTimeout(ReactionTimeoutMillis) { future.await() }
+    }
+}

--- a/client/src/main/kotlin/io/spine/chords/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/EntityChooser.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
+import io.spine.chords.appshell.app
+import io.spine.base.EntityState
+import io.spine.chords.appshell.client
+import io.spine.chords.runtime.MessageFieldValue
+import kotlin.reflect.full.allSupertypes
+import kotlin.reflect.javaType
+
+/**
+ * A drop-down list, which allows the user to choose an entity among all
+ * entities of a given type.
+ *
+ * This component allows the user to pick a respective item by looking it up
+ * in the drop-down list associated with the component. This drop-down list
+ * displays items for all respective entities of a given type [E], and allows
+ * the user to filter this list by entering a search substring within the
+ * component's input field.
+ *
+ * Like any [InputComponent][io.spine.chords.InputComponent], this
+ * component identifies the currently selected item using its [value] property.
+ * It should be noted that the [value] property contains the entity's ID (of
+ * type [I]), and not the entity state of type [E] itself, which is just used
+ * internally within the component.
+ *
+ * In order to implement a concrete component for choosing entities of some
+ * particular type, the component's implementation that extends this class has
+ * to specify the type of items to be searched for by implementing the
+ * [entityStateClass] method, and implement [entityId] and [itemText] methods.
+ *
+ * @param I a type of entity ID.
+ * @param E a type of entity state.
+ */
+@Stable
+public abstract class EntityChooser<
+        I : MessageFieldValue,
+        E : EntityState // Keep in sync with the `TypeParameters` enum!
+        > : DropdownSelector<I>() {
+
+    /**
+     * An enumeration of class's type parameters.
+     */
+    @Suppress("unused" /* All type parameters are listed for
+    completeness despite only a part of them might be used via this enum. */)
+    private enum class TypeParameters(val index: Int) {
+
+        /**
+         * The entity ID type parameter (`I` class's parameter).
+         */
+        ID(0),
+
+        /**
+         * The entity state type parameter (`E` class's parameter).
+         */
+        ENTITY_STATE(1)
+    }
+
+    override val items: MutableState<Iterable<I>> = mutableStateOf(listOf())
+
+    private val entityStates = run {
+        val entityStates = mutableStateOf(listOf<E>())
+        app.client.readAndObserve(entityStateClass, entityStates, ::entityId)
+        entityStates
+    }
+
+    private val entityStatesByIds: HashMap<I, E> = hashMapOf()
+
+    /**
+     * A function which has to be implemented to provide a value of
+     * type `Class[E]` for the component which is being implemented.
+     *
+     * E.g., if [E] is a `User` class, it would just specify `User::class.java`.
+     */
+    @OptIn(ExperimentalStdlibApi::class)
+    private val entityStateClass: Class<E> get() {
+        val parameterizedEntityChooserType = this::class.allSupertypes.first {
+            it.classifier == EntityChooser::class
+        }
+        val entityStateType =
+            parameterizedEntityChooserType.arguments[TypeParameters.ENTITY_STATE.index].type
+        checkNotNull(entityStateType) {
+            "The V type parameter (entity value type) cannot be a star <*> projection. "
+        }
+
+        // We only have the entity state type as an abstract `Type` value at
+        // runtime, so we have no other choice than to explicitly cast it to
+        // Class<E> here (it's safe as long as `TypeParameters` enum is kept
+        // up to date).
+        @Suppress("UNCHECKED_CAST")
+        return entityStateType.javaType as Class<E>
+    }
+
+    /**
+     * Returns the unique identifier of the given entity.
+     *
+     * @param entityState
+     *         an entity state whose unique identifier should be returned.
+     * @return a unique identifier field of the given [entityState].
+     */
+    protected abstract fun entityId(entityState: E): I
+
+    /**
+     * A function, which has to be implemented to provide a text representation
+     * for the given entity's item.
+     *
+     * Item text representations are used for displaying item contents in
+     * the list, and define the text by which items can be searched/filtered by
+     * the user within the component's input field.
+     *
+     * @param entityId
+     *         an ID of an entity displayed in this item.
+     * @param entityState
+     *         an entity displayed in the item whose text representation should
+     *         be obtained.
+     * @return an item's text representation.
+     */
+    protected abstract fun itemText(entityId: I, entityState: E?): String?
+
+    /**
+     * Given an entity ID, returns the respective entity state.
+     *
+     * @param entityId
+     *         ID of an entity whose state should be obtained.
+     * @return an entity state with the specified ID.
+     */
+    protected fun entityById(entityId: I): E? = entityStatesByIds[entityId]
+
+    /**
+     * Renders the composable content that should be displayed in a drop-down
+     * list item identified by the provided parameters.
+     *
+     * This function can be overridden to customize what is displayed within
+     * each drop-down list item. By default, this method displays the item's
+     * text representation as defined by the [entityItemText] function, with
+     * highlighting its portion that matches the [searchString] entered by
+     * the user.
+     *
+     * @param entityId
+     *         ID of an item whose content should be rendered.
+     * @param entityState
+     *         an entity state that corresponds to the item being rendered.
+     * @param entityItemText
+     *         an entity item's text representation as defined by
+     *         the [itemText] function.
+     */
+    @Composable
+    protected open fun itemContent(entityId: I, entityState: E?, entityItemText: String) {
+        super.itemContent(entityId, entityItemText)
+    }
+
+    // A changed parameter name reflects a more concrete meaning of this
+    // parameter in this component.
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun itemText(entityId: I): String {
+        val entityState = entityById(entityId)
+        return itemText(entityId, entityState) ?: ""
+    }
+
+    @Composable
+    // A changed parameter name reflects a more concrete meaning of this
+    // parameter in this component.
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun itemContent(entityId: I, entityItemText: String) {
+        val entityState = entityById(entityId)
+        itemContent(entityId, entityState, entityItemText)
+    }
+
+    @Composable
+    @ReadOnlyComposable
+    override fun beforeComposeContent() {
+        super.beforeComposeContent()
+        entityStatesByIds.clear()
+        entityStates.value.forEach {
+            entityStatesByIds[entityId(it)] = it
+        }
+        items.value = entityStates.value.map { entityId(it) }
+    }
+}

--- a/client/src/main/kotlin/io/spine/chords/appshell/ClientApplication.kt
+++ b/client/src/main/kotlin/io/spine/chords/appshell/ClientApplication.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords.appshell
+
+import io.spine.chords.Client
+
+/**
+ * Makes the [ClientApplication]'s [client][ClientApplication.client] property
+ * to be available via a shortcut `app.client` expression.
+ */
+// The receiver is needed to specify a "static" context for the function.
+@Suppress("UnusedReceiverParameter")
+public val Application.client: Client get() = (app as ClientApplication).client
+
+/**
+ * A variant of [Application] that represents a client application, which
+ * interacts with the application server.
+ *
+ * @param name
+ *         an application's name, which is in particular displayed in
+ *         the application window's title.
+ * @param client
+ *         a [Client] that handles the server communication, which should be
+ *         used throughout the application.
+ * @param views
+ *         the list application's views.
+ * @param initialView
+ *         allows to specify a view from the list of [views], if any view other
+ *         than the first one has to be displayed when the application starts.
+ */
+public open class ClientApplication(
+    name: String,
+    public val client: Client,
+    views: List<AppView>,
+    initialView: AppView? = null
+) : Application(name, views, initialView)

--- a/client/src/main/kotlin/io/spine/chords/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/form/CommandMessageForm.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords.form
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import io.spine.chords.appshell.app
+import io.spine.chords.AbstractComponentCompanion
+import io.spine.base.CommandMessage
+import io.spine.base.EventMessage
+import io.spine.chords.ComponentProps
+import io.spine.chords.EventSubscription
+import io.spine.chords.appshell.client
+import io.spine.protobuf.ValidatingBuilder
+import kotlinx.coroutines.TimeoutCancellationException
+
+/**
+ * A form that allows entering a value of a command message and posting
+ * the respective command.
+ *
+ * It can be used in the same way as the [MessageForm] class, and adds
+ * the [postCommand] function, which post the command with the entered field
+ * values, and awaits for receiving the feedback upon its processing.
+ *
+ * @param C
+ *         a type of the command message being edited with the form.
+ */
+public class CommandMessageForm<C : CommandMessage> :
+    MessageForm<C>() {
+
+    /**
+     * Form instance declaration and creation API.
+     */
+    public companion object : AbstractComponentCompanion({
+        CommandMessageForm<CommandMessage>()
+    }) {
+
+        /**
+         * Declares a `CommandMessageForm` instance, which is not bound to
+         * a parent form automatically, and can be bound to the respective data
+         * field manually as needed.
+         *
+         * The form's content that is specified with the [content] parameter is
+         * expected to include field editors for all command message's fields,
+         * which are required to create a valid value of type [C].
+         *
+         * @param C
+         *         a type of the command being edited with the form.
+         * @param B
+         *         a type of the command message builder.
+         * @param builder
+         *         a lambda that should create and return a new builder for
+         *         a command of type [C].
+         * @param value
+         *         the command message value to be edited within the form.
+         * @param props
+         *         a lambda that can set any additional props on the form.
+         * @param content
+         *         a form's content, which can contain an arbitrary layout along
+         *         with field editor declarations.
+         * @return a form's instance that has been created for this
+         *         declaration site.
+         */
+        @Composable
+        public operator fun <C : CommandMessage, B: ValidatingBuilder<out C>> invoke(
+            builder: () -> B,
+            value: MutableState<C?> = mutableStateOf(null),
+            props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
+            content: @Composable FormPartScope<C>.() -> Unit
+        ): CommandMessageForm<C> = Multipart(builder, value, props) {
+            FormPart(content)
+        }
+
+        /**
+         * Declares a multipart `CommandMessageForm` instance, which is not
+         * bound to a parent form automatically, and can be bound to
+         * the respective data field manually as needed.
+         *
+         * The form's content that is specified with the [content] parameter
+         * should specify each form's part with using
+         * [FormPart][MultipartFormScope.FormPart] declarations, which, in turn,
+         * should contain the respective field editors.
+         *
+         * @param C
+         *         a type of the command message being edited with the form.
+         * @param B
+         *         a type of the command message builder.
+         * @param value
+         *         the command message value to be edited within the form.
+         * @param builder
+         *         a lambda that should create and return a new builder for
+         *         a message of type [M].
+         * @param props
+         *         a lambda that can set any additional props on the form.
+         * @param content
+         *         a form's content, which can contain an arbitrary layout along
+         *         with field editor declarations.
+         * @return a form's instance that has been created for this
+         *         declaration site.
+         */
+        @Composable
+        public fun <C : CommandMessage, B: ValidatingBuilder<out C>> Multipart(
+            builder: () -> B,
+            value: MutableState<C?> = mutableStateOf(null),
+            props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
+            content: @Composable MultipartFormScope<C>.() -> Unit
+        ): CommandMessageForm<C> = createAndRender({
+            this.value = value
+            this.builder = builder as () -> ValidatingBuilder<C>
+            multipartContent = content
+            props.run { configure() }
+        }) {
+            Content()
+        }
+
+        /**
+         * Creates a [CommandMessageForm] instance without rendering it in
+         * the composable content with the same call.
+         *
+         * This method can be used to create a form's instance outside
+         * a composable context, and render it separately. A form's instance
+         * created in this way, has to be rendered  explicitly by calling either
+         * its [Content] method (for single-part forms) or its
+         * [MultipartContent] method (for rendering a multipart form) in
+         * a composable context where it needs to be displayed.
+         *
+         * @param C
+         *         a type of the command message being edited with the form.
+         * @param B
+         *         a type of the command message builder.
+         * @param builder
+         *         a lambda that should create and return a new builder for
+         *         a message of type [M].
+         * @param value
+         *         the command message value to be edited within the form.
+         * @param onBeforeBuild
+         *         a lambda that allows to amend the command message
+         *         after any valid field is entered to it.
+         * @param props
+         *         a lambda that can set any additional props on the form.
+         * @return a form's instance that has been created for this
+         *         declaration site.
+         */
+        public fun <C : CommandMessage, B: ValidatingBuilder<out C>> create(
+            builder: () -> B,
+            value: MutableState<C?> = mutableStateOf(null),
+            onBeforeBuild: B.() -> Unit = {},
+            props: ComponentProps<CommandMessageForm<C>> = ComponentProps {}
+        ): CommandMessageForm<C> =
+            super.create(null) {
+                this.value = value
+                this.builder = builder as () -> ValidatingBuilder<C>
+                this.onBeforeBuild = onBeforeBuild as ValidatingBuilder<out C>.() -> Unit
+                props.run { configure() }
+            }
+    }
+
+    /**
+     * A function, which, given a command message that is about to be posted,
+     * should subscribe to a respective event that is expected to arrive in
+     * response to handling that command.
+     */
+    public lateinit var eventSubscription: (C) -> EventSubscription<out EventMessage>
+
+    override fun initialize() {
+        super.initialize()
+        check(this::eventSubscription.isInitialized) {
+            "CommandMessageForm's `eventSubscription` property must " +
+            "be specified."
+        }
+    }
+
+    /**
+     * Posts the command based on all currently entered data and awaits
+     * the feedback upon processing the command.
+     *
+     * Here's a more detailed description about the sequence of actions
+     * performed by this method:
+     * - Validates the data entered in the form and builds the respective
+     *   command message. In case if any validation errors are encountered, this
+     *   method skips further stages, and just makes the respective validation
+     *   errors to be displayed.
+     * - Posts the command that was validated and built.
+     * - Awaits for an event that should arrive upon successful handling of
+     *   the command, as defined by the [eventSubscription]
+     *   constructor's parameters.
+     * - If the event doesn't arrive in a predefined timeout that is considered
+     *   an adequate delay from user's perspective, this method
+     *   throws [TimeoutCancellationException].
+     *
+     * @return `true` if the command was successfully built without any
+     *         validation errors, and `false` if the command message could not
+     *         be successfully built from the currently entered data (validation
+     *         errors are displayed to the user in this case).
+     * @throws TimeoutCancellationException
+     *         if the event doesn't arrive within a reasonable timeout defined
+     *         by the implementation.
+     */
+    public suspend fun postCommand(): Boolean {
+        updateValidationDisplay(true)
+        if (!valueValid.value) {
+            return false
+        }
+        val command = value.value
+        check(command != null) {
+            "CommandMessageForm's value should be not null since it was just " +
+            "checked to be valid within postCommand."
+        }
+        return try {
+            val subscription = eventSubscription(command)
+            app.client.command(command)
+            subscription.awaitEvent()
+            true
+        } catch (
+            @Suppress(
+                // Using a defensive wide-scope catch to cover any message
+                // creation failures.
+                "TooGenericExceptionCaught",
+                // TODO:2023-09-22:dmitry.pikhulya: handle server communication errors
+                //                                  https://github.com/Projects-tm/1DAM/issues/17
+                "SwallowedException"
+            )
+            e: Exception
+        ) {
+            false
+        }
+    }
+}

--- a/client/src/main/kotlin/io/spine/chords/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/layout/CommandWizard.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import com.google.protobuf.Message
+import io.spine.chords.form.FormFieldsScope
+import io.spine.chords.form.MessageForm
+import io.spine.chords.form.FormPartScope
+import io.spine.chords.form.ValidationDisplayMode.MANUAL
+import io.spine.base.CommandMessage
+import io.spine.base.EventMessage
+import io.spine.chords.EventSubscription
+import io.spine.chords.form.CommandMessageForm
+import io.spine.chords.runtime.MessageField
+import io.spine.protobuf.ValidatingBuilder
+
+/**
+ * A kind of [Wizard], which allows creating a command message and posting
+ * the respective command.
+ *
+ * Its usage is similar to [Wizard], but has some specifics:
+ * - In order to use [CommandWizard], the respective command message has to be
+ *   structured respectively. All of its fields have to be split into meaningful
+ *   sub-messages. Each of these sub-messages would have a respective field in
+ *   the command message, and would be edited in a corresponding separate
+ *   wizard's page (one wizard's page per one command's sub-message).
+ * - The [createPages] method of this class has to be implemented to return
+ *   subclasses of [CommandWizardPage] instead of
+ *   a generic [WizardPage][io.spine.chords.layout.WizardPage].
+ * - The content of each page implemented in this way is automatically included
+ *   into a form that composes the respective message's field. The context of
+ *   that form is passed as the [FormPartScope] receiver of the
+ *   [page][CommandWizardPage]'s [content][CommandWizardPage.content] method.
+ * - This means that you can place respective [Field][FormFieldsScope.Field]
+ *   declarations right in the [content][CommandWizardPage.content] method.
+ *
+ * @param C
+ *         a type of the command message constructed in the wizard.
+ * @param B
+ *         a type of the command message builder.
+ */
+@Stable
+public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<out C>> : Wizard() {
+
+    internal val commandMessageForm: CommandMessageForm<C> =
+        CommandMessageForm.create({ createCommandBuilder() },
+            onBeforeBuild = { beforeBuild(this) }) {
+            validationDisplayMode = MANUAL
+            eventSubscription = { subscribeToEvent(it) }
+        }
+
+    /**
+     * Creates the pages that the wizard consists of.
+     *
+     * Each page should aim to construct a `Message` which is a field
+     * of the `CommandMessage` constructed by this wizard.
+     */
+    protected abstract override fun createPages():
+            List<CommandWizardPage<out Message, out ValidatingBuilder<out Message>>>
+
+    /**
+     * The page of this wizard on which the focus was the last time.
+     */
+    internal var lastFocusedPage:
+            CommandWizardPage<out Message, out ValidatingBuilder<out Message>>? = null
+
+    /**
+     * A function that should be implemented to create and return a new builder
+     * for the command message of type [C].
+     *
+     * This function should in particular assign command ID field, and any
+     * fields that are not edited in the wizard, but need to be specified in
+     * a properly built command.
+     */
+    protected abstract fun createCommandBuilder(): B
+
+    /**
+     * A function, which, given a command message that is about to be posted,
+     * should subscribe to a respective event that is expected to arrive in
+     * response to handling that command.
+     *
+     * @param command
+     *         a command, which is going to be posted.
+     * @return a subscription to the event that is expected to arrive in response
+     *         to handling [command]
+     */
+    protected abstract fun subscribeToEvent(command: C): EventSubscription<out EventMessage>
+
+    /**
+     * Allows to programmatically amend the command message builder before
+     * the command is built.
+     *
+     * This function is invoked upon every attempt to build the command edited
+     * in the wizard, which happens when any command's field is edited by the
+     * user. When this function is invoked, the command builder's fields have
+     * already been set from all form's field editors, which currently have
+     * valid values. Note that there is no guarantee that the command message
+     * that is about to be built is going to be valid.
+     *
+     * The builder is passed as the receiver of this function,
+     * so properties can be set and read without referring to the builder
+     * explicitly. For example, if we wanted to set command's `field1` and
+     * `field2` explicitly, this could be done like this:
+     *
+     * ```
+     *     class WizardImpl: CommandWizard(...) {
+     *
+     *         override fun CommandMessage.Builder.onBeforeBuild() = {
+     *             field1 = field1Value
+     *             field2 = field2Value
+     *         }
+     *     }
+     * ```
+     */
+    protected open fun beforeBuild(builder: B) {}
+
+    override suspend fun submit(): Boolean {
+        return commandMessageForm.postCommand()
+    }
+}
+
+/**
+ * A base class for a page in `CommandWizard`, which helps fill in a message
+ * that constitutes the content of one the command message's fields.
+ *
+ * @param M A type of the command's field edited in this page.
+ * @param B A builder type of the command's field edited in this page.
+ *
+ * @param wizard The wizard that this page is a part of.
+ * @param commandField The command's field whose content is edited in this page.
+ * @param builder A function that should create and return a builder for message
+ *   a with a type of [M].
+ */
+public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M>>(
+    protected override val wizard: CommandWizard<out CommandMessage,
+                                                 out ValidatingBuilder<out CommandMessage>>,
+    private val commandField: MessageField<out CommandMessage, M>,
+    private val builder: () -> B
+): AbstractWizardPage(wizard) {
+    private var pageForm: MessageForm<M>? = null
+        set(value) {
+            if (field == null) {
+                require(value != null)
+                field = value
+            } else {
+                require(value == field)
+            }
+        }
+
+    @Composable
+    override fun content() {
+        val commandMessageForm = wizard.commandMessageForm as CommandMessageForm<CommandMessage>
+        commandMessageForm.MultipartContent {
+            FormPart(showPart = { show() }) {
+                Field(commandField as MessageField<CommandMessage, M>) {
+                    if (pageForm == null) {
+                        pageForm = MessageForm.create(fieldValue, this@CommandWizardPage.builder) {
+                            validationDisplayMode = MANUAL
+                        }
+                    }
+                    pageForm!!.Content {
+                        content()
+                    }
+                }
+            }
+        }
+
+        if (wizard.lastFocusedPage != this) {
+            wizard.lastFocusedPage = this
+            pageForm?.focus()
+        }
+    }
+
+    /**
+     * The composable content that should include the fields
+     * ([Field][FormFieldsScope.Field] declarations) for a part of command's
+     * message that corresponds to this page.
+     */
+    @Composable
+    protected abstract fun FormPartScope<M>.content()
+
+    override fun validate(): Boolean {
+        val form = pageForm!!
+        form.updateValidationDisplay(true)
+        return form.valueValid.value
+    }
+}

--- a/client/src/main/kotlin/io/spine/chords/person/UserChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/person/UserChooser.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+package io.spine.chords.person
+
+import com.teamdev.projects.v2.users.user.UserProfile
+import io.spine.chords.ComponentCompanion
+import io.spine.chords.EntityChooser
+import io.spine.core.UserId
+import io.spine.person.format
+
+/**
+ * A drop-down list that allows selecting a user defined by the [UserId] type.
+ */
+public class UserChooser : EntityChooser<UserId, UserProfile>() {
+
+    /**
+     * A component instance declaration API.
+     */
+    public companion object : ComponentCompanion<UserChooser>({ UserChooser() })
+
+    init {
+        label = "User"
+    }
+
+    override fun entityId(entityState: UserProfile): UserId = entityState.id
+    override fun itemText(entityId: UserId, entityState: UserProfile?): String? =
+        entityState?.info?.name?.format()
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -778,7 +778,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 16:28:40 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 17:30:04 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1778,7 +1778,7 @@ This report was generated on **Tue Sep 17 16:28:40 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 16:28:43 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 17:30:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2591,7 +2591,7 @@ This report was generated on **Tue Sep 17 16:28:43 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 16:28:45 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 17:30:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3608,4 +3608,4 @@ This report was generated on **Tue Sep 17 16:28:45 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 16:28:47 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 17:30:10 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.10`
+# Dependencies of `io.spine.chords:spine-chords-codegen-runtime:2.0.0-SNAPSHOT.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -778,12 +778,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 17:30:04 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 19:00:27 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.10`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1778,12 +1778,12 @@ This report was generated on **Tue Sep 17 17:30:04 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 17:30:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 19:00:30 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-model:2.0.0-SNAPSHOT.10`
+# Dependencies of `io.spine.chords:spine-chords-proto-model:2.0.0-SNAPSHOT.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2591,12 +2591,12 @@ This report was generated on **Tue Sep 17 17:30:06 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 17:30:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 19:00:32 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-protobuf:2.0.0-SNAPSHOT.10`
+# Dependencies of `io.spine.chords:spine-chords-protobuf:2.0.0-SNAPSHOT.11`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3608,4 +3608,4 @@ This report was generated on **Tue Sep 17 17:30:08 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 17 17:30:10 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 17 19:00:34 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.10</version>
+<version>2.0.0-SNAPSHOT.11</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.10")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.11")


### PR DESCRIPTION
Adds the Chords Client library (residing in the `client` module), which complements the other libraries with components that support server connectivity using the Spine Event Engine.
