### PR TITLE
Remove `out` modifiers from the generic parameters of `codegen-runtime` interfaces

### DIFF
--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefFileGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefFileGenerator.kt
@@ -26,6 +26,7 @@
 
 package io.spine.chords.codegen.plugins
 
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.asClassName
@@ -151,5 +152,27 @@ internal val TypeName.simpleClassName: String
             "",
             ".$simpleName"
         )
-    else
-        simpleName
+    else simpleName
+
+/**
+ * Builds `@Suppress` annotation with `UNCHECKED_CAST` and
+ * `RemoveRedundantQualifierName` arguments.
+ */
+internal fun suppressUncheckedCastAndRedundantQualifier() =
+    buildSuppressAnnotation(
+        "UNCHECKED_CAST",
+        "RemoveRedundantQualifierName"
+    )
+
+/**
+ * Builds `@Suppress` annotation with given [warnings].
+ */
+@Suppress("SameParameterValue")
+private fun buildSuppressAnnotation(vararg warnings: String) =
+    AnnotationSpec.builder(Suppress::class.asClassName())
+        .also { builder ->
+            warnings.forEach { warning ->
+                builder.addMember("%S", warning)
+            }
+        }
+        .build()

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageOneofObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageOneofObjectGenerator.kt
@@ -26,7 +26,6 @@
 
 package io.spine.chords.codegen.plugins
 
-import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -131,10 +130,7 @@ internal class MessageOneofObjectGenerator(
                 PropertySpec
                     .builder("fieldMap", fieldMapType, PRIVATE)
                     .addAnnotation(
-                        buildSuppressAnnotation(
-                            "UNCHECKED_CAST",
-                            "RemoveRedundantQualifierName"
-                        )
+                        suppressUncheckedCastAndRedundantQualifier()
                     )
                     .initializer(
                         fieldMapInitializer(
@@ -168,19 +164,6 @@ internal class MessageOneofObjectGenerator(
             .build()
     }
 }
-
-/**
- * Builds `@Suppress` annotation with given [warnings].
- */
-@Suppress("SameParameterValue")
-private fun buildSuppressAnnotation(vararg warnings: String) =
-    AnnotationSpec.builder(Suppress::class.asClassName())
-        .also { builder ->
-            warnings.forEach { warning ->
-                builder.addMember("%S", warning)
-            }
-        }
-        .build()
 
 /**
  * Generates initialization code for the `fieldMap` property

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt
@@ -51,7 +51,7 @@ public interface MessageDef<T : Message> {
     /**
      * Returns collection of [MessageField]s generated for the fields of [T] Proto message.
      */
-    public val fields: Collection<MessageField<T, out MessageFieldValue>>
+    public val fields: Collection<MessageField<T, MessageFieldValue>>
 
     /**
      * Returns collection of [MessageOneof]s generated for the oneofs of [T] Proto message.

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt
@@ -49,10 +49,10 @@ public interface MessageOneof<T : Message> {
     /**
      * Returns collection of [MessageField]s declared by this `oneof`.
      */
-    public val fields: Collection<MessageField<T, out MessageFieldValue>>
+    public val fields: Collection<MessageField<T, MessageFieldValue>>
 
     /**
      * Returns [MessageField] that is currently set in this oneof.
      */
-    public fun selectedField(message: T): MessageField<T, out MessageFieldValue>?
+    public fun selectedField(message: T): MessageField<T, MessageFieldValue>?
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.28`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.29`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:16 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:15 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.28`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.29`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Thu Oct 10 16:32:16 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:18 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:17 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.28`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.29`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Thu Oct 10 16:32:18 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:20 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:18 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.6`
+# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.7`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3668,12 +3668,12 @@ This report was generated on **Thu Oct 10 16:32:20 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:21 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:19 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.28`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.29`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4672,12 +4672,12 @@ This report was generated on **Thu Oct 10 16:32:21 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:23 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:20 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.28`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.29`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5471,12 +5471,12 @@ This report was generated on **Thu Oct 10 16:32:23 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:24 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:20 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.28`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.29`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6240,4 +6240,4 @@ This report was generated on **Thu Oct 10 16:32:24 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 16:32:25 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 11 18:13:21 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.28</version>
+<version>2.0.0-SNAPSHOT.29</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,7 +27,7 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.28")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.29")
 
 
 /**
@@ -41,4 +41,4 @@ val chordsVersion: String by extra("2.0.0-SNAPSHOT.28")
  *
  * Update this version if the `chordsVersion` is updated.
  */
-val gradlePluginVersion: String by extra("1.9.6")
+val gradlePluginVersion: String by extra("1.9.7")


### PR DESCRIPTION
This PR removes `out` modifiers from the generic parameters of `MessageOneof` and `MessageDef` interfaces.

Otherwise, it leads to unnecessary type casts. See [this issue](https://github.com/SpineEventEngine/Chords/issues/38) for detail.
