### PR TITLE
Update codegen plugins

### DIFF
--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefObjectGenerator.kt
@@ -89,8 +89,8 @@ internal class MessageDefObjectGenerator(
      *
      *     public override val fields: Collection<MessageField<IpAddress, Any>>
      *         = listOf(
-     *             ipv4.safeCast<MessageField<IpAddressDef, Any>>()!!,
-     *             ipv6.safeCast<MessageField<IpAddressDef, Any>>()!!
+     *             ipv4.safeCast<MessageField<IpAddressDef, Any>>(),
+     *             ipv6.safeCast<MessageField<IpAddressDef, Any>>()
      *         )
      *
      *     public override val oneofs: Collection<MessageOneof<IpAddress>>
@@ -223,8 +223,8 @@ private fun <E> Iterable<E>.ifNotEmpty(action: (Iterable<E>) -> Unit) {
  * The generated code looks like the following:
  * ```
  * listOf(
- *     ipv4.safeCast<MessageField<IpAddressDef, Any>>()!!,
- *     ipv6.safeCast<MessageField<IpAddressDef, Any>>()!!
+ *     ipv4.safeCast<MessageField<IpAddressDef, Any>>(),
+ *     ipv6.safeCast<MessageField<IpAddressDef, Any>>()
  * )
  * ```
  */
@@ -238,7 +238,7 @@ private fun fieldsPropertyInitializer(
         "listOf(${lineSeparator()}",
         ")"
     ) { fieldName ->
-        "${fieldName.propertyName}.safeCast<%T>()!!"
+        "${fieldName.propertyName}.safeCast<%T>()"
     }, *fieldNames.map { messageField }.toTypedArray()
 )
 

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldObjectGenerator.kt
@@ -243,7 +243,7 @@ private val validatingBuilderClassName = ClassName(
  */
 private fun Field.generateSetValueCode(messageTypeName: TypeName): String {
     val messageSimpleClassName = messageTypeName.simpleClassName
-    val builderCast = "(builder as $messageSimpleClassName.Builder)"
+    val builderCast = "builder.safeCast<$messageSimpleClassName.Builder>()"
     val setterCall = "$primarySetterName(newValue)"
     return if (isRepeated) {
         "$builderCast.clear${name.value.camelCase()}().$setterCall"

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageOneofObjectGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageOneofObjectGenerator.kt
@@ -92,8 +92,8 @@ internal class MessageOneofObjectGenerator(
      *     public object IpAddressValueOneof : MessageOneof<IpAddress> {
      *         private val fieldMap: Map<Int, MessageField<IpAddress, Any>> =
      *             mapOf(
-     *                 1 to IpAddressDef.ipv4.safeCast<MessageField<IpAddressDef, Any>>()!!,
-     *                 2 to IpAddressDef.ipv6.safeCast<MessageField<IpAddressDef, Any>>()!!
+     *                 1 to IpAddressDef.ipv4.safeCast<MessageField<IpAddressDef, Any>>(),
+     *                 2 to IpAddressDef.ipv6.safeCast<MessageField<IpAddressDef, Any>>()
      *             )
      *
      *         public override val name: String = "value"
@@ -205,8 +205,8 @@ internal class MessageOneofObjectGenerator(
  * The generated code looks like the following:
  * ```
  * mapOf(
- *     1 to IpAddressDef.ipv4.safeCast<MessageField<IpAddressDef, Any>>()!!,
- *     2 to IpAddressDef.ipv6.safeCast<MessageField<IpAddressDef, Any>>()!!
+ *     1 to IpAddressDef.ipv4.safeCast<MessageField<IpAddressDef, Any>>(),
+ *     2 to IpAddressDef.ipv6.safeCast<MessageField<IpAddressDef, Any>>()
  * )
  * ```
  */
@@ -221,6 +221,6 @@ private fun fieldMapInitializer(
         "mapOf(${lineSeparator()}",
         ")"
     ) {
-        "${it.number} to $messageDefClassName.${it.name.javaCase()}.safeCast<%T>()!!"
+        "${it.number} to $messageDefClassName.${it.name.javaCase()}.safeCast<%T>()"
     }, *fields.map { messageField }.toTypedArray()
 )

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
@@ -27,7 +27,8 @@
 package io.spine.chords.runtime
 
 /**
- * Returns `this` if this object is instance of [T], otherwise `null`.
+ * Returns `this` if this object is instance of [T],
+ * otherwise throws [IllegalStateException].
  *
  * Helps avoid the `UNCHECKED_CAST` warning.
  */

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
@@ -31,6 +31,7 @@ package io.spine.chords.runtime
  *
  * Helps avoid the `UNCHECKED_CAST` warning.
  */
-public inline fun <reified T: Any> Any.safeCast() : T? {
-    return if (this is T) this else null
+public inline fun <reified T : Any> Any.safeCast(): T {
+    return if (this is T) this
+    else error("Cannot cast `$this` to `${T::class}`")
 }

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
@@ -34,5 +34,5 @@ package io.spine.chords.runtime
  */
 public inline fun <reified T : Any> Any.safeCast(): T {
     return if (this is T) this
-    else error("Cannot cast `$this` to `${T::class}`")
+    else error("Cannot cast `$this` to `${T::class}`.")
 }

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt
@@ -42,12 +42,18 @@ import com.google.protobuf.Message
 public interface MessageOneof<T : Message> {
 
     /**
-     * The name of the oneof field in a message as it is defined in Proto file.
+     * The name of the oneof group in a message as it is defined in Proto file.
      */
     public val name: String
 
     /**
-     * Returns collection of [MessageField]s declared by this `oneof`.
+     * Returns a value of the `is_required` option if it is applied to this oneof,
+     * otherwise returns `false`.
+     */
+    public val required: Boolean
+
+    /**
+     * Returns collection of [MessageField]s declared by this oneof.
      */
     public val fields: Collection<MessageField<T, MessageFieldValue>>
 

--- a/codegen/tests/src/test/kotlin/io/spine/chords/codegen/CodegenPluginsSpec.kt
+++ b/codegen/tests/src/test/kotlin/io/spine/chords/codegen/CodegenPluginsSpec.kt
@@ -109,16 +109,21 @@ internal class CodegenPluginsSpec {
      */
     @ParameterizedTest
     @MethodSource("messageOneofTestData")
+    @Suppress("LongParameterList")
     fun <T : Message, V>
             `generate 'MessageOneof' implementations`(
         oneof: MessageOneof<T>,
         message: T,
         selectedFieldValue: V,
         protoOneofName: String,
+        required: Boolean,
         fieldCount: Int
     ) {
         withClue("Property `name` was not correctly generated.") {
             oneof.name shouldBe protoOneofName
+        }
+        withClue("Property `required` was not correctly generated.") {
+            oneof.required shouldBe required
         }
         withClue("Property `fields` was not correctly generated.") {
             oneof.fields.size shouldBe fieldCount
@@ -176,12 +181,12 @@ internal class CodegenPluginsSpec {
             of(
                 TestCommandDef.oneOfPlainField,
                 testCommandBuilder().setOneOfOption1(true).build(),
-                true, "one_of_plain_field", 3
+                true, "one_of_plain_field", true, 3
             ),
             of(
                 TestCommandOneOfTypeDef.value,
                 oneOfTypeBuilder().setOption3(100).build(),
-                100, "value", 3
+                100, "value", false, 3
             )
         )
     }

--- a/codegen/tests/src/test/proto/spine/chords/codegen/commands.proto
+++ b/codegen/tests/src/test/proto/spine/chords/codegen/commands.proto
@@ -52,6 +52,8 @@ message TestCommand {
     EnumType enum_field = 4;
 
     oneof one_of_plain_field {
+        option (is_required) = true;
+
         bool one_of_option_1 = 5;
         string one_of_option_2 = 6;
         int32 one_of_option_3 = 7;

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.35`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.36`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 20 02:06:02 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 18:01:45 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.35`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.36`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Sun Oct 20 02:06:02 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 20 02:06:03 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 18:01:46 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.35`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.36`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Sun Oct 20 02:06:03 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 20 02:06:05 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 18:01:47 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.35`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.36`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Sun Oct 20 02:06:05 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 20 02:06:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 18:01:48 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.35`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.36`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Sun Oct 20 02:06:06 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 20 02:06:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 18:01:48 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.35`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.36`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Sun Oct 20 02:06:06 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 20 02:06:07 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 18:01:49 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.35</version>
+<version>2.0.0-SNAPSHOT.36</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.35")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.36")


### PR DESCRIPTION
This PR updates codegen plugins with the following improvements:
- `Any.safeCast` throws an exception instead of returning `null` so there is no need to use the operator `!!` in the client's code.
- Add the `required` property to `MessageOneof` and generate the appropriate code for the implementations.
