### PR TITLE
Use Gradle plugin for code generation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "config"]
 	path = config
 	url = https://github.com/SpineEventEngine/config
-[submodule "codegen/workspace"]
-	path = codegen/workspace
-	url = git@github.com:SpineEventEngine/Chords.git
-	branch = codegen_workspace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ buildscript {
     standardSpineSdkRepositories()
 
     dependencies {
-        classpath("io.spine.chords.gradle:io.spine.chords.gradle.gradle.plugin:1.9.2")
+        classpath(io.spine.internal.dependency.Spine.Chords.gradlePlugin)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,10 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 buildscript {
     standardSpineSdkRepositories()
+
+    dependencies {
+        classpath("io.spine.chords.gradle:io.spine.chords.gradle.gradle.plugin:1.9.2")
+    }
 }
 
 plugins {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -40,8 +40,6 @@ plugins {
     id("com.github.jk1.dependency-license-report").version("1.16")
     // https://github.com/johnrengelman/shadow/releases
     id("com.github.johnrengelman.shadow").version("6.1.0")
-
-    id("io.spine.chords.gradle") version "1.9.0"
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -40,6 +40,8 @@ plugins {
     id("com.github.jk1.dependency-license-report").version("1.16")
     // https://github.com/johnrengelman/shadow/releases
     id("com.github.johnrengelman.shadow").version("6.1.0")
+
+    id("io.spine.chords.gradle") version "1.9.0"
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -239,4 +239,12 @@ object Spine {
         const val server = "$group:spine-server:$version"
         const val testUtilServer = "$toolsGroup:spine-testutil-server:$version"
     }
+
+    object Chords {
+        private const val pluginGroup = "$group.chords.gradle"
+        private const val pluginId = "$pluginGroup.gradle.plugin"
+        private const val pluginVersion = "1.9.2"
+
+        const val gradlePlugin = "$pluginGroup:$pluginId:$pluginVersion"
+    }
 }

--- a/codegen/gradle-plugin/build.gradle.kts
+++ b/codegen/gradle-plugin/build.gradle.kts
@@ -26,7 +26,6 @@
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.spine.internal.dependency.JUnit
-import io.spine.internal.gradle.isSnapshot
 import io.spine.internal.gradle.publish.ChordsPublishing
 import io.spine.internal.gradle.publish.ChordsPublishing.GradlePlugin.metadataUrl
 import io.spine.internal.gradle.publish.MavenMetadata.Companion.fetchAndParse
@@ -78,6 +77,12 @@ tasks.named("test") {
     dependsOn(functionalTestTask)
 }
 
+// We do not publish the plugin to Gradle Plugin Portal because
+// the plugin should be in a dedicated Git repository.
+// See https://github.com/SpineEventEngine/Chords/issues/50 for detail.
+//
+// It is published to Spine Cloud Artifacts repository for now.
+//
 //pluginBundle {
 //    website = "https://spine.io"
 //    vcsUrl = "https://github.com/SpineEventEngine/Chords/tree/master/codegen/gradle-plugin"
@@ -88,6 +93,16 @@ tasks.named("test") {
 //        artifactId = "spine-chords-gradle-plugin"
 //        version = versionToPublish
 //    }
+//}
+//
+// Do not attempt to publish snapshot versions to comply with publishing rules.
+// See: https://plugins.gradle.org/docs/publish-plugin#approval
+//val publishPlugins: Task by tasks.getting {
+//    enabled = !versionToPublish.isSnapshot()
+//}
+//
+//val publish: Task by tasks.getting {
+//    dependsOn(publishPlugins)
 //}
 
 gradlePlugin {
@@ -213,16 +228,6 @@ project.afterEvaluate {
         }
     }
 }
-
-// Do not attempt to publish snapshot versions to comply with publishing rules.
-// See: https://plugins.gradle.org/docs/publish-plugin#approval
-//val publishPlugins: Task by tasks.getting {
-//    enabled = !versionToPublish.isSnapshot()
-//}
-//
-//val publish: Task by tasks.getting {
-//    dependsOn(publishPlugins)
-//}
 
 configureTaskDependencies()
 

--- a/codegen/tests/build.gradle.kts
+++ b/codegen/tests/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     id("io.spine.tools.gradle.bootstrap")
     id("com.google.protobuf")
     `maven-publish`
-    id("io.spine.chords.gradle")
+    id("io.spine.chords.gradle") version "1.9.0"
 }
 
 apply<JavaPlugin>()
@@ -68,24 +68,3 @@ dependencies {
     implementation(project(":runtime"))
     testImplementation(Kotest.runnerJUnit5)
 }
-
-/**
- * The task below executes a separate Gradle build of the `codegen-plugins`
- * project. It is needed because the ProtoData plugin, that helps to generate
- * the Kotlin extensions for the Proto messages, requires the newer version
- * of Gradle.
- *
- * See the [RunCodegenPlugins] for details.
- */
-//val applyCodegenPlugins = tasks.register<RunCodegenPlugins>("applyCodegenPlugins") {
-//    dependsOn(
-//        rootProject.tasks.named("buildCodegenPlugins")
-//    )
-//}
-//
-//// Generate the code before the `compileKotlin` task.
-//tasks.named("compileKotlin") {
-//    dependsOn(
-//        applyCodegenPlugins
-//    )
-//}

--- a/codegen/tests/build.gradle.kts
+++ b/codegen/tests/build.gradle.kts
@@ -31,16 +31,14 @@ import com.google.protobuf.gradle.protoc
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
-import io.spine.internal.gradle.RunCodegenPlugins
 
 plugins {
     id("io.spine.tools.gradle.bootstrap")
     id("com.google.protobuf")
-    `maven-publish`
-    id("io.spine.chords.gradle") version "1.9.0"
 }
 
 apply<JavaPlugin>()
+apply(plugin = "io.spine.chords.gradle")
 
 spine {
     // Spine Model Compiler is enabled only for generating validation code for
@@ -67,4 +65,10 @@ dependencies {
     implementation(Spine.server)
     implementation(project(":runtime"))
     testImplementation(Kotest.runnerJUnit5)
+}
+
+tasks.named("generateCode") {
+    dependsOn(
+        rootProject.tasks.named("buildCodegenPlugins")
+    )
 }

--- a/codegen/tests/build.gradle.kts
+++ b/codegen/tests/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("io.spine.tools.gradle.bootstrap")
     id("com.google.protobuf")
     `maven-publish`
+    id("io.spine.chords.gradle")
 }
 
 apply<JavaPlugin>()
@@ -76,15 +77,15 @@ dependencies {
  *
  * See the [RunCodegenPlugins] for details.
  */
-val applyCodegenPlugins = tasks.register<RunCodegenPlugins>("applyCodegenPlugins") {
-    dependsOn(
-        rootProject.tasks.named("buildCodegenPlugins")
-    )
-}
-
-// Generate the code before the `compileKotlin` task.
-tasks.named("compileKotlin") {
-    dependsOn(
-        applyCodegenPlugins
-    )
-}
+//val applyCodegenPlugins = tasks.register<RunCodegenPlugins>("applyCodegenPlugins") {
+//    dependsOn(
+//        rootProject.tasks.named("buildCodegenPlugins")
+//    )
+//}
+//
+//// Generate the code before the `compileKotlin` task.
+//tasks.named("compileKotlin") {
+//    dependsOn(
+//        applyCodegenPlugins
+//    )
+//}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.24`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.25`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:35 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:05 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.24`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.25`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Tue Oct 01 15:15:35 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:36 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.24`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.25`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Tue Oct 01 15:15:36 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:38 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.2`
+# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.3`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3668,12 +3668,12 @@ This report was generated on **Tue Oct 01 15:15:38 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:39 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:07 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.24`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.25`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4672,12 +4672,12 @@ This report was generated on **Tue Oct 01 15:15:39 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:40 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.24`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.25`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5471,12 +5471,12 @@ This report was generated on **Tue Oct 01 15:15:40 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:41 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.24`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.25`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6240,4 +6240,4 @@ This report was generated on **Tue Oct 01 15:15:41 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 01 15:15:42 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 12:56:09 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1066,7 +1066,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:05 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:11 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1925,7 +1925,7 @@ This report was generated on **Tue Oct 08 12:56:05 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:12 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2912,7 +2912,7 @@ This report was generated on **Tue Oct 08 12:56:06 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:13 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3668,7 +3668,7 @@ This report was generated on **Tue Oct 08 12:56:06 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:07 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:14 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4672,7 +4672,7 @@ This report was generated on **Tue Oct 08 12:56:07 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:14 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5471,7 +5471,7 @@ This report was generated on **Tue Oct 08 12:56:08 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:15 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6240,4 +6240,4 @@ This report was generated on **Tue Oct 08 12:56:08 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 08 12:56:09 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 08 13:16:16 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.24</version>
+<version>2.0.0-SNAPSHOT.25</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto-values/build.gradle.kts
+++ b/proto-values/build.gradle.kts
@@ -38,6 +38,7 @@ plugins {
     id("io.spine.tools.gradle.bootstrap")
     id("com.google.protobuf")
     `maven-publish`
+    id("io.spine.chords.gradle") version "1.9.0"
 }
 
 apply<JavaPlugin>()
@@ -68,31 +69,4 @@ dependencies {
     api(Spine.money)
     implementation(JavaX.annotations)
     testImplementation(Kotest.runnerJUnit5)
-}
-
-/**
- * The task below executes a separate Gradle build of the `codegen-plugins`
- * project. It is needed because the ProtoData plugin, that helps to generate
- * the Kotlin extensions for the Proto messages, requires the newer version
- * of Gradle.
- *
- * See the [RunCodegenPlugins] for details.
- */
-val applyCodegenPlugins = tasks.register<RunCodegenPlugins>("applyCodegenPlugins") {
-    // Dependencies that are required to load the Proto files from.
-    dependencies(
-        // A list of the external dependencies,
-        // onto which the processed Proto sources depend.
-        Spine.money
-    )
-    dependsOn(
-        rootProject.tasks.named("buildCodegenPlugins")
-    )
-}
-
-// Run the code generation before `compileKotlin` task.
-tasks.named("compileKotlin") {
-    dependsOn(
-        applyCodegenPlugins
-    )
 }

--- a/proto-values/build.gradle.kts
+++ b/proto-values/build.gradle.kts
@@ -32,16 +32,15 @@ import io.spine.internal.dependency.JavaX
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
-import io.spine.internal.gradle.RunCodegenPlugins
 
 plugins {
     id("io.spine.tools.gradle.bootstrap")
     id("com.google.protobuf")
     `maven-publish`
-    id("io.spine.chords.gradle") version "1.9.0"
 }
 
 apply<JavaPlugin>()
+apply(plugin = "io.spine.chords.gradle")
 
 spine {
     // Spine Model Compiler is enabled only for generating validation code for
@@ -69,4 +68,10 @@ dependencies {
     api(Spine.money)
     implementation(JavaX.annotations)
     testImplementation(Kotest.runnerJUnit5)
+}
+
+tasks.named("generateCode") {
+    dependsOn(
+        rootProject.tasks.named("buildCodegenPlugins")
+    )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,13 +26,6 @@
 
 rootProject.name = "Chords"
 
-pluginManagement {
-    repositories {
-        mavenLocal()
-        gradlePluginPortal()
-    }
-}
-
 include(
     "core",
     "runtime",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,13 @@
 
 rootProject.name = "Chords"
 
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
 include(
     "core",
     "runtime",

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,7 +27,7 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.24")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.25")
 
 
 /**
@@ -41,4 +41,4 @@ val chordsVersion: String by extra("2.0.0-SNAPSHOT.24")
  *
  * Update this version if the `chordsVersion` is updated.
  */
-val gradlePluginVersion: String by extra("1.9.2")
+val gradlePluginVersion: String by extra("1.9.3")


### PR DESCRIPTION
This PR adds the use of the Gradle plugin for code generation.

Also, the `codegen/workspace` module has been removed as it is no longer needed.
