### PR TITLE
Remove redundant return value from the `onBeforeBuild` callback

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -184,7 +184,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public operator fun <C : CommandMessage, B: ValidatingBuilder<out C>> invoke(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: ((B) -> B) = { it },
+            onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable FormPartScope<C>.() -> Unit
         ): CommandMessageForm<C> = Multipart(builder, value, onBeforeBuild, props) {
@@ -219,7 +219,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> Multipart(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: ((B) -> B) = { it },
+            onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable MultipartFormScope<C>.() -> Unit
         ): CommandMessageForm<C> = createAndRender({
@@ -229,8 +229,7 @@ public class CommandMessageForm<C : CommandMessage> :
             @Suppress("UNCHECKED_CAST")
             this.builder = builder as () -> ValidatingBuilder<C>
             @Suppress("UNCHECKED_CAST")
-            this.onBeforeBuild = onBeforeBuild
-                    as (ValidatingBuilder<out C>) -> ValidatingBuilder<out C>
+            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
             multipartContent = content
             props.run { configure() }
         }) {
@@ -270,7 +269,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> create(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: ((B) -> B) = { it },
+            onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {}
         ): CommandMessageForm<C> =
             super.create(null) {
@@ -282,8 +281,7 @@ public class CommandMessageForm<C : CommandMessage> :
 
                 // Storing the builder as ValidatingBuilder internally.
                 @Suppress("UNCHECKED_CAST")
-                this.onBeforeBuild = onBeforeBuild
-                        as (ValidatingBuilder<out C>) -> ValidatingBuilder<out C>
+                this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
                 props.run { configure() }
             }
     }

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -128,24 +128,20 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
      * valid values. Note that there is no guarantee that the command message
      * that is about to be built is going to be valid.
      *
-     * The altered builder should be returned as a result of this method.
      * For example, if we wanted to set command's `field1` and
-     * `field2` explicitly, this could be done like this:
-     *
+     * `field2` explicitly when the form builds a `MyMessage` value, this could
+     * be done like this:
      * ```
      *     class WizardImpl: CommandWizard(...) {
      *
-     *         override fun beforeBuild(builder: Message.Builder): Message.Builder {
-     *             with(builder) {
-     *                 field1 = field1Value
-     *                 field2 = field2Value
-     *             }
-     *             return builder
+     *         override fun beforeBuild(builder: MyMessage.Builder) {
+     *             builder.field1 = field1Value
+     *             builder.field2 = field2Value
      *         }
      *     }
      * ```
      */
-    protected open fun beforeBuild(builder: B): B { return builder }
+    protected open fun beforeBuild(builder: B) {}
 
     override suspend fun submit(): Boolean {
         return commandMessageForm.postCommand()
@@ -182,9 +178,15 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
 
     @Composable
     override fun content() {
+        // CommandMessageForm's type param is in+out, and it's logically just
+        // out in CommandWizard.
+        @Suppress("UNCHECKED_CAST")
         val commandMessageForm = wizard.commandMessageForm as CommandMessageForm<CommandMessage>
         commandMessageForm.MultipartContent {
             FormPart(showPart = { show() }) {
+                // The message type param is in+out, and it's just out
+                // for commandField.
+                @Suppress("UNCHECKED_CAST")
                 Field(commandField as MessageField<CommandMessage, M>) {
                     if (pageForm == null) {
                         pageForm = MessageForm.create(fieldValue, this@CommandWizardPage.builder) {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:10 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Sun Oct 27 21:22:02 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:04 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:13 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Sun Oct 27 21:22:04 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:06 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:15 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Sun Oct 27 21:22:06 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:09 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:19 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Sun Oct 27 21:22:09 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:12 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:21 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Sun Oct 27 21:22:12 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:14 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:22 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.39</version>
+<version>2.0.0-SNAPSHOT.40</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.39")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.40")


### PR DESCRIPTION
This PR revises the signature of the `onBeforeBuild` callback for `MessageForm`/`CommandMessageForm` by removing a redundant return value. 

The reasons for for considering it excessive are the following:
- The main reason is that there's nothing to return in general for this callback in the first place. There's one-way flow of data _into_ the function both logically and technically in this case.
- If it's there when it's not needed, having it in the signature is confusing from several perspectives:
  - From the user's perspective: this signature alone provokes the thought that the builder's instance that is returned might be (or even might have to be?) different than that, which is passed as the parameter.
  - From the perspective of developer/maintainer of `MessageForm` itself this provokes a similar concern/confusion: should I do something with the returned value? What exactly, why?
