### PR TITLE
Rework `PaymentMethodEditor` to be a class-based custom form component

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -118,8 +118,8 @@ import kotlinx.coroutines.TimeoutCancellationException
  * ) {
  *
  *     Column {
- *          UserNameField(AuthorizedUser.userName)
- *          PasswordField(AuthorizedUser.password)
+ *          UserNameField(AuthorizeUserDef.userName)
+ *          PasswordField(AuthorizeUserDef.password)
  *
  *          // We're invoking the form's `updateValidationDisplay()` method in
  *          // this way just as an example, and in practice it can be invoked

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -248,7 +248,8 @@ public class CommandMessageForm<C : CommandMessage> :
          * [MultipartContent] method (for rendering a multipart form) in
          * a composable context where it needs to be displayed.
          *
-         * NOTE: `create` would typically not need to be invoked from composable
+         * NOTE: `create` returns a new instance each time it is invoked and
+         * would typically not need to be invoked from composable
          * functions/methods. If you need to render a component inside
          * a composable function or method, then you probably need one of the
          * [invoke] based instance declarations instead of using the

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -221,17 +221,20 @@ public abstract class InputComponent<V> : FocusableComponent() {
     public var valueRequired: Boolean by mutableStateOf(false)
 
     /**
-     * An external validation error that should be displayed by the component,
-     * if the value within this [MutableState] is not `null`.
+     * This property is dedicated to be set by the form automatically for
+     * providing an external validation error that should be displayed by
+     * the component, if the value within this [MutableState] is not `null`.
      *
      * The value in this [State] is identified by the environment where this
      * input component is used (e.g., by a form that it's a part of), and thus
      * such an external validation state is identified independently in addition
      * to the component's internal validation.
      *
-     * // TODO:2024-10-21:dmitry.pikhulya: Make it clear in the documentation
-     *      that it shouldn't be customized by the user when component instance
-     *      declaration is made.
+     * NOTE: this property would typically never need to be configured by
+     * the application's code when declaring a component in some composable
+     * function. Instead, it should be used by the actual component's
+     * implementation to ensure that the value specified in this property is
+     * displayed as needed.
      */
     public open var externalValidationMessage: State<String?>? = null
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.37`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.38`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -111,7 +111,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -230,7 +230,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -750,7 +750,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -992,7 +992,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 18:12:16 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 14:10:05 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.37`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.38`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Thu Oct 24 18:12:16 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 18:12:17 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 14:10:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.37`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.38`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1992,7 +1992,7 @@ This report was generated on **Thu Oct 24 18:12:17 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2107,7 +2107,7 @@ This report was generated on **Thu Oct 24 18:12:17 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2596,7 +2596,7 @@ This report was generated on **Thu Oct 24 18:12:17 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2838,7 +2838,7 @@ This report was generated on **Thu Oct 24 18:12:17 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2912,12 +2912,12 @@ This report was generated on **Thu Oct 24 18:12:17 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 18:12:18 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 14:10:07 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.37`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.38`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2996,7 +2996,7 @@ This report was generated on **Thu Oct 24 18:12:18 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3111,7 +3111,7 @@ This report was generated on **Thu Oct 24 18:12:18 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3600,7 +3600,7 @@ This report was generated on **Thu Oct 24 18:12:18 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3842,7 +3842,7 @@ This report was generated on **Thu Oct 24 18:12:18 EEST 2024** using [Gradle-Lic
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3916,12 +3916,12 @@ This report was generated on **Thu Oct 24 18:12:18 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 18:12:19 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 14:10:09 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.37`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.38`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Thu Oct 24 18:12:19 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 18:12:20 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 14:10:11 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.37`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.38`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Thu Oct 24 18:12:20 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 18:12:21 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 25 14:10:13 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1066,7 +1066,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 25 14:10:05 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 21:22:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1925,7 +1925,7 @@ This report was generated on **Fri Oct 25 14:10:05 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 25 14:10:06 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 21:22:04 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2912,7 +2912,7 @@ This report was generated on **Fri Oct 25 14:10:06 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 25 14:10:07 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 21:22:06 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3916,7 +3916,7 @@ This report was generated on **Fri Oct 25 14:10:07 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 25 14:10:09 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 21:22:09 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4715,7 +4715,7 @@ This report was generated on **Fri Oct 25 14:10:09 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 25 14:10:11 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 21:22:12 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5484,4 +5484,4 @@ This report was generated on **Fri Oct 25 14:10:11 EEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 25 14:10:13 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 21:22:14 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.38</version>
+<version>2.0.0-SNAPSHOT.39</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.37</version>
+<version>2.0.0-SNAPSHOT.38</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -73,7 +73,7 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.compose.desktop</groupId>
-    <artifactId>desktop-jvm-macos-x64</artifactId>
+    <artifactId>desktop-jvm-windows-x64</artifactId>
     <version>1.5.12</version>
     <scope>compile</scope>
   </dependency>

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -495,7 +495,8 @@ public open class MessageForm<M : Message> :
             this.builder = builder as () -> ValidatingBuilder<M>
             // Storing onBeforeBuild using a more general ValidatingBuilder<out M> type internally.
             @Suppress("UNCHECKED_CAST")
-            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> ValidatingBuilder<out M>
+            this.onBeforeBuild =
+                onBeforeBuild as (ValidatingBuilder<out M>) -> ValidatingBuilder<out M>
             multipartContent = content
             props.run { configure() }
         }) {
@@ -551,7 +552,8 @@ public open class MessageForm<M : Message> :
             this.builder = builder as () -> ValidatingBuilder<M>
             // Storing onBeforeBuild using a more general ValidatingBuilder<out M> type internally.
             @Suppress("UNCHECKED_CAST")
-            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> ValidatingBuilder<out M>
+            this.onBeforeBuild =
+                onBeforeBuild as (ValidatingBuilder<out M>) -> ValidatingBuilder<out M>
             multipartContent = content
             props.run { configure() }
         }) {
@@ -568,6 +570,14 @@ public open class MessageForm<M : Message> :
          * its [Content] method (for singlepart forms) or its
          * [MultipartContent] method (for rendering a multipart form) in
          * a composable context where it needs to be displayed.
+         *
+         * NOTE: this method creates a new instance each time it is invoked.
+         * When invoking it in context of a `@Composable` method, make sure to
+         * take this fact into account (e.g. caching the instance with
+         * [remember][androidx.compose.runtime.remember]). This method would
+         * typically not need to be invoked from `@Composable` methods though,
+         * and the regular `@Composable` declarations (using one of the [invoke]
+         * functions) would need to be used in the majority of cases.
          *
          * @param M A type of the message being edited with the form.
          * @param B A type of the message builder.

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1209,6 +1209,12 @@ public open class MessageForm<M : Message> :
      * a subclass, the [customMultipartContent] method
      * has to be overridden instead.
      *
+     * The content for the implementation of this method can be specified in
+     * the same way as you specify the content for a usual in-place `MessageForm`
+     * component (e.g. a combination of arbitrary layout/"regular" Compose
+     * components along with actual field editor components for all form's
+     * fields, which need to be edited).
+     *
      * @see customMultipartContent
      */
     @Composable
@@ -1223,6 +1229,17 @@ public open class MessageForm<M : Message> :
      * needs to render a singlepart form content, you can alternatively override
      * the [customContent] function instead of this one for a more
      * compact solution.
+     *
+     * The content for the implementation of this method can be specified in
+     * the same way as you specify the content for a usual in-place
+     * `MessageForm.Multipart` component.
+     *
+     * The content for the implementation of this method can be specified in
+     * the same way as you specify the content for a usual in-place
+     * [MessageForm.Multipart][Multipart] component (e.g. a set of
+     * [FormPart][MultipartFormScope.FormPart] declarations, which would in turn
+     * contain field editors and other components for each form
+     * part respectively).
      *
      * @see customContent
      */

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
@@ -43,8 +43,7 @@ import io.spine.chords.runtime.MessageOneof
  * defines the types of declarations available on this level
  * (see [FormPart] functions).
  *
- * @param M
- *         a type of message that is edited in the form.
+ * @param M A type of message that is edited in the form.
  */
 public interface MultipartFormScope<M : Message> {
 
@@ -60,20 +59,17 @@ public interface MultipartFormScope<M : Message> {
      * See the description of the [MessageForm] class for the instructions of
      * how to use this function.
      *
-     * @param showPart
-     *         a function that ensures that the respective part is revealed in
-     *         the form's UI.
-     *         For example, command message's fields can be split between
-     *         multiple form parts that can be displayed on different wizard's
-     *         pages. In this case, this parameter has to be passed a function
-     *         that would display the respective part of the UI.
-     * @param content
-     *         a composable content that defines how the respective message's
-     *         part is edited.
-     *         It can contain an arbitrary UI, but ensure that each field editor
-     *         component is wrapped using the [Field][FormFieldsScope.Field]
-     *         function that is available via the nested [FormPartScope] that
-     *         is provided as the receiver for this [content] function.
+     * @param showPart A function that ensures that the respective part is
+     *   revealed in the form's UI. For example, command message's fields can be
+     *   split between multiple form parts that can be displayed on different
+     *   wizard's pages. In this case, this parameter has to be passed
+     *   a function that would display the respective part of the UI.
+     * @param content A composable content that defines how the respective
+     *   message's part is edited. It can contain an arbitrary UI, but ensure
+     *   that each field editor component is wrapped using the
+     *   [Field][FormFieldsScope.Field] function that is available via the
+     *   nested [FormPartScope] that is provided as the receiver for this
+     *   [content] function.
      */
     @Composable
     public fun FormPart(
@@ -85,9 +81,8 @@ public interface MultipartFormScope<M : Message> {
      * The same as the other `FormPart` function, which doesn't require the
      * `showPart` parameter (implies its value to be `null`).
      *
-     * @param content
-     *         a composable content that defines how this message's part
-     *         is edited.
+     * @param content a composable content that defines how this message's part
+     *     is edited.
      */
     @Composable
     public fun FormPart(
@@ -125,8 +120,7 @@ internal class MultipartFormScopeImpl<M : Message>(
  * different contexts where fields can be declared (see [FormPartScope]
  * and [OneOfFieldsScope]).
  *
- * @param M
- *         a type of the message edited in the form.
+ * @param M A type of the message edited in the form.
  */
 public sealed interface FormFieldsScope<M : Message> {
 
@@ -178,8 +172,7 @@ public sealed interface FormFieldsScope<M : Message> {
  * represents a context in which message's field and oneof editors can
  * be declared.
  *
- * @param M
- *         a type of message that is edited in the form.
+ * @param M A type of message that is edited in the form.
  */
 public sealed interface FormPartScope<M : Message> : FormFieldsScope<M> {
 
@@ -211,11 +204,9 @@ public sealed interface FormPartScope<M : Message> : FormFieldsScope<M> {
      * [content] function using the [Field] function, which has to be called
      * for declaring each oneof's field editor.
      *
-     * @param oneof
-     *         name of the message's oneof being edited in the form.
-     * @param content
-     *         composable content that specifies [Field] declarations that
-     *         constitute this oneof.
+     * @param oneof Name of the message's oneof being edited in the form.
+     * @param content Composable content that specifies [Field] declarations
+     *   that constitute this oneof.
      */
     @Composable
     public fun OneOfFields(
@@ -236,8 +227,7 @@ public sealed interface FormPartScope<M : Message> : FormFieldsScope<M> {
  * A scope introduced by [FormPartScope.OneOfFields], which defines
  * the declarations available for declaring oneof field editors.
  *
- * @param M
- *         a type of message that is edited in the form.
+ * @param M A type of message that is edited in the form.
  */
 public sealed interface OneOfFieldsScope<M : Message> : FormFieldsScope<M> {
 
@@ -262,8 +252,7 @@ public sealed interface OneOfFieldsScope<M : Message> : FormFieldsScope<M> {
  * A scope introduced by the [Field][FormFieldsScope.Field] function in order to
  * facilitate editing the respective field value.
  *
- * @param V
- *         a type of field's value.
+ * @param V A type of field's value.
  */
 public sealed interface FormFieldScope<V : MessageFieldValue> {
 
@@ -491,13 +480,12 @@ private class OneOfFieldsScopeImpl<M : Message>(
  *
  * Not intended to be used for any application development directly.
  *
- * @param M
- *         a type of message that is edited in the form.
- * @param formScope
- *         a [MultipartFormScope], which contains this form part declaration.
- * @param showPart
- *         a function that ensures that the respective part is revealed in
- *         the form's UI.
+ * @param M A type of message that is edited in the form.
+ *
+ * @param formScope A [MultipartFormScope], which contains this form
+ *   part declaration.
+ * @param showPart A function that ensures that the respective part is revealed
+ *   in the form's UI.
  */
 internal class FormPartScopeImpl<M : Message>(
     formScope: MultipartFormScope<M>,
@@ -549,14 +537,11 @@ internal class FormPartScopeImpl<M : Message>(
  *
  * Not intended to be used for any application development directly.
  *
- * @param M
- *        a type of message that this field belongs to.
- * @param V
- *        a type of field's value.
- * @param formField
- *         a field represented by this scope object.
- * @param form
- *         a form to which this field belongs.
+ * @param M A type of message that this field belongs to.
+ * @param V A type of field's value.
+ *
+ * @param formField A field represented by this scope object.
+ * @param form A form to which this field belongs.
  */
 internal class FormFieldScopeImpl<M : Message, V : MessageFieldValue>(
     private val formField: MessageForm<M>.FormField,

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -45,10 +45,6 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
 
 /**
  * A component that edits a [PaymentMethod].
- *
- * It is intended to be used with [MessageForm][io.spine.chords.proto.form.MessageForm]
- * and is automatically bound to edit one of the respective fields of the
- * message that is edited in the containing form.
  */
 public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
     init {

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.Top
 import androidx.compose.ui.unit.dp
 import com.google.protobuf.Message
-import io.spine.chords.core.ValidationErrorText
 import io.spine.chords.core.layout.InputRow
 import io.spine.chords.proto.form.FormFieldsScope
 import io.spine.chords.proto.form.MessageForm
@@ -88,6 +87,5 @@ public fun <M : Message> FormFieldsScope<M>.PaymentMethodEditor(
                 }
             }
         }
-        ValidationErrorText()
     }
 }

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -32,9 +32,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.Top
 import androidx.compose.ui.unit.dp
-import com.google.protobuf.Message
 import io.spine.chords.core.layout.InputRow
-import io.spine.chords.proto.form.FormFieldsScope
+import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
 import io.spine.chords.proto.form.OneofRadioButton
 import io.spine.chords.proto.form.OptionalMessageCheckbox
@@ -43,7 +42,6 @@ import io.spine.chords.proto.value.money.PaymentMethod
 import io.spine.chords.proto.value.money.PaymentMethodDef.bankAccount
 import io.spine.chords.proto.value.money.PaymentMethodDef.method
 import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
-import io.spine.chords.runtime.MessageField
 
 /**
  * A component that edits a [PaymentMethod].
@@ -51,23 +49,20 @@ import io.spine.chords.runtime.MessageField
  * It is intended to be used with [MessageForm][io.spine.chords.proto.form.MessageForm]
  * and is automatically bound to edit one of the respective fields of the
  * message that is edited in the containing form.
- *
- * @receiver A context introduced by the parent form, whose field is to
- *   be edited.
- * @param M a type of message to which the edited `PaymentMethod` field belongs.
- *
- * @param field the form message's field, whose value should be edited with
- *   this component.
  */
-@Composable
-public fun <M : Message> FormFieldsScope<M>.PaymentMethodEditor(
-    field: MessageField<M, PaymentMethod>
-) {
-    MessageForm(field, { PaymentMethod.newBuilder() }) {
-        InputRow(
-            padding = PaddingValues()
-        ) {
-            OptionalMessageCheckbox("Specify payment method")
+public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
+    init {
+        builder = { PaymentMethod.newBuilder() }
+    }
+
+    @Composable
+    override fun FormPartScope<PaymentMethod>.customContent() {
+        if (!valueRequired) {
+            InputRow(
+                padding = PaddingValues()
+            ) {
+                OptionalMessageCheckbox("Specify payment method")
+            }
         }
         InputRow(
             padding = PaddingValues()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.38")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.39")


### PR DESCRIPTION
This PR:
- Introduces an ability to create custom form implementations for specific data types with built-in content.
- Reworks `PaymentMethodEditor` to be such a custom form, while ensuring that it can be used as an editor for both a required and optional fields (the respective checkbox is either visible or not in this case).
- Updates the KDoc format for some form-related declarations.