### PR TITLE
Extend the `Client` API to allow reading entities by ID

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -63,6 +63,17 @@ import java.util.concurrent.CompletableFuture
     )
 
     /**
+     * Retrieves an entity of the specified class with the given ID.
+     *
+     * @param entityClass The class of the entity to retrieve.
+     * @param entityIdFieldValue The ID of the entity to retrieve.
+     */
+    public fun <E : EntityState, M : Message> read(
+        entityClass: Class<E>,
+        entityIdFieldValue: M
+    ): E?
+
+    /**
      * Posts a command to the server.
      *
      * @param cmd A command that has to be posted.

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -66,11 +66,11 @@ import java.util.concurrent.CompletableFuture
      * Retrieves an entity of the specified class with the given ID.
      *
      * @param entityClass The class of the entity to retrieve.
-     * @param entityIdFieldValue The ID of the entity to retrieve.
+     * @param id The ID of the entity to retrieve.
      */
     public fun <E : EntityState, M : Message> read(
         entityClass: Class<E>,
-        entityIdFieldValue: M
+        id: M
     ): E?
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -108,15 +108,15 @@ public class DesktopClient(
      * Retrieves an entity of the specified class with the given ID.
      *
      * @param entityClass The class of the entity to retrieve.
-     * @param entityIdFieldValue The ID of the entity to retrieve.
+     * @param id The ID of the entity to retrieve.
      */
     public override fun <E : EntityState, M : Message> read(
         entityClass: Class<E>,
-        entityIdFieldValue: M
+        id: M
     ): E? {
         val entities = clientRequest()
             .select(entityClass)
-            .byId(entityIdFieldValue)
+            .byId(id)
             .run()
         if (entities.isEmpty()) {
             return null

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -105,6 +105,26 @@ public class DesktopClient(
     }
 
     /**
+     * Retrieves an entity of the specified class with the given ID.
+     *
+     * @param entityClass The class of the entity to retrieve.
+     * @param entityIdFieldValue The ID of the entity to retrieve.
+     */
+    public override fun <E : EntityState, M : Message> read(
+        entityClass: Class<E>,
+        entityIdFieldValue: M
+    ): E? {
+        val entities = clientRequest()
+            .select(entityClass)
+            .byId(entityIdFieldValue)
+            .run()
+        if (entities.isEmpty()) {
+            return null
+        }
+        return entities[0];
+    }
+
+    /**
      * Posts a command to the server.
      *
      * @param cmd A command that has to be posted.

--- a/codegen/gradle-plugin/build.gradle.kts
+++ b/codegen/gradle-plugin/build.gradle.kts
@@ -35,7 +35,7 @@ import io.spine.internal.gradle.publish.SpinePublishing
 plugins {
     `java-gradle-plugin`
     `maven-publish`
-    id("com.gradle.plugin-publish") version "0.12.0"
+//    id("com.gradle.plugin-publish") version "0.12.0"
     id("com.github.johnrengelman.shadow").version("6.1.0")
 }
 
@@ -78,17 +78,17 @@ tasks.named("test") {
     dependsOn(functionalTestTask)
 }
 
-pluginBundle {
-    website = "https://spine.io"
-    vcsUrl = "https://github.com/SpineEventEngine/Chords/tree/master/codegen/gradle-plugin"
-    tags = listOf("spine", "chords", "gradle", "plugin", "codegen")
-
-    mavenCoordinates {
-        groupId = "io.spine.chords"
-        artifactId = "spine-chords-gradle-plugin"
-        version = versionToPublish
-    }
-}
+//pluginBundle {
+//    website = "https://spine.io"
+//    vcsUrl = "https://github.com/SpineEventEngine/Chords/tree/master/codegen/gradle-plugin"
+//    tags = listOf("spine", "chords", "gradle", "plugin", "codegen")
+//
+//    mavenCoordinates {
+//        groupId = "io.spine.chords"
+//        artifactId = "spine-chords-gradle-plugin"
+//        version = versionToPublish
+//    }
+//}
 
 gradlePlugin {
     plugins {
@@ -216,13 +216,13 @@ project.afterEvaluate {
 
 // Do not attempt to publish snapshot versions to comply with publishing rules.
 // See: https://plugins.gradle.org/docs/publish-plugin#approval
-val publishPlugins: Task by tasks.getting {
-    enabled = !versionToPublish.isSnapshot()
-}
-
-val publish: Task by tasks.getting {
-    dependsOn(publishPlugins)
-}
+//val publishPlugins: Task by tasks.getting {
+//    enabled = !versionToPublish.isSnapshot()
+//}
+//
+//val publish: Task by tasks.getting {
+//    dependsOn(publishPlugins)
+//}
 
 configureTaskDependencies()
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1066,7 +1066,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:49 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:35 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1925,7 +1925,7 @@ This report was generated on **Tue Oct 01 13:56:49 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:51 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:36 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2912,12 +2912,12 @@ This report was generated on **Tue Oct 01 13:56:51 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:52 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:38 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.1`
+# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3668,7 +3668,7 @@ This report was generated on **Tue Oct 01 13:56:52 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:54 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:39 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4672,7 +4672,7 @@ This report was generated on **Tue Oct 01 13:56:54 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:55 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:40 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5471,7 +5471,7 @@ This report was generated on **Tue Oct 01 13:56:55 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:56 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:41 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6240,4 +6240,4 @@ This report was generated on **Tue Oct 01 13:56:56 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 13:56:57 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 15:15:42 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:20 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:49 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Fri Sep 27 14:40:20 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:51 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Fri Sep 27 14:40:21 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:21 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:52 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.0`
+# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.1`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3668,12 +3668,12 @@ This report was generated on **Fri Sep 27 14:40:21 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:22 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:54 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4672,12 +4672,12 @@ This report was generated on **Fri Sep 27 14:40:22 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:55 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5471,12 +5471,12 @@ This report was generated on **Fri Sep 27 14:40:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:56 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6240,4 +6240,4 @@ This report was generated on **Fri Sep 27 14:40:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 27 14:40:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 01 13:56:57 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.23</version>
+<version>2.0.0-SNAPSHOT.24</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -41,4 +41,4 @@ val chordsVersion: String by extra("2.0.0-SNAPSHOT.24")
  *
  * Update this version if the `chordsVersion` is updated.
  */
-val gradlePluginVersion: String by extra("1.9.1")
+val gradlePluginVersion: String by extra("1.9.2")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,7 +27,7 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.23")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.24")
 
 
 /**


### PR DESCRIPTION
This PR extends the `Client` API to allow reading entities by ID from the application read side.

Also, as of this PR we temporarily disable the publication of Chords Gradle plugin to the Gradle plugin portal, since it still lacks the documentation, and therefore, wasn't approved by the Gradle team.