### PR TITLE
Migrate to the latest versions of Chords Gradle plugin and ProtoData

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -251,7 +251,7 @@ object Spine {
 
         object GradlePlugin {
             private const val artifact = "${artifactPrefix}gradle-plugin"
-            private const val version = "1.9.8"
+            private const val version = "1.9.10"
 
             const val id = "io.spine.chords"
             const val lib = "$chordsGroup:$artifact:$version"

--- a/codegen/plugins/build.gradle.kts
+++ b/codegen/plugins/build.gradle.kts
@@ -46,7 +46,7 @@ buildscript {
     doForceVersions(configurations)
 
     dependencies {
-        classpath(io.spine.internal.dependency.Spine.McJava.pluginLib)
+        classpath(io.spine.internal.dependency.McJava.pluginLib)
     }
 }
 
@@ -55,7 +55,7 @@ plugins {
     id("net.ltgt.errorprone")
     id("detekt-code-analysis")
     id("com.google.protobuf")
-    id("io.spine.protodata") version "0.60.3"
+    id("io.spine.protodata") version "0.61.7"
     idea
 }
 

--- a/codegen/plugins/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -31,6 +31,7 @@ import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Kover
 import io.spine.internal.dependency.Ksp
+import io.spine.internal.dependency.McJava
 import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.ProtoTap
 import io.spine.internal.dependency.Protobuf
@@ -77,8 +78,8 @@ private const val ABOUT_DEPENDENCY_EXTENSIONS = ""
  * This plugin is not published to Gradle Portal and cannot be applied directly to a project.
  * Firstly, it should be put to buildscript's classpath and then applied by ID only.
  */
-val PluginDependenciesSpec.mcJava: Spine.McJava
-    get() = Spine.McJava
+val PluginDependenciesSpec.mcJava: McJava
+    get() = McJava
 
 /**
  * Shortcut to [ProtoData] dependency object.

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -23,33 +23,33 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package io.spine.chords.codegen.plugins
 
-import io.spine.core.EventContext
-import io.spine.protodata.ast.event.FieldEntered
-import io.spine.protodata.ast.typeName
-import io.spine.protodata.plugin.ViewRepository
-import io.spine.server.route.EventRoute
-import io.spine.server.route.EventRouting
+package io.spine.internal.dependency
 
 /**
- * The repository for [FieldView].
+ * Dependencies on Spine Model Compiler for Java.
+ *
+ * See [mc-java](https://github.com/SpineEventEngine/mc-java).
  */
-internal class FieldViewRepository : ViewRepository<FieldMetadataId,
-        FieldView,
-        FieldMetadata>() {
+@Suppress(
+    "MemberVisibilityCanBePrivate" /* `pluginLib()` is used by subprojects. */,
+    "ConstPropertyName"
+)
+object McJava {
+    const val group = Spine.toolsGroup
 
-    override fun setupEventRouting(routing: EventRouting<FieldMetadataId>) {
-        super.setupEventRouting(routing)
-        routing.route(FieldEntered::class.java)
-        { message: FieldEntered, _: EventContext? ->
-            EventRoute.withId(
-                fieldMetadataId {
-                    file = message.file
-                    typeName = message.type
-                    field = message.field
-                }
-            )
-        }
-    }
+    /** The version to be used for integration tests. */
+    const val version = "2.0.0-SNAPSHOT.245"
+
+    const val pluginId = "io.spine.mc-java"
+
+    val pluginLib = pluginLib(version)
+    fun pluginLib(version: String): String = "$group:spine-mc-java-plugins:$version:all"
+
+    /** The artifact reference for forcing in configurations. */
+    @Suppress("unused")
+    const val pluginsArtifact: String = "$group:spine-mc-java-plugins:$version"
+
+    val base = base(version)
+    fun base(version: String): String = "$group:spine-mc-java-base:$version"
 }

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -27,59 +27,42 @@
 package io.spine.internal.dependency
 
 /**
- * Dependencies on ProtoData modules.
- *
- * To use a locally published ProtoData version instead of the version from a public plugin
- * registry, set the `PROTODATA_VERSION` and/or the `PROTODATA_DF_VERSION` environment variables
- * and stop the Gradle daemons so that Gradle observes the env change:
- * ```
- * export PROTODATA_VERSION=0.43.0-local
- * export PROTODATA_DF_VERSION=0.41.0
- *
- * ./gradle --stop
- * ./gradle build   # Conduct the intended checks.
- * ```
- *
- * Then, to reset the console to run the usual versions again, remove the values of
- * the environment variables and stop the daemon:
- * ```
- * export PROTODATA_VERSION=""
- * export PROTODATA_DF_VERSION=""
- *
- * ./gradle --stop
- * ```
- *
- * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
- */
+* Dependencies on ProtoData modules.
+*
+* See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
+*/
 @Suppress(
     "unused" /* Some subprojects do not use ProtoData directly. */,
-    "ConstPropertyName",
+    "ConstPropertyName" /* We use custom convention for artifact properties. */,
     "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */
 )
 object ProtoData {
+    const val pluginGroup = Spine.group
     const val group = "io.spine.protodata"
     const val pluginId = "io.spine.protodata"
 
     /**
      * The version of ProtoData dependencies.
      */
-    const val version: String = "0.60.2"
+    const val version = "0.61.7"
 
-    const val lib: String =
-        "io.spine:protodata:$version"
+    /**
+     * Identifies ProtoData as a `classpath` dependency under `buildScript` block.
+     *
+     * The dependency is obtained from https://plugins.gradle.org/m2/.
+     */
+    const val lib = "io.spine:protodata:$version"
 
-    const val pluginLib: String =
-        "$group:gradle-plugin:$version"
+    /**
+     * The artifact for the ProtoData Gradle plugin.
+     */
+    const val pluginLib =  "$group:gradle-plugin:$version"
 
     fun api(version: String): String =
         "$group:protodata-api:$version"
 
     val api
         get() = api(version)
-
-    @Deprecated("Use `backend` instead", ReplaceWith("backend"))
-    val compiler
-        get() = backend
 
     val backend
         get() = "$group:protodata-backend:$version"
@@ -101,4 +84,7 @@ object ProtoData {
 
     val fatCli
         get() = "$group:protodata-fat-cli:$version"
+
+    val testlib
+        get() = "$group:protodata-testlib:$version"
 }

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,8 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.203"
+        const val base = "2.0.0-SNAPSHOT.212"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.212"
 
         /**
          * The version of [Spine.base_1_9]
@@ -59,7 +60,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
          */
-        const val reflect = "2.0.0-SNAPSHOT.187"
+        const val reflect = "2.0.0-SNAPSHOT.188"
 
         /**
          * The version of [Spine.Logging].
@@ -82,7 +83,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.176"
+        const val core = "2.0.0-SNAPSHOT.177"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -90,13 +91,6 @@ object Spine {
          * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
          */
         const val mc = "2.0.0-SNAPSHOT.133"
-
-        /**
-         * The version of [McJava].
-         *
-         * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
-         */
-        const val mcJava = "2.0.0-SNAPSHOT.206"
 
         /**
          * The version of [Spine.baseTypes].
@@ -131,29 +125,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.217"
+        const val toolBase = "2.0.0-SNAPSHOT.226"
 
         /**
-         * The version of [Spine.javadocTools].
+         * The version of [Spine.javadocFilter].
          *
          * @see <a href="https://github.com/SpineEventEngine/doc-tools">spine-javadoc-tools</a>
          */
         const val javadocTools = "2.0.0-SNAPSHOT.75"
-
-        /**
-         * The version of [Spine.money]
-         *
-         * @see <a href="https://github.com/SpineEventEngine/money">spine-money</a>
-         */
-        const val money = "1.5.0"
-
-        /**
-         * The version of [Spine.bootstrap]
-         *
-         * @see <a href="https://github.com/SpineEventEngine/bootstrap">spine-bootstrap</a>
-         *
-         */
-        const val bootstrap = "1.9.0"
     }
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
@@ -164,12 +143,13 @@ object Spine {
      */
     const val base_1_9 = "$group:spine-base:${ArtifactVersion.base_1_9}"
 
+    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.baseForBuildScript}"
+
     const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
     const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
     const val time = "$group:spine-time:${ArtifactVersion.time}"
     const val change = "$group:spine-change:${ArtifactVersion.change}"
     const val text = "$group:spine-text:${ArtifactVersion.text}"
-    const val money = "$group:spine-money:${ArtifactVersion.money}"
 
     const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.testlib}"
     const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
@@ -179,7 +159,9 @@ object Spine {
     const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
     const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"
     const val modelCompiler = "$toolsGroup:spine-model-compiler:${ArtifactVersion.mc}"
-    const val bootstrap = "$toolsGroup:spine-bootstrap:${ArtifactVersion.bootstrap}"
+
+    @Deprecated(message = "Please use top level `McJava` object instead.")
+    val McJava = io.spine.internal.dependency.McJava
 
     /**
      * Dependencies on the artifacts of the Spine Logging library.
@@ -201,35 +183,8 @@ object Spine {
         internal const val middleware = "$group:spine-logging-middleware:$version"
         internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
         internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
-
-        @Deprecated(
-            message = "Please use `Logging.lib` instead.",
-            replaceWith = ReplaceWith("lib")
-        )
-        const val floggerApi = "$group:spine-flogger-api:$version"
-
-        @Deprecated(
-            message = "Please use `grpcContext` instead.",
-            replaceWith = ReplaceWith("grpcContext")
-        )
-        const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
     }
 
-    /**
-     * Dependencies on Spine Model Compiler for Java.
-     *
-     * See [mc-java](https://github.com/SpineEventEngine/mc-java).
-     */
-    @Suppress("MemberVisibilityCanBePrivate") // `pluginLib()` is used by subprojects.
-    object McJava {
-        const val version = ArtifactVersion.mcJava
-        const val pluginId = "io.spine.mc-java"
-        val pluginLib = pluginLib(version)
-        fun pluginLib(version: String): String = "$toolsGroup:spine-mc-java-plugins:$version:all"
-    }
-
-    @Deprecated("Please use `javadocFilter` instead.", ReplaceWith("javadocFilter"))
-    const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
     const val javadocFilter = "$toolsGroup:spine-javadoc-filter:${ArtifactVersion.javadocTools}"
 
     const val client = CoreJava.client // Added for brevity.

--- a/codegen/plugins/codegen-plugins/build.gradle.kts
+++ b/codegen/plugins/codegen-plugins/build.gradle.kts
@@ -39,14 +39,6 @@ dependencies {
     implementation(Chords.Runtime.lib(version.toString()))
 }
 
-modelCompiler {
-    java {
-        codegen {
-            validation().enabled.set(false)
-        }
-    }
-}
-
 /**
  * Path to `codegen-workspace` folder in the module resources.
  *

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/BuilderExtensionGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/BuilderExtensionGenerator.kt
@@ -32,7 +32,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.PropertySpec
 import io.spine.chords.runtime.MessageDef
-import io.spine.protodata.TypeName
+import io.spine.protodata.ast.TypeName
 import io.spine.protodata.type.TypeSystem
 
 /**

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/FieldView.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/FieldView.kt
@@ -27,7 +27,7 @@ package io.spine.chords.codegen.plugins
 
 import io.spine.core.External
 import io.spine.core.Subscribe
-import io.spine.protodata.event.FieldEntered
+import io.spine.protodata.ast.event.FieldEntered
 import io.spine.protodata.plugin.View
 
 /**

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/KClassPropertiesGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/KClassPropertiesGenerator.kt
@@ -32,9 +32,9 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.asClassName
-import io.spine.protodata.Field
-import io.spine.protodata.TypeName
-import io.spine.protodata.isPartOfOneof
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.isPartOfOneof
 import io.spine.protodata.type.TypeSystem
 import kotlin.reflect.KClass
 

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefFileGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefFileGenerator.kt
@@ -35,8 +35,8 @@ import io.spine.chords.runtime.MessageDef.Companion.MESSAGE_DEF_CLASS_SUFFIX
 import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageFieldValue
 import io.spine.chords.runtime.MessageOneof
-import io.spine.protodata.Field
-import io.spine.protodata.TypeName
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.TypeName
 import io.spine.protodata.type.TypeSystem
 import io.spine.string.camelCase
 

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefObjectGenerator.kt
@@ -38,9 +38,9 @@ import com.squareup.kotlinpoet.asClassName
 import io.spine.chords.runtime.MessageDef
 import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageOneof
-import io.spine.protodata.Field
-import io.spine.protodata.TypeName
-import io.spine.protodata.isPartOfOneof
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.isPartOfOneof
 import io.spine.protodata.type.TypeSystem
 import java.lang.System.lineSeparator
 

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldObjectGenerator.kt
@@ -38,19 +38,19 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import io.spine.chords.runtime.MessageField
 import io.spine.protobuf.AnyPacker.unpack
-import io.spine.protodata.Field
-import io.spine.protodata.Type
-import io.spine.protodata.TypeName
-import io.spine.protodata.isEnum
-import io.spine.protodata.isPrimitive
-import io.spine.protodata.isRepeated
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.Type
+import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.isEnum
+import io.spine.protodata.ast.isPrimitive
+import io.spine.protodata.ast.isRepeated
 import io.spine.protodata.java.getterName
 import io.spine.protodata.java.javaPackage
 import io.spine.protodata.java.primarySetterName
 import io.spine.protodata.java.primitiveClass
 import io.spine.protodata.type.TypeSystem
 import io.spine.protodata.type.findHeader
-import io.spine.protodata.typeName
+import io.spine.protodata.ast.typeName
 import io.spine.string.camelCase
 
 /**

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldsPlugin.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldsPlugin.kt
@@ -31,7 +31,7 @@ import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageOneof
 import io.spine.protodata.plugin.Plugin
 import io.spine.protodata.plugin.ViewRepository
-import io.spine.protodata.renderer.Renderer
+import io.spine.protodata.render.Renderer
 
 /**
  * The ProtoData [Plugin] that generates [MessageDef], [MessageField],

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldsRenderer.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldsRenderer.kt
@@ -29,11 +29,11 @@ package io.spine.chords.codegen.plugins
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import io.spine.chords.runtime.MessageDef.Companion.MESSAGE_DEF_CLASS_SUFFIX
-import io.spine.protodata.Field
-import io.spine.protodata.TypeName
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.TypeName
 import io.spine.protodata.java.javaPackage
-import io.spine.protodata.renderer.Renderer
-import io.spine.protodata.renderer.SourceFileSet
+import io.spine.protodata.render.Renderer
+import io.spine.protodata.render.SourceFileSet
 import io.spine.protodata.type.TypeSystem
 import io.spine.string.Indent
 import io.spine.tools.code.Kotlin

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageOneofObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageOneofObjectGenerator.kt
@@ -38,9 +38,9 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import io.spine.chords.runtime.MessageOneof
-import io.spine.protodata.Field
-import io.spine.protodata.TypeName
-import io.spine.protodata.isPartOfOneof
+import io.spine.protodata.ast.Field
+import io.spine.protodata.ast.TypeName
+import io.spine.protodata.ast.isPartOfOneof
 import io.spine.protodata.java.javaCase
 import io.spine.protodata.type.TypeSystem
 import java.lang.System.lineSeparator

--- a/codegen/plugins/codegen-plugins/src/main/resources/codegen-workspace/build.gradle.kts
+++ b/codegen/plugins/codegen-plugins/src/main/resources/codegen-workspace/build.gradle.kts
@@ -40,14 +40,14 @@ buildscript {
     doForceVersions(configurations)
 
     dependencies {
-        classpath(io.spine.internal.dependency.Spine.McJava.pluginLib)
+        classpath(io.spine.internal.dependency.McJava.pluginLib)
     }
 }
 
 plugins {
     kotlin("jvm")
     id("com.google.protobuf")
-    id("io.spine.protodata") version "0.60.2"
+    id("io.spine.protodata") version "0.61.7"
     idea
 }
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1066,7 +1066,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 14:43:52 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:20:23 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1925,7 +1925,7 @@ This report was generated on **Wed Oct 16 14:43:52 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 14:43:54 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:20:24 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2912,7 +2912,7 @@ This report was generated on **Wed Oct 16 14:43:54 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 14:43:55 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:20:25 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3916,7 +3916,7 @@ This report was generated on **Wed Oct 16 14:43:55 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 14:43:55 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:20:26 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4715,7 +4715,7 @@ This report was generated on **Wed Oct 16 14:43:55 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 14:43:56 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:20:27 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5484,4 +5484,4 @@ This report was generated on **Wed Oct 16 14:43:56 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 14:43:57 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:20:27 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.33`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.34`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 13:02:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:32:10 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.33`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.34`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Wed Oct 16 13:02:08 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 13:02:09 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:32:12 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.33`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.34`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Wed Oct 16 13:02:09 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 13:02:10 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:32:13 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.33`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.34`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Wed Oct 16 13:02:10 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 13:02:11 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:32:14 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.33`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.34`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Wed Oct 16 13:02:11 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 13:02:13 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:32:16 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.33`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.34`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Wed Oct 16 13:02:13 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 16 13:02:14 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 17:32:17 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.32`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.33`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 14:58:07 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:43:52 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.32`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.33`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Tue Oct 15 14:58:07 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 14:58:08 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:43:54 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.32`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.33`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Tue Oct 15 14:58:08 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 14:58:09 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:43:55 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.32`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.33`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Tue Oct 15 14:58:09 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 14:58:10 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:43:55 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.32`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.33`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Tue Oct 15 14:58:10 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 14:58:10 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:43:56 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.32`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.33`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Tue Oct 15 14:58:10 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 14:58:11 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:43:57 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.32</version>
+<version>2.0.0-SNAPSHOT.33</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.33</version>
+<version>2.0.0-SNAPSHOT.34</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.32")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.33")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.33")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.34")


### PR DESCRIPTION
This PR migrates the projects to the latest versions of Chords Gradle plugin `(1.9.10)` and ProtoData `(0.61.7)`.