### PR TITLE
Replace `onBeforeBuild` with `MessageEditingController`

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -37,6 +37,7 @@ import io.spine.chords.core.ComponentProps
 import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.appshell.client
 import io.spine.chords.proto.form.FormPartScope
+import io.spine.chords.proto.form.MessageEditingController
 import io.spine.chords.proto.form.MessageForm
 import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
@@ -172,8 +173,10 @@ public class CommandMessageForm<C : CommandMessage> :
          * @param builder A lambda that should create and return a new builder
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
-         * @param onBeforeBuild A lambda that allows to amend the command message
-         *   after any valid field is entered to it.
+         * @param editingController Allows to control different aspects of
+         *   editing the message's data on different editing lifecycle, such as
+         *   an initial editor value, or an ability to amend message's builder
+         *   before the edited message is built.
          * @param props A lambda that can set any additional props on the form.
          * @param content A form's content, which can contain an arbitrary layout along
          *   with field editor declarations.
@@ -184,10 +187,10 @@ public class CommandMessageForm<C : CommandMessage> :
         public operator fun <C : CommandMessage, B: ValidatingBuilder<out C>> invoke(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: (B) -> Unit = {},
+            editingController: MessageEditingController<C, B>? = null,
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable FormPartScope<C>.() -> Unit
-        ): CommandMessageForm<C> = Multipart(builder, value, onBeforeBuild, props) {
+        ): CommandMessageForm<C> = Multipart(builder, value, editingController, props) {
             FormPart(content)
         }
 
@@ -207,8 +210,10 @@ public class CommandMessageForm<C : CommandMessage> :
          * @param value The command message value to be edited within the form.
          * @param builder A lambda that should create and return a new builder
          *   for a command message of type [C].
-         * @param onBeforeBuild A lambda that allows to amend the command
-         *   message after any valid field is entered to it.
+         * @param editingController Allows to control different aspects of
+         *   editing the message's data on different editing lifecycle, such as
+         *   an initial editor value, or an ability to amend message's builder
+         *   before the edited message is built.
          * @param props A lambda that can set any additional props on the form.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
@@ -219,7 +224,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> Multipart(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: (B) -> Unit = {},
+            editingController: MessageEditingController<C, B>? = null,
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable MultipartFormScope<C>.() -> Unit
         ): CommandMessageForm<C> = createAndRender({
@@ -229,7 +234,8 @@ public class CommandMessageForm<C : CommandMessage> :
             @Suppress("UNCHECKED_CAST")
             this.builder = builder as () -> ValidatingBuilder<C>
             @Suppress("UNCHECKED_CAST")
-            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
+            this.editingController =
+                editingController as MessageEditingController<C, ValidatingBuilder<out C>>
             multipartContent = content
             props.run { configure() }
         }) {
@@ -260,8 +266,10 @@ public class CommandMessageForm<C : CommandMessage> :
          * @param builder A lambda that should create and return a new builder
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
-         * @param onBeforeBuild A lambda that allows to amend the command
-         *   message after any valid field is entered to it.
+         * @param editingController Allows to control different aspects of
+         *   editing the message's data on different editing lifecycle, such as
+         *   an initial editor value, or an ability to amend message's builder
+         *   before the edited message is built.
          * @param props A lambda that can set any additional props on the form.
          * @return A form's instance that has been created for this
          *   declaration site.
@@ -269,7 +277,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> create(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: (B) -> Unit = {},
+            editingController: MessageEditingController<C, B>? = null,
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {}
         ): CommandMessageForm<C> =
             super.create(null) {
@@ -281,7 +289,8 @@ public class CommandMessageForm<C : CommandMessage> :
 
                 // Storing the builder as ValidatingBuilder internally.
                 @Suppress("UNCHECKED_CAST")
-                this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
+                this.editingController =
+                    editingController as MessageEditingController<C, ValidatingBuilder<out C>>
                 props.run { configure() }
             }
     }

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -174,9 +174,9 @@ public class CommandMessageForm<C : CommandMessage> :
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
          * @param editingController Allows to control different aspects of
-         *   editing the message's data on different editing lifecycle, such as
-         *   an initial editor value, or an ability to amend message's builder
-         *   before the edited message is built.
+         *   editing the message's data on different stages of editing
+         *   lifecycle, such as an initial editor value, or an ability to amend
+         *   message's builder before the edited message is built.
          * @param props A lambda that can set any additional props on the form.
          * @param content A form's content, which can contain an arbitrary layout along
          *   with field editor declarations.
@@ -211,9 +211,9 @@ public class CommandMessageForm<C : CommandMessage> :
          * @param builder A lambda that should create and return a new builder
          *   for a command message of type [C].
          * @param editingController Allows to control different aspects of
-         *   editing the message's data on different editing lifecycle, such as
-         *   an initial editor value, or an ability to amend message's builder
-         *   before the edited message is built.
+         *   editing the message's data on different stages of editing
+         *   lifecycle, such as an initial editor value, or an ability to amend
+         *   message's builder before the edited message is built.
          * @param props A lambda that can set any additional props on the form.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
@@ -267,9 +267,9 @@ public class CommandMessageForm<C : CommandMessage> :
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
          * @param editingController Allows to control different aspects of
-         *   editing the message's data on different editing lifecycle, such as
-         *   an initial editor value, or an ability to amend message's builder
-         *   before the edited message is built.
+         *   editing the message's data on different stages of editing
+         *   lifecycle, such as an initial editor value, or an ability to amend
+         *   message's builder before the edited message is built.
          * @param props A lambda that can set any additional props on the form.
          * @return A form's instance that has been created for this
          *   declaration site.

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -184,7 +184,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public operator fun <C : CommandMessage, B: ValidatingBuilder<out C>> invoke(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: ((B) -> B) = { it },
+            onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable FormPartScope<C>.() -> Unit
         ): CommandMessageForm<C> = Multipart(builder, value, onBeforeBuild, props) {
@@ -219,7 +219,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> Multipart(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: ((B) -> B) = { it },
+            onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable MultipartFormScope<C>.() -> Unit
         ): CommandMessageForm<C> = createAndRender({
@@ -229,8 +229,7 @@ public class CommandMessageForm<C : CommandMessage> :
             @Suppress("UNCHECKED_CAST")
             this.builder = builder as () -> ValidatingBuilder<C>
             @Suppress("UNCHECKED_CAST")
-            this.onBeforeBuild = onBeforeBuild
-                    as (ValidatingBuilder<out C>) -> ValidatingBuilder<out C>
+            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
             multipartContent = content
             props.run { configure() }
         }) {
@@ -270,7 +269,7 @@ public class CommandMessageForm<C : CommandMessage> :
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> create(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
-            onBeforeBuild: ((B) -> B) = { it },
+            onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {}
         ): CommandMessageForm<C> =
             super.create(null) {
@@ -282,8 +281,7 @@ public class CommandMessageForm<C : CommandMessage> :
 
                 // Storing the builder as ValidatingBuilder internally.
                 @Suppress("UNCHECKED_CAST")
-                this.onBeforeBuild = onBeforeBuild
-                        as (ValidatingBuilder<out C>) -> ValidatingBuilder<out C>
+                this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
                 props.run { configure() }
             }
     }

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -70,7 +70,6 @@ import io.spine.protobuf.ValidatingBuilder
  *   aspects of command message's data editing, such as an initial command
  *   value, or an ability to amend the command builder before the edited command
  *   is created.
- *
  */
 @Stable
 public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<out C>>(
@@ -117,38 +116,11 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
      * should subscribe to a respective event that is expected to arrive in
      * response to handling that command.
      *
-     * @param command
-     *         a command, which is going to be posted.
-     * @return a subscription to the event that is expected to arrive in response
-     *         to handling [command]
+     * @param command A command, which is going to be posted.
+     * @return A subscription to the event that is expected to arrive in
+     *   response to handling [command]
      */
     protected abstract fun subscribeToEvent(command: C): EventSubscription<out EventMessage>
-
-    /**
-     * Allows to programmatically amend the command message builder before
-     * the command is built.
-     *
-     * This function is invoked upon every attempt to build the command edited
-     * in the wizard, which happens when any command's field is edited by the
-     * user. When this function is invoked, the command builder's fields have
-     * already been set from all form's field editors, which currently have
-     * valid values. Note that there is no guarantee that the command message
-     * that is about to be built is going to be valid.
-     *
-     * For example, if we wanted to set command's `field1` and
-     * `field2` explicitly when the form builds a `MyMessage` value, this could
-     * be done like this:
-     * ```
-     *     class WizardImpl: CommandWizard(...) {
-     *
-     *         override fun beforeBuild(builder: MyMessage.Builder) {
-     *             builder.field1 = field1Value
-     *             builder.field2 = field2Value
-     *         }
-     *     }
-     * ```
-     */
-    protected open fun beforeBuild(builder: B) {}
 
     override suspend fun submit(): Boolean {
         return commandMessageForm.postCommand()

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -128,24 +128,20 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
      * valid values. Note that there is no guarantee that the command message
      * that is about to be built is going to be valid.
      *
-     * The altered builder should be returned as a result of this method.
      * For example, if we wanted to set command's `field1` and
-     * `field2` explicitly, this could be done like this:
-     *
+     * `field2` explicitly when the form builds a `MyMessage` value, this could
+     * be done like this:
      * ```
      *     class WizardImpl: CommandWizard(...) {
      *
-     *         override fun beforeBuild(builder: Message.Builder): Message.Builder {
-     *             with(builder) {
-     *                 field1 = field1Value
-     *                 field2 = field2Value
-     *             }
-     *             return builder
+     *         override fun beforeBuild(builder: MyMessage.Builder) {
+     *             builder.field1 = field1Value
+     *             builder.field2 = field2Value
      *         }
      *     }
      * ```
      */
-    protected open fun beforeBuild(builder: B): B { return builder }
+    protected open fun beforeBuild(builder: B) {}
 
     override suspend fun submit(): Boolean {
         return commandMessageForm.postCommand()
@@ -182,9 +178,15 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
 
     @Composable
     override fun content() {
+        // CommandMessageForm's type param is in+out, and it's logically just
+        // out in CommandWizard.
+        @Suppress("UNCHECKED_CAST")
         val commandMessageForm = wizard.commandMessageForm as CommandMessageForm<CommandMessage>
         commandMessageForm.MultipartContent {
             FormPart(showPart = { show() }) {
+                // The message type param is in+out, and it's just out
+                // for commandField.
+                @Suppress("UNCHECKED_CAST")
                 Field(commandField as MessageField<CommandMessage, M>) {
                     if (pageForm == null) {
                         pageForm = MessageForm.create(fieldValue, this@CommandWizardPage.builder) {

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -39,6 +39,7 @@ import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.core.layout.AbstractWizardPage
 import io.spine.chords.core.layout.Wizard
+import io.spine.chords.proto.form.MessageEditingController
 import io.spine.chords.runtime.MessageField
 import io.spine.protobuf.ValidatingBuilder
 
@@ -62,18 +63,24 @@ import io.spine.protobuf.ValidatingBuilder
  * - This means that you can place respective [Field][FormFieldsScope.Field]
  *   declarations right in the [content][CommandWizardPage.content] method.
  *
- * @param C
- *         a type of the command message constructed in the wizard.
- * @param B
- *         a type of the command message builder.
+ * @param C A type of the command message constructed in the wizard.
+ * @param B A type of the command message builder.
+ *
+ * @param editingController Can optionally be specified to control different
+ *   aspects of command message's data editing, such as an initial command
+ *   value, or an ability to amend the command builder before the edited command
+ *   is created.
+ *
  */
 @Stable
-public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<out C>> : Wizard() {
+public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<out C>>(
+    editingController: MessageEditingController<C, B>? = null
+) : Wizard() {
 
     internal val commandMessageForm: CommandMessageForm<C> =
         CommandMessageForm.create(
             { createCommandBuilder() },
-            onBeforeBuild = { beforeBuild(it) }
+            editingController = editingController
         )
         {
             validationDisplayMode = MANUAL

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:10 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Sun Oct 27 21:22:02 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:04 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:13 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Sun Oct 27 21:22:04 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:06 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:15 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Sun Oct 27 21:22:06 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:09 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:19 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Sun Oct 27 21:22:09 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:12 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:21 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.38`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.39`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Sun Oct 27 21:22:12 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 21:22:14 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 27 23:19:22 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.39`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 23:19:10 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 29 20:59:54 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.39`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Sun Oct 27 23:19:10 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 23:19:13 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 29 20:59:56 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.39`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Sun Oct 27 23:19:13 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 23:19:15 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 29 20:59:58 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.39`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Sun Oct 27 23:19:15 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 23:19:19 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 29 21:00:00 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.39`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Sun Oct 27 23:19:19 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 23:19:21 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 29 21:00:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.39`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Sun Oct 27 23:19:21 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 27 23:19:22 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 29 21:00:03 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.39</version>
+<version>2.0.0-SNAPSHOT.40</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -107,7 +107,7 @@ public enum class ValidationDisplayMode {
  * An object, which allows to control various aspects of editing a message
  * of type [M] on different stages of the editing lifecycle.
  *
- * It concerns only data-related aspects of message's editing only, such as an
+ * It concerns the data-related aspects of message's editing only, such as an
  * initial message's value that an editor should contain, or revising the data
  * that is being edited. This doesn't include any UI-related aspects that might
  * be related to how the values are presented visually, or other aspects of the
@@ -147,6 +147,7 @@ public interface MessageEditingController<M: Message, B: ValidatingBuilder<out M
     public fun reviseMessageBuilder(builder: B) {}
 }
 
+// Seems all class's functions are better to have in this class.
 /**
  * A kind of input component, which allows creating a field-wise editor UI
  * (form) for creating and editing a Protobuf message's value.
@@ -407,6 +408,49 @@ public interface MessageEditingController<M: Message, B: ValidatingBuilder<out M
  *   (show or hide) form validation errors programmatically. This makes sense
  *   only when using the form's display mode is effectively manual.
  *
+ * ### Controlling the data entry using [MessageEditingController]
+ *
+ * It is possible to customize the way how the edited data is handled by
+ * specifying an instance of [MessageEditingController] via the
+ * `editingController` parameter of form declaration/instantiation (see the
+ * [invoke] and [create] functions).
+ *
+ * Specifying the `editingController` parameter is optional, and if specified,
+ * it allows to customize different aspects of the data entry, depending on
+ * which functionality of the provided the [MessageEditingController] instance
+ * is implemented. You're free to implement only those properties/methods, which
+ * are required for your specific needs, while leaving the default
+ * implementations for the rest of them.
+ *
+ * - If the [initialValue][MessageEditingController.initialValue] property of
+ *   `MessageEditingController` has a non-`null` value, then this value will be
+ *   set as the initial form's value when the form enters the composition
+ *   context — when it is rendered for the first time in general, or when it is
+ *   rendered for the first time after previously being "hidden" (removed from
+ *   the composable context and brought to it again, e.g. via
+ *   conditional rendering).
+ *
+ *   Note that in the absence of `MessageEditingController` or when its
+ *   `initialValue` property is `null`, the form would always display whatever
+ *   value was initially passed via its [value] [MutableState]. If the
+ *   `MessageEditingController`'s `initialValue` property has a non-null value
+ *   though, this value would technically be used to modify the `MutableState`
+ *   in the form's `value` property, which will happen a single time when the
+ *   form enters into the composition context, and would overwrite any value
+ *   that might have been in that `MutableState` before that moment.
+ *
+ * - The [reviseMessageBuilder][MessageEditingController.reviseMessageBuilder]
+ *   method can be implemented when it is required to amend a message before it
+ *   is built by the form. When this method is invoked, the provided builder is
+ *   already configured to have all field values according to the current form's
+ *   field editors.
+ *
+ *   Implementing this method can be useful for cases like when some of the
+ *   message's field(s) are not edited directly, but still should be set based
+ *   on values of some edited fields, or when it is needed to normalize the
+ *   values entered by the user (e.g. bring a telephone number field to some
+ *   canonical form).
+ *
  * ### Implementing custom form components
  *
  * It is possible to implement custom form components for editing specific
@@ -423,7 +467,6 @@ public interface MessageEditingController<M: Message, B: ValidatingBuilder<out M
  *
  * @param M A type of the message being edited with the form.
  */
-// Seems all class's functions are better to have in this class.
 @Suppress("TooManyFunctions")
 public open class MessageForm<M : Message> :
     InputComponent<M>(), InputContext {
@@ -452,9 +495,9 @@ public open class MessageForm<M : Message> :
          *   for a message of type [M].
          * @param props A lambda that can set any additional props on the form.
          * @param editingController Allows to control different aspects of
-         *   editing the message's data on different editing lifecycle, such as
-         *   an initial editor value, or an ability to amend message's builder
-         *   before the edited message is built.
+         *   editing the message's data on different stages of editing
+         *   lifecycle, such as an initial editor value, or an ability to amend
+         *   message's builder before the edited message is built.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
          * @return A form's instance that has been created for this
@@ -492,9 +535,9 @@ public open class MessageForm<M : Message> :
          * @param defaultValue A value that should be displayed in the form
          *   by default.
          * @param editingController Allows to control different aspects of
-         *   editing the message's data on different editing lifecycle, such as
-         *   an initial editor value, or an ability to amend message's builder
-         *   before the edited message is built.
+         *   editing the message's data on different stages of editing
+         *   lifecycle, such as an initial editor value, or an ability to amend
+         *   message's builder before the edited message is built.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
          * @return A form's instance that has been created for this
@@ -536,9 +579,9 @@ public open class MessageForm<M : Message> :
          *   for a message of type [M].
          * @param props A lambda that can set any additional props on the form.
          * @param editingController Allows to control different aspects of
-         *   editing the message's data on different editing lifecycle, such as
-         *   an initial editor value, or an ability to amend message's builder
-         *   before the edited message is built.
+         *   editing the message's data on different stages of editing
+         *   lifecycle, such as an initial editor value, or an ability to amend
+         *   message's builder before the edited message is built.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
          * @return A form's instance that has been created for this

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.39")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.40")


### PR DESCRIPTION
This PR replaces the `onBeforeBuild` callback of `MessageForm`/`CommandMessageForm` with the notion of `MessageEditingController`, which is an object that can control various aspects of message's data editing on different stages of editing lifecycle.

For now `MessageEditingController` has an ability to:
- specify the initial editing value, and ...
- an ability to revise the contents of the message's builder right before the message is built (for scenarios like setting "calculated" fields, which are not edited by themselves, but are based on the values of some edited fields). 

  Potential scenarios of normalizing the input data (bringing it to some canonical form, e.g. ensuring that a phone number has some "standard" form) should also technically be possible via this same feature, but would likely be not ideal from the user's experience perspective because this way some already entered pieces of  data would just be "transformed" (according to respective "normalization" logic), which would likely happen not at a point in time that a user would expect (not when the user is entering the value, or not right after it is entered but when the whole message's data has been entered in all of its required fields). We might need to return to this later when we actually face actual scenarios that don't behave in an acceptable way for such scenarios.