### PR TITLE
Revise definitions of component's companion objects, add companion object for `PaymentMethodEditor`

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -155,9 +155,7 @@ public class CommandMessageForm<C : CommandMessage> :
      */
     public companion object :
         MessageFormCompanionBase<CommandMessage, CommandMessageForm<CommandMessage>>(
-            {
-                CommandMessageForm()
-            }
+            { CommandMessageForm() }
         ) {
 
         /**

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -173,11 +173,11 @@ public class CommandMessageForm<C : CommandMessage> :
          * @param builder A lambda that should create and return a new builder
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
-         * @param onBeforeBuild A lambda that allows to amend the command message
-         *   after any valid field is entered to it.
+         * @param onBeforeBuild A lambda that allows to amend the command
+         *   message after any valid field is entered to it.
          * @param props A lambda that can set any additional props on the form.
-         * @param content A form's content, which can contain an arbitrary layout along
-         *   with field editor declarations.
+         * @param content A form's content, which can contain an arbitrary
+         *   layout along with field editor declarations.
          * @return A form's instance that has been created for this
          *   declaration site.
          */
@@ -217,7 +217,11 @@ public class CommandMessageForm<C : CommandMessage> :
          * declaration site.
          */
         @Composable
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `C` type parameter.
+            "UNCHECKED_CAST"
+        )
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> Multipart(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
@@ -234,7 +238,7 @@ public class CommandMessageForm<C : CommandMessage> :
 
         /**
          * Creates a [CommandMessageForm] instance without rendering it in
-         * the composable content with the same call.
+         * the composable content right away.
          *
          * This method can be used to create a form's instance outside
          * a composable context, and render it separately. A form's instance
@@ -265,7 +269,11 @@ public class CommandMessageForm<C : CommandMessage> :
          * @return A form's instance that has been created for this
          *   declaration site.
          */
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `C` type parameter.
+            "UNCHECKED_CAST"
+        )
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> create(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -37,7 +37,7 @@ import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.appshell.client
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
-import io.spine.chords.proto.form.MessageFormCompanionBase
+import io.spine.chords.proto.form.MessageFormDeclarationApiBase
 import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
 import kotlinx.coroutines.TimeoutCancellationException
@@ -147,14 +147,9 @@ import kotlinx.coroutines.TimeoutCancellationException
  * @param C
  *         a type of the command message being edited with the form.
  */
-public class CommandMessageForm<C : CommandMessage> :
-    MessageForm<C>() {
-
-    /**
-     * Form instance declaration and creation API.
-     */
+public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
     public companion object :
-        MessageFormCompanionBase<CommandMessage, CommandMessageForm<CommandMessage>>(
+        MessageFormDeclarationApiBase<CommandMessage, CommandMessageForm<CommandMessage>>(
             { CommandMessageForm() }
         ) {
 

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import io.spine.chords.core.appshell.app
-import io.spine.chords.core.AbstractComponentCompanion
 import io.spine.base.CommandMessage
 import io.spine.base.EventMessage
 import io.spine.chords.core.ComponentProps
@@ -38,6 +37,7 @@ import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.appshell.client
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
+import io.spine.chords.proto.form.MessageFormCompanionBase
 import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
 import kotlinx.coroutines.TimeoutCancellationException
@@ -153,9 +153,12 @@ public class CommandMessageForm<C : CommandMessage> :
     /**
      * Form instance declaration and creation API.
      */
-    public companion object : AbstractComponentCompanion({
-        CommandMessageForm<CommandMessage>()
-    }) {
+    public companion object :
+        MessageFormCompanionBase<CommandMessage, CommandMessageForm<CommandMessage>>(
+            {
+                CommandMessageForm()
+            }
+        ) {
 
         /**
          * Declares a `CommandMessageForm` instance, which is not bound to
@@ -216,25 +219,20 @@ public class CommandMessageForm<C : CommandMessage> :
          * declaration site.
          */
         @Composable
+        @Suppress("UNCHECKED_CAST")
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> Multipart(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
             onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable MultipartFormScope<C>.() -> Unit
-        ): CommandMessageForm<C> = createAndRender({
-            this.value = value
-
-            // Storing the builder as ValidatingBuilder internally.
-            @Suppress("UNCHECKED_CAST")
-            this.builder = builder as () -> ValidatingBuilder<C>
-            @Suppress("UNCHECKED_CAST")
-            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
-            multipartContent = content
-            props.run { configure() }
-        }) {
-            Content()
-        }
+        ): CommandMessageForm<C> = super.Multipart(
+            value as MutableState<CommandMessage?>,
+            builder,
+            props as ComponentProps<CommandMessageForm<CommandMessage>>,
+            onBeforeBuild,
+            content as @Composable MultipartFormScope<CommandMessage>.() -> Unit
+        ) as CommandMessageForm<C>
 
         /**
          * Creates a [CommandMessageForm] instance without rendering it in
@@ -269,24 +267,18 @@ public class CommandMessageForm<C : CommandMessage> :
          * @return A form's instance that has been created for this
          *   declaration site.
          */
+        @Suppress("UNCHECKED_CAST")
         public fun <C : CommandMessage, B: ValidatingBuilder<out C>> create(
             builder: () -> B,
             value: MutableState<C?> = mutableStateOf(null),
             onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {}
-        ): CommandMessageForm<C> =
-            super.create(null) {
-                this.value = value
-
-                // Storing the builder as ValidatingBuilder internally.
-                @Suppress("UNCHECKED_CAST")
-                this.builder = builder as () -> ValidatingBuilder<C>
-
-                // Storing the builder as ValidatingBuilder internally.
-                @Suppress("UNCHECKED_CAST")
-                this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out C>) -> Unit
-                props.run { configure() }
-            }
+        ): CommandMessageForm<C> = super.create(
+            value as MutableState<CommandMessage?>,
+            builder,
+            onBeforeBuild,
+            props as ComponentProps<CommandMessageForm<CommandMessage>>
+        ) as CommandMessageForm<C>
     }
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -37,7 +37,7 @@ import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.appshell.client
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
-import io.spine.chords.proto.form.MessageFormDeclarationApiBase
+import io.spine.chords.proto.form.MessageFormSetupBase
 import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
 import kotlinx.coroutines.TimeoutCancellationException
@@ -149,7 +149,7 @@ import kotlinx.coroutines.TimeoutCancellationException
  */
 public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
     public companion object :
-        MessageFormDeclarationApiBase<CommandMessage, CommandMessageForm<CommandMessage>>(
+        MessageFormSetupBase<CommandMessage, CommandMessageForm<CommandMessage>>(
             { CommandMessageForm() }
         ) {
 

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -226,7 +226,7 @@ public class CommandMessageForm<C : CommandMessage> :
             onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {},
             content: @Composable MultipartFormScope<C>.() -> Unit
-        ): CommandMessageForm<C> = super.Multipart(
+        ): CommandMessageForm<C> = declareMultipartInstance(
             value as MutableState<CommandMessage?>,
             builder,
             props as ComponentProps<CommandMessageForm<CommandMessage>>,
@@ -273,7 +273,7 @@ public class CommandMessageForm<C : CommandMessage> :
             value: MutableState<C?> = mutableStateOf(null),
             onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<CommandMessageForm<C>> = ComponentProps {}
-        ): CommandMessageForm<C> = super.create(
+        ): CommandMessageForm<C> = createInstance(
             value as MutableState<CommandMessage?>,
             builder,
             onBeforeBuild,

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -178,8 +178,8 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
 
     @Composable
     override fun content() {
-        // CommandMessageForm's type param is in+out, and it's logically just
-        // out in CommandWizard.
+        // `CommandMessageForm`'s type param is in+out, and it's logically just
+        // out in `CommandWizard`.
         @Suppress("UNCHECKED_CAST")
         val commandMessageForm = wizard.commandMessageForm as CommandMessageForm<CommandMessage>
         commandMessageForm.MultipartContent {

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -90,18 +90,54 @@ import androidx.compose.runtime.remember
  *
  * A component's constructor would actually not need to be used directly in most
  * cases! Instead of using the constructor, such expressions work thanks to
- * the [invoke][ComponentDeclarationApi.invoke] operator function being declared
+ * the [invoke][ComponentSetup.invoke] operator function being declared
  * on the component's companion object, which is in particular required to
  * prevent creating a new component's instance upon each composition, and use
  * a cached instance instead.
  *
- * See below how to implement such components.
+ * #### Preferred instance declarations style
+ *
+ * Note that the component instance declaration examples above are technically
+ * a shorthand notation for using the `invoke` function on the component's
+ * companion object explicitly. So, theoretically, the same examples could be
+ * written like this:
+ *
+ * ```kotlin
+ *     SomeComponent.Companion.invoke({
+ *         property1 = value1
+ *         property2 = value2
+ *         ...
+ *     })
+ * ```
+ *
+ * ...or like this:
+ *
+ * ```kotlin
+ *     SomeComponent.invoke {
+ *         property1 = value1
+ *         property2 = value2
+ *         ...
+ *     }
+ * ```
+ *
+ * Nevertheless, such explicit usage of `Companion` or `invoke` is not
+ * recommended, and a shorthand form is recommended instead:
+ *
+ * ```kotlin
+ *     SomeComponent {
+ *         property1 = value1
+ *         property2 = value2
+ *         ...
+ *     }
+ * ```
+ *
+ * See also below how to implement such components.
  *
  * ### Implementing class-based components
  *
  * - Create a subclass of [Component].
  *
- * - Add a companion object of type [ComponentDeclarationApi], which introduces
+ * - Add a companion object of type [ComponentSetup], which introduces
  *   the instance declaration API (which is technically being an invocation).
  *
  *   You can consider the presence of this companion object as a kind of
@@ -310,9 +346,9 @@ import androidx.compose.runtime.remember
  *
  * @constructor A constructor, which is used internally by the component's
  *   implementation (its companion object). As an application developer, use
- *   [companion object][ComponentDeclarationApi]'s
- *   [invoke][ComponentDeclarationApi.invoke] operator for instantiating
- *   and rendering any specific component's implementation.
+ *   [companion object][ComponentSetup]'s [invoke][ComponentSetup.invoke]
+ *   operator for instantiating and rendering any specific
+ *   component's implementation.
  */
 @Stable
 public abstract class Component {
@@ -323,7 +359,7 @@ public abstract class Component {
      *
      * In most cases this property would not need to be used by the
      * application's code directly, since it would be set automatically by
-     * [ComponentDeclarationApi.invoke] or an analogous component
+     * [ComponentSetup.invoke] or an analogous component
      * declaration function.
      */
     public var props: ComponentProps<Component>? = null
@@ -365,7 +401,7 @@ public abstract class Component {
      *   lifecycle, including instance creation, property updates, and
      *   rendering, which removes the need to perform any of those steps
      *   explicitly. See the "Using class-based components" section in
-     *   [Component] class description, and the [ComponentDeclarationApi.invoke]
+     *   [Component] class description, and the [ComponentSetup.invoke]
      *   operator functions for details.
      *
      * - The component's composable content has to be specified by overriding
@@ -419,12 +455,12 @@ public abstract class Component {
  *
  * It generally doesn't need to be used directly when using the components,
  * since it would be implicitly created by a lambda that is passed to the
- * [ComponentDeclarationApi.invoke] function.
+ * [ComponentSetup.invoke] function.
  * It is a part of an internal implementation of [Component], and, in case of
  * some advanced components, can also be used when creating new components.
  *
  * @See Component
- * @see ComponentDeclarationApi.invoke
+ * @see ComponentSetup.invoke
  * @see Component.props
  */
 public fun interface ComponentProps <C: Component> {
@@ -447,16 +483,16 @@ public fun interface ComponentProps <C: Component> {
  * components" sections of the [Component] class for general information about
  * how class-based components are used in an application.
  *
- * In most cases custom class-based components would use [ComponentDeclarationApi]
+ * In most cases custom class-based components would use [ComponentSetup]
  * for to introduce the component's _instance declaration API_. However, in some
  * rare case a component might require different instance declaration API. In
  * such cases those companion objects would use this class as a base class for
  * a companion object instead.
  *
  * @param createInstance A lambda that should create a component's instance.
- * @see ComponentDeclarationApi
+ * @see ComponentSetup
  */
-public abstract class AbstractComponentDeclarationApi(
+public abstract class AbstractComponentSetup(
     protected val createInstance: (() -> Component)? = null
 ) {
 
@@ -567,11 +603,11 @@ public abstract class AbstractComponentDeclarationApi(
  * @constructor Creates a companion object for a component of type [C].
  * @param createInstance A lambda that should create a component's instance of
  *   type [C] with the given properties configuration callback.
- * @see AbstractComponentDeclarationApi
+ * @see AbstractComponentSetup
  */
-public open class ComponentDeclarationApi<C: Component>(
+public open class ComponentSetup<C: Component>(
     createInstance: () -> C
-) : AbstractComponentDeclarationApi(createInstance) {
+) : AbstractComponentSetup(createInstance) {
 
     /**
      * Declares an instance of component of type [C] with the respective

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -86,7 +86,7 @@ import androidx.compose.runtime.remember
  *
  * It should be noted that such _component instance declarations_ as shown above
  * are a main way of using class-based components, but they are technically not
- * the same as just instantiating components using their  constructor.
+ * the same as just instantiating components using their constructor.
  *
  * A component's constructor would actually not need to be used directly in most
  * cases! Instead of using the constructor, such expressions work thanks to
@@ -159,7 +159,7 @@ import androidx.compose.runtime.remember
  *
  * ```kotlin
  *     public class HelloComponent : Component() {
- *         public companion object : ComponentCompanion<HelloComponent>({
+ *         public companion object : ComponentSetup<HelloComponent>({
  *             HelloComponent()
  *         })
  *
@@ -176,6 +176,17 @@ import androidx.compose.runtime.remember
  * ```kotlin
  *     HelloComponent { name = "User" }
  * ```
+ *
+ * A note on code style: despite Kotlin's
+ * [code conventions](https://kotlinlang.org/docs/coding-conventions.html#class-layout)
+ * guide, which recommends having companion objects at the very end of class
+ * declarations, Chords libraries adopt and recommend a rule of having
+ * `ComponentSetup` based companion objects in component classes as the very
+ * first declaration in the class instead.
+ *
+ * Such placement is considered acceptable *just as an exception for component
+ * classes* though, since companion objects here serve the purpose that is
+ * similar to a class's constructor.
  *
  * ### When to write class-based and function-based components?
  *

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -90,10 +90,10 @@ import androidx.compose.runtime.remember
  *
  * A component's constructor would actually not need to be used directly in most
  * cases! Instead of using the constructor, such expressions work thanks to
- * the [invoke][ComponentCompanion.invoke] operator function being declared on
- * the component's companion object, which is in particular required to prevent
- * creating a new component's instance upon each composition, and use a cached
- * instance instead.
+ * the [invoke][ComponentDeclarationApi.invoke] operator function being declared
+ * on the component's companion object, which is in particular required to
+ * prevent creating a new component's instance upon each composition, and use
+ * a cached instance instead.
  *
  * See below how to implement such components.
  *
@@ -101,7 +101,7 @@ import androidx.compose.runtime.remember
  *
  * - Create a subclass of [Component].
  *
- * - Add a companion object of type [ComponentCompanion], which introduces
+ * - Add a companion object of type [ComponentDeclarationApi], which introduces
  *   the instance declaration API (which is technically being an invocation).
  *
  *   You can consider the presence of this companion object as a kind of
@@ -310,8 +310,8 @@ import androidx.compose.runtime.remember
  *
  * @constructor A constructor, which is used internally by the component's
  *   implementation (its companion object). As an application developer, use
- *   [companion object][ComponentCompanion]'s
- *   [invoke][ComponentCompanion.invoke] operator for instantiating
+ *   [companion object][ComponentDeclarationApi]'s
+ *   [invoke][ComponentDeclarationApi.invoke] operator for instantiating
  *   and rendering any specific component's implementation.
  */
 @Stable
@@ -323,7 +323,7 @@ public abstract class Component {
      *
      * In most cases this property would not need to be used by the
      * application's code directly, since it would be set automatically by
-     * [ComponentCompanion.invoke] or an analogous component
+     * [ComponentDeclarationApi.invoke] or an analogous component
      * declaration function.
      */
     public var props: ComponentProps<Component>? = null
@@ -365,7 +365,7 @@ public abstract class Component {
      *   lifecycle, including instance creation, property updates, and
      *   rendering, which removes the need to perform any of those steps
      *   explicitly. See the "Using class-based components" section in
-     *   [Component] class description, and the [ComponentCompanion.invoke]
+     *   [Component] class description, and the [ComponentDeclarationApi.invoke]
      *   operator functions for details.
      *
      * - The component's composable content has to be specified by overriding
@@ -419,12 +419,12 @@ public abstract class Component {
  *
  * It generally doesn't need to be used directly when using the components,
  * since it would be implicitly created by a lambda that is passed to the
- * [ComponentCompanion.invoke] function.
+ * [ComponentDeclarationApi.invoke] function.
  * It is a part of an internal implementation of [Component], and, in case of
  * some advanced components, can also be used when creating new components.
  *
  * @See Component
- * @see ComponentCompanion.invoke
+ * @see ComponentDeclarationApi.invoke
  * @see Component.props
  */
 public fun interface ComponentProps <C: Component> {
@@ -447,16 +447,16 @@ public fun interface ComponentProps <C: Component> {
  * components" sections of the [Component] class for general information about
  * how class-based components are used in an application.
  *
- * In most cases custom class-based components would use [ComponentCompanion]
+ * In most cases custom class-based components would use [ComponentDeclarationApi]
  * for to introduce the component's _instance declaration API_. However, in some
  * rare case a component might require different instance declaration API. In
  * such cases those companion objects would use this class as a base class for
  * a companion object instead.
  *
  * @param createInstance A lambda that should create a component's instance.
- * @see ComponentCompanion
+ * @see ComponentDeclarationApi
  */
-public abstract class AbstractComponentCompanion(
+public abstract class AbstractComponentDeclarationApi(
     protected val createInstance: (() -> Component)? = null
 ) {
 
@@ -567,11 +567,11 @@ public abstract class AbstractComponentCompanion(
  * @constructor Creates a companion object for a component of type [C].
  * @param createInstance A lambda that should create a component's instance of
  *   type [C] with the given properties configuration callback.
- * @see AbstractComponentCompanion
+ * @see AbstractComponentDeclarationApi
  */
-public open class ComponentCompanion<C: Component>(
+public open class ComponentDeclarationApi<C: Component>(
     createInstance: () -> C
-) : AbstractComponentCompanion(createInstance) {
+) : AbstractComponentDeclarationApi(createInstance) {
 
     /**
      * Declares an instance of component of type [C] with the respective

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -154,7 +154,7 @@ import kotlinx.coroutines.launch
 // All class's functions are better to have in this class.
 @Suppress("TooManyFunctions", "LargeClass")
 public class DropdownListBox<I> : Component() {
-    public companion object : AbstractComponentDeclarationApi() {
+    public companion object : AbstractComponentSetup() {
 
         /**
          * Declares an instance of [DropdownListBox] with the respective

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -154,11 +154,7 @@ import kotlinx.coroutines.launch
 // All class's functions are better to have in this class.
 @Suppress("TooManyFunctions", "LargeClass")
 public class DropdownListBox<I> : Component() {
-
-    /**
-     * Component instance declaration API.
-     */
-    public companion object : AbstractComponentCompanion() {
+    public companion object : AbstractComponentDeclarationApi() {
 
         /**
          * Declares an instance of [DropdownListBox] with the respective

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.41`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -111,7 +111,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -230,7 +230,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -750,7 +750,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -992,7 +992,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 01 11:22:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 02 06:19:22 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.41`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Fri Nov 01 11:22:28 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 01 11:22:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 02 06:19:24 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.41`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1992,7 +1992,7 @@ This report was generated on **Fri Nov 01 11:22:30 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2107,7 +2107,7 @@ This report was generated on **Fri Nov 01 11:22:30 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2596,7 +2596,7 @@ This report was generated on **Fri Nov 01 11:22:30 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2838,7 +2838,7 @@ This report was generated on **Fri Nov 01 11:22:30 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2912,12 +2912,12 @@ This report was generated on **Fri Nov 01 11:22:30 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 01 11:22:32 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 02 06:19:25 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.41`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2996,7 +2996,7 @@ This report was generated on **Fri Nov 01 11:22:32 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3111,7 +3111,7 @@ This report was generated on **Fri Nov 01 11:22:32 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3600,7 +3600,7 @@ This report was generated on **Fri Nov 01 11:22:32 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3842,7 +3842,7 @@ This report was generated on **Fri Nov 01 11:22:32 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3916,12 +3916,12 @@ This report was generated on **Fri Nov 01 11:22:32 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 01 11:22:33 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 02 06:19:27 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.41`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Fri Nov 01 11:22:33 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 01 11:22:34 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 02 06:19:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.41`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.40`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Fri Nov 01 11:22:34 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 01 11:22:35 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 02 06:19:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 23:12:55 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 05 14:31:25 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Mon Nov 04 23:12:55 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 23:13:01 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 05 14:31:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Mon Nov 04 23:13:01 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 23:13:03 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 05 14:31:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Mon Nov 04 23:13:03 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 23:13:05 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 05 14:31:33 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Mon Nov 04 23:13:05 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 23:13:07 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 05 14:31:35 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Mon Nov 04 23:13:07 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 23:13:09 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 05 14:31:37 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.40`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.42`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 06:19:22 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 21:50:23 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.40`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.42`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Sat Nov 02 06:19:22 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 06:19:24 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 21:50:26 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.40`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.42`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Sat Nov 02 06:19:24 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 06:19:25 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 21:50:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.40`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.42`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Sat Nov 02 06:19:25 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 06:19:27 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 21:50:31 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.40`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.42`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Sat Nov 02 06:19:27 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 06:19:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 21:50:33 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.40`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.42`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Sat Nov 02 06:19:28 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 02 06:19:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 21:50:35 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1066,7 +1066,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 21:50:23 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 23:12:55 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1925,7 +1925,7 @@ This report was generated on **Mon Nov 04 21:50:23 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 21:50:26 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 23:13:01 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2912,7 +2912,7 @@ This report was generated on **Mon Nov 04 21:50:26 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 21:50:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 23:13:03 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3916,7 +3916,7 @@ This report was generated on **Mon Nov 04 21:50:28 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 21:50:31 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 23:13:05 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4715,7 +4715,7 @@ This report was generated on **Mon Nov 04 21:50:31 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 21:50:33 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 23:13:07 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5484,4 +5484,4 @@ This report was generated on **Mon Nov 04 21:50:33 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 04 21:50:35 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 04 23:13:09 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.compose.desktop</groupId>
-    <artifactId>desktop-jvm-macos-x64</artifactId>
+    <artifactId>desktop-jvm-windows-x64</artifactId>
     <version>1.5.12</version>
     <scope>compile</scope>
   </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.42</version>
+<version>2.0.0-SNAPSHOT.43</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.41</version>
+<version>2.0.0-SNAPSHOT.42</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
@@ -29,7 +29,7 @@ package io.spine.chords.proto.form
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.google.protobuf.Message
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.core.InputComponent
 import io.spine.chords.runtime.MessageField
@@ -83,7 +83,7 @@ import io.spine.chords.runtime.MessageFieldValue
  *   instance. It is invoked before each recomposition of the component.
  * @return A component's instance that has been created for this
  *   declaration site.
- * @see ComponentDeclarationApi.invoke
+ * @see ComponentSetup.invoke
  */
 context(FormFieldsScope<M>)
 @Composable
@@ -92,7 +92,7 @@ public operator fun <
         M : Message,
         V : MessageFieldValue
         >
-        ComponentDeclarationApi<C>.invoke(
+        ComponentSetup<C>.invoke(
     field: MessageField<M, V>,
     props: ComponentProps<C>? = null
 ): C {
@@ -112,7 +112,7 @@ public operator fun <
  *
  * A regular way to both lazily instantiate and render a component is via
  * the respective component's companion object's `invoke` operator (see the
- * [ComponentDeclarationApi.invoke] operator functions).
+ * [ComponentSetup.invoke] operator functions).
  *
  * @receiver A context introduced by the parent form whose fields need to
  *   be edited.

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
@@ -29,7 +29,7 @@ package io.spine.chords.proto.form
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.google.protobuf.Message
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.core.InputComponent
 import io.spine.chords.runtime.MessageField
@@ -83,7 +83,7 @@ import io.spine.chords.runtime.MessageFieldValue
  *   instance. It is invoked before each recomposition of the component.
  * @return A component's instance that has been created for this
  *   declaration site.
- * @see ComponentCompanion.invoke
+ * @see ComponentDeclarationApi.invoke
  */
 context(FormFieldsScope<M>)
 @Composable
@@ -92,7 +92,7 @@ public operator fun <
         M : Message,
         V : MessageFieldValue
         >
-        ComponentCompanion<C>.invoke(
+        ComponentDeclarationApi<C>.invoke(
     field: MessageField<M, V>,
     props: ComponentProps<C>? = null
 ): C {
@@ -112,7 +112,7 @@ public operator fun <
  *
  * A regular way to both lazily instantiate and render a component is via
  * the respective component's companion object's `invoke` operator (see the
- * [ComponentCompanion.invoke] operator functions).
+ * [ComponentDeclarationApi.invoke] operator functions).
  *
  * @receiver A context introduced by the parent form whose fields need to
  *   be edited.

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -747,7 +747,7 @@ public open class MessageForm<M : Message> :
             fieldSelector: FocusableComponent
         ) {
             @Suppress(
-                // MessageOneof.fields uses an in/out MessageFieldValue as
+                // `MessageOneof.fields` uses an in/out `MessageFieldValue` as
                 // a common parent for field types.
                 "UNCHECKED_CAST"
             )

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -373,7 +373,7 @@ public enum class ValidationDisplayMode {
  * For example, if it is needed to create a custom form component for editing
  * a `PersonName` message value, this can be done like this:
  * - Create a subclass of `MessageForm` (`PersonNameForm` in this case).
- * - Add a companion object of type [MessageFormDeclarationApi] to ensure that the
+ * - Add a companion object of type [MessageFormSetup] to ensure that the
  *   component has an instance declaration API.
  * - Override either [customContent] (for rendering ordinary singlepart forms),
  *   or [customMultipartContent] (if a multipart form is needed), which should
@@ -419,7 +419,7 @@ public enum class ValidationDisplayMode {
 // Seems all class's functions are better to have in this class.
 @Suppress("TooManyFunctions")
 public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
-    public companion object : MessageFormDeclarationApiBase<Message, MessageForm<Message>>(
+    public companion object : MessageFormSetupBase<Message, MessageForm<Message>>(
         { MessageForm() }
     ) {
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -373,7 +373,7 @@ public enum class ValidationDisplayMode {
  * For example, if it is needed to create a custom form component for editing
  * a `PersonName` message value, this can be done like this:
  * - Create a subclass of `MessageForm` (`PersonNameForm` in this case).
- * - Add a companion object of type [MessageFormCompanion] to ensure that the
+ * - Add a companion object of type [MessageFormDeclarationApi] to ensure that the
  *   component has an instance declaration API.
  * - Override either [customContent] (for rendering ordinary singlepart forms),
  *   or [customMultipartContent] (if a multipart form is needed), which should
@@ -418,13 +418,8 @@ public enum class ValidationDisplayMode {
  */
 // Seems all class's functions are better to have in this class.
 @Suppress("TooManyFunctions")
-public open class MessageForm<M : Message> :
-    InputComponent<M>(), InputContext {
-
-    /**
-     * Form instance declaration and creation API.
-     */
-    public companion object : MessageFormCompanionBase<Message, MessageForm<Message>>(
+public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
+    public companion object : MessageFormDeclarationApiBase<Message, MessageForm<Message>>(
         { MessageForm() }
     ) {
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -462,7 +462,7 @@ public open class MessageForm<M : Message> :
             props: ComponentProps<MessageForm<M>> = ComponentProps {},
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
-        ): MessageForm<M> = super.declareInstance(
+        ): MessageForm<M> = declareInstance(
             value as MutableState<Message?>,
             builder,
             props as ComponentProps<MessageForm<Message>>,
@@ -615,7 +615,7 @@ public open class MessageForm<M : Message> :
             defaultValue: M? = null,
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
-        ): MessageForm<M> = super.declareMultipartInstance(
+        ): MessageForm<M> = declareMultipartInstance(
             field as MessageField<PM, Message>,
             builder,
             props as ComponentProps<MessageForm<Message>>,

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -429,9 +429,8 @@ public open class MessageForm<M : Message> :
     ) {
 
         /**
-         * Declares a `MessageForm` instance, which is not bound to a parent
-         * form automatically, and can be bound to the respective data field
-         * manually as needed.
+         * Declares a `MessageForm` instance, which edits a value stored
+         * in the [value] `MutableState`.
          *
          * The form's content that is specified with the [content] parameter is
          * expected to include field editors for all message's fields, which
@@ -453,9 +452,8 @@ public open class MessageForm<M : Message> :
          */
         @Composable
         @Suppress(
-            // explicit casts are needed due to the fact that the `M` parameter
-            // in this companion object implementation cannot be declared on
-            // the companion object itself, and cannot be "inferred" from the class.
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
             "UNCHECKED_CAST"
         )
         public operator fun <M : Message, B : ValidatingBuilder<out M>> invoke(
@@ -501,7 +499,11 @@ public open class MessageForm<M : Message> :
          */
         context(FormFieldsScope<PM>)
         @Composable
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public operator fun <
                 PM : Message,
                 M : Message,
@@ -524,9 +526,8 @@ public open class MessageForm<M : Message> :
         ) as MessageForm<M>
 
         /**
-         * Declares a multipart `MessageForm` instance, which is not bound to
-         * a parent form automatically, and can be bound to the respective data
-         * field manually as needed.
+         * Declares a multipart `MessageForm` instance, which edits a value
+         * stored in the [value] `MutableState`.
          *
          * The form's content that is specified with the [content] parameter
          * should specify each form's part with using
@@ -548,7 +549,11 @@ public open class MessageForm<M : Message> :
          *   declaration site.
          */
         @Composable
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public fun <M : Message, B: ValidatingBuilder<out M>> Multipart(
             value: MutableState<M?>,
             builder: () -> B,
@@ -593,7 +598,11 @@ public open class MessageForm<M : Message> :
          */
         context(FormFieldsScope<PM>)
         @Composable
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public fun <
                 PM : Message,
                 M : Message,
@@ -617,7 +626,7 @@ public open class MessageForm<M : Message> :
 
         /**
          * Creates a [MessageForm] instance without rendering it in
-         * the composable content with the same call.
+         * the composable content right away.
          *
          * This method can be used to create a form's instance outside
          * a composable context, and render it separately. A form's instance
@@ -646,7 +655,11 @@ public open class MessageForm<M : Message> :
          * @return A form's instance that has been created for this
          *   declaration site.
          */
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public fun <M : Message, B: ValidatingBuilder<out M>> create(
             value: MutableState<M?>,
             builder: () -> B,
@@ -729,11 +742,16 @@ public open class MessageForm<M : Message> :
          * @param fieldSelector A field selector component
          *   (such as [OneofRadioButton]).
          */
-        internal fun registerFieldSelector(
-            field: MessageField<M, MessageFieldValue>,
+        internal fun <F: MessageFieldValue> registerFieldSelector(
+            field: MessageField<M, F>,
             fieldSelector: FocusableComponent
         ) {
-            check(oneof.fields.contains(field)) {
+            @Suppress(
+                // MessageOneof.fields uses an in/out MessageFieldValue as
+                // a common parent for field types.
+                "UNCHECKED_CAST"
+            )
+            check(oneof.fields.contains(field as MessageField<M, MessageFieldValue>)) {
                 "The oneof field (${field.name}) being registered doesn't " +
                 "belong to this oneof (${oneof.name})"
             }

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -464,7 +464,7 @@ public open class MessageForm<M : Message> :
             props: ComponentProps<MessageForm<M>> = ComponentProps {},
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
-        ): MessageForm<M> = super.invoke(
+        ): MessageForm<M> = super.declareInstance(
             value as MutableState<Message?>,
             builder,
             props as ComponentProps<MessageForm<Message>>,
@@ -514,7 +514,7 @@ public open class MessageForm<M : Message> :
             defaultValue: M? = null,
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
-        ): MessageForm<M> = super.invoke(
+        ): MessageForm<M> = declareInstance(
             field as MessageField<PM, Message>,
             builder,
             props as ComponentProps<MessageForm<Message>>,
@@ -555,7 +555,7 @@ public open class MessageForm<M : Message> :
             props: ComponentProps<MessageForm<M>> = ComponentProps {},
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
-        ): MessageForm<M> = super.Multipart(
+        ): MessageForm<M> = declareMultipartInstance(
             value as MutableState<Message?>,
             builder,
             props as ComponentProps<MessageForm<Message>>,
@@ -606,7 +606,7 @@ public open class MessageForm<M : Message> :
             defaultValue: M? = null,
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
-        ): MessageForm<M> = super.Multipart(
+        ): MessageForm<M> = super.declareMultipartInstance(
             field as MessageField<PM, Message>,
             builder,
             props as ComponentProps<MessageForm<Message>>,
@@ -652,7 +652,7 @@ public open class MessageForm<M : Message> :
             builder: () -> B,
             onBeforeBuild: (B) -> Unit = {},
             props: ComponentProps<MessageForm<M>> = ComponentProps {}
-        ): MessageForm<M> = super.create(
+        ): MessageForm<M> = createInstance(
             value as MutableState<Message?>,
             builder,
             onBeforeBuild,

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
@@ -155,11 +155,14 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
     ): F = createAndRender({
         this.value = value
 
-        // Storing the builder as ValidatingBuilder internally.
+        // Storing the builder as `ValidatingBuilder` internally.
         @Suppress("UNCHECKED_CAST")
         this.builder = builder as () -> ValidatingBuilder<M>
-        // Storing onBeforeBuild using a more general ValidatingBuilder<out M> type internally.
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Storing `onBeforeBuild` using a more general
+            // `ValidatingBuilder<out M>` type internally.
+            "UNCHECKED_CAST"
+        )
         this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> Unit
         multipartContent = content
         props.run { configure() }
@@ -208,11 +211,14 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
         onBeforeBuild: (B) -> Unit = {},
         content: @Composable MultipartFormScope<M>.() -> Unit
     ): F = createAndRender({
-        // Storing the builder as ValidatingBuilder internally.
+        // Storing the builder as `ValidatingBuilder` internally.
         @Suppress("UNCHECKED_CAST")
         this.builder = builder as () -> ValidatingBuilder<M>
-        // Storing onBeforeBuild using a more general ValidatingBuilder<out M> type internally.
-        @Suppress("UNCHECKED_CAST")
+        @Suppress(
+            // Storing `onBeforeBuild` using a more general
+            // `ValidatingBuilder<out M>` type internally.
+            "UNCHECKED_CAST"
+        )
         this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> Unit
         multipartContent = content
         props.run { configure() }
@@ -259,7 +265,7 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
         super.create(null) {
             this.value = value
 
-            // Storing the builder as ValidatingBuilder internally.
+            // Storing the builder as `ValidatingBuilder` internally.
             @Suppress("UNCHECKED_CAST")
             this.builder = builder as () -> ValidatingBuilder<M>
             @Suppress("UNCHECKED_CAST")

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
@@ -208,7 +208,6 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
         onBeforeBuild: (B) -> Unit = {},
         content: @Composable MultipartFormScope<M>.() -> Unit
     ): F = createAndRender({
-
         // Storing the builder as ValidatingBuilder internally.
         @Suppress("UNCHECKED_CAST")
         this.builder = builder as () -> ValidatingBuilder<M>

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.proto.form
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import com.google.protobuf.Message
+import io.spine.chords.core.AbstractComponentCompanion
+import io.spine.chords.core.ComponentProps
+import io.spine.chords.runtime.MessageField
+import io.spine.protobuf.ValidatingBuilder
+
+/**
+ * A base class for creating companion objects for [MessageForm] and its
+ * subclasses.
+ *
+ * This class introduces only a set of protected methods, which may or may not
+ * be made public or used explicitly in a subclasses, depending on the needs of
+ * actual implementation.
+ */
+public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
+    createInstance: () -> F
+) : AbstractComponentCompanion({ createInstance() }) {
+
+    /**
+     * Declares a `MessageForm` instance, which is not bound to a parent
+     * form automatically, and can be bound to the respective data field
+     * manually as needed.
+     *
+     * The form's content that is specified with the [content] parameter is
+     * expected to include field editors for all message's fields, which
+     * are required to create a valid value of type [M].
+     *
+     * @param B A type of the message builder.
+     *
+     * @param value The message value to be edited within the form.
+     * @param builder A lambda that should create and return a new builder for
+     *   a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
+    @Composable
+    protected open operator fun <B : ValidatingBuilder<out M>> invoke(
+        value: MutableState<M?>,
+        builder: () -> B,
+        props: ComponentProps<F> = ComponentProps {},
+        onBeforeBuild: (B) -> Unit = {},
+        content: @Composable FormPartScope<M>.() -> Unit
+    ): F = Multipart(value, builder, props, onBeforeBuild) {
+        FormPart(content)
+    }
+
+    /**
+     * Declares a `MessageForm` instance, which is automatically bound to
+     * edit a parent form's field identified by [field].
+     *
+     * The form's content that is specified with the [content] parameter is
+     * expected to include field editors for all message's fields, which
+     * are required to create a valid value of type [M].
+     *
+     * @receiver The context introduced by the parent form.
+     * @param PM Parent message type.
+     * @param B A type of the message builder.
+     *
+     * @param field The parent message's field whose message is to be edited
+     *   within this form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param defaultValue A value that should be displayed in the form
+     *   by default.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
+    context(FormFieldsScope<PM>)
+    @Composable
+    protected open operator fun <
+            PM : Message,
+            B : ValidatingBuilder<out M>
+            >
+            invoke(
+        field: MessageField<PM, M>,
+        builder: () -> B,
+        props: ComponentProps<F> = ComponentProps {},
+        defaultValue: M? = null,
+        onBeforeBuild: (B) -> Unit = {},
+        content: @Composable FormPartScope<M>.() -> Unit
+    ): F = Multipart(field, builder, props, defaultValue, onBeforeBuild) {
+        FormPart(content)
+    }
+
+    /**
+     * Declares a multipart `MessageForm` instance, which is not bound to
+     * a parent form automatically, and can be bound to the respective data
+     * field manually as needed.
+     *
+     * The form's content that is specified with the [content] parameter
+     * should specify each form's part with using
+     * [FormPart][MultipartFormScope.FormPart] declarations, which, in turn,
+     * should contain the respective field editors.
+     *
+     * @param B A type of the message builder.
+     *
+     * @param value The message value to be edited within the form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
+    @Composable
+    protected open fun <B : ValidatingBuilder<out M>> Multipart(
+        value: MutableState<M?>,
+        builder: () -> B,
+        props: ComponentProps<F> = ComponentProps {},
+        onBeforeBuild: (B) -> Unit = {},
+        content: @Composable MultipartFormScope<M>.() -> Unit
+    ): F = createAndRender({
+        this.value = value
+
+        // Storing the builder as ValidatingBuilder internally.
+        @Suppress("UNCHECKED_CAST")
+        this.builder = builder as () -> ValidatingBuilder<M>
+        // Storing onBeforeBuild using a more general ValidatingBuilder<out M> type internally.
+        @Suppress("UNCHECKED_CAST")
+        this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> Unit
+        multipartContent = content
+        props.run { configure() }
+    }) {
+        Content()
+    }
+
+    /**
+     * Declares a multipart `MessageForm` instance, which is automatically
+     * bound to edit a message in a parent form's field identified
+     * by [field].
+     *
+     * The form's content that is specified with the [content] parameter
+     * should specify each form's part with using
+     * [FormPart][MultipartFormScope.FormPart] declarations, which, in turn,
+     * should contain the respective field editors.
+     *
+     * @receiver The context introduced by the parent form.
+     * @param PM Parent message type.
+     * @param B A type of the message builder.
+     *
+     * @param field The parent message's field whose message is to be edited
+     *   within this form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param defaultValue A value that should be displayed in the form by default.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return a form's instance that has been created for this
+     *         declaration site.
+     */
+    context(FormFieldsScope<PM>)
+    @Composable
+    protected open fun <
+            PM : Message,
+            B : ValidatingBuilder<out M>
+            >
+            Multipart(
+        field: MessageField<PM, M>,
+        builder: () -> B,
+        props: ComponentProps<F> = ComponentProps {},
+        defaultValue: M? = null,
+        onBeforeBuild: (B) -> Unit = {},
+        content: @Composable MultipartFormScope<M>.() -> Unit
+    ): F = createAndRender({
+
+        // Storing the builder as ValidatingBuilder internally.
+        @Suppress("UNCHECKED_CAST")
+        this.builder = builder as () -> ValidatingBuilder<M>
+        // Storing onBeforeBuild using a more general ValidatingBuilder<out M> type internally.
+        @Suppress("UNCHECKED_CAST")
+        this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> Unit
+        multipartContent = content
+        props.run { configure() }
+    }) {
+        ContentWithinField(field, defaultValue)
+    }
+
+    /**
+     * Creates a [MessageForm] instance without rendering it in
+     * the composable content with the same call.
+     *
+     * This method can be used to create a form's instance outside
+     * a composable context, and render it separately. A form's instance
+     * created in this way, has to be rendered  explicitly by calling either
+     * its [Content][MessageForm.Content] method (for singlepart forms) or its
+     * [MultipartContent][MessageForm.MultipartContent] method (for rendering a
+     * multipart form) in a composable context where it needs to be displayed.
+     *
+     * NOTE: this method creates a new instance each time it is invoked.
+     * When invoking it in context of a `@Composable` method, make sure to
+     * take this fact into account (e.g. caching the instance with
+     * [remember][androidx.compose.runtime.remember]). This method would
+     * typically not need to be invoked from `@Composable` methods though,
+     * and the regular `@Composable` declarations (using one of the [invoke]
+     * functions) would need to be used in the majority of cases.
+     *
+     * @param B A type of the message builder.
+     *
+     * @param value The message value to be edited within the form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param props A lambda that can set any additional props on the form.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
+    protected open fun <B : ValidatingBuilder<out M>> create(
+        value: MutableState<M?>,
+        builder: () -> B,
+        onBeforeBuild: (B) -> Unit = {},
+        props: ComponentProps<F> = ComponentProps {}
+    ): F =
+        super.create(null) {
+            this.value = value
+
+            // Storing the builder as ValidatingBuilder internally.
+            @Suppress("UNCHECKED_CAST")
+            this.builder = builder as () -> ValidatingBuilder<M>
+            @Suppress("UNCHECKED_CAST")
+            this.onBeforeBuild = onBeforeBuild as (ValidatingBuilder<out M>) -> Unit
+            props.run { configure() }
+        }
+}
+
+/**
+ * A class, which should be used for declaring companion objects of any custom
+ * [MessageForm] subclass [F], which is designed to edit some concrete message
+ * type [M].
+ *
+ * Adding such a companion object to custom form subclasses is needed to ensure
+ * that they can be declared or created in various usage scenarios, similarly
+ * to how any other [Component][io.spine.chords.core.Component] implementation
+ * can be declared. See the "Implementing custom form components" section in
+ * the [MessageForm]'s documentation.
+ */
+public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
+    createInstance: () -> F
+) : MessageFormCompanionBase<M, F>(createInstance) {
+
+    @Composable
+    public override fun <B : ValidatingBuilder<out M>> invoke(
+        value: MutableState<M?>,
+        builder: () -> B,
+        props: ComponentProps<F>,
+        onBeforeBuild: (B) -> Unit,
+        content: @Composable FormPartScope<M>.() -> Unit
+    ): F = super.invoke(value, builder, props, onBeforeBuild, content)
+
+    context(FormFieldsScope<PM>)
+    @Composable
+    public override fun <PM : Message, B : ValidatingBuilder<out M>> invoke(
+        field: MessageField<PM, M>,
+        builder: () -> B,
+        props: ComponentProps<F>,
+        defaultValue: M?,
+        onBeforeBuild: (B) -> Unit,
+        content: @Composable FormPartScope<M>.() -> Unit
+    ): F = super.invoke(field, builder, props, defaultValue, onBeforeBuild, content)
+
+    @Composable
+    public override fun <B : ValidatingBuilder<out M>> Multipart(
+        value: MutableState<M?>,
+        builder: () -> B,
+        props: ComponentProps<F>,
+        onBeforeBuild: (B) -> Unit,
+        content: @Composable MultipartFormScope<M>.() -> Unit
+    ): F = super.Multipart(value, builder, props, onBeforeBuild, content)
+
+    context(FormFieldsScope<PM>)
+    @Composable
+    public override fun <PM : Message, B : ValidatingBuilder<out M>> Multipart(
+        field: MessageField<PM, M>,
+        builder: () -> B,
+        props: ComponentProps<F>,
+        defaultValue: M?,
+        onBeforeBuild: (B) -> Unit,
+        content: @Composable MultipartFormScope<M>.() -> Unit
+    ): F = super.Multipart(field, builder, props, defaultValue, onBeforeBuild, content)
+
+    public override fun <B : ValidatingBuilder<out M>> create(
+        value: MutableState<M?>,
+        builder: () -> B,
+        onBeforeBuild: (B) -> Unit,
+        props: ComponentProps<F>
+    ): F = super.create(value, builder, onBeforeBuild, props)
+}

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
@@ -69,13 +69,13 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
      *   declaration site.
      */
     @Composable
-    protected open operator fun <B : ValidatingBuilder<out M>> invoke(
+    protected fun <B : ValidatingBuilder<out M>> declareInstance(
         value: MutableState<M?>,
         builder: () -> B,
         props: ComponentProps<F> = ComponentProps {},
         onBeforeBuild: (B) -> Unit = {},
         content: @Composable FormPartScope<M>.() -> Unit
-    ): F = Multipart(value, builder, props, onBeforeBuild) {
+    ): F = declareMultipartInstance(value, builder, props, onBeforeBuild) {
         FormPart(content)
     }
 
@@ -107,18 +107,18 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
      */
     context(FormFieldsScope<PM>)
     @Composable
-    protected open operator fun <
+    protected open fun <
             PM : Message,
             B : ValidatingBuilder<out M>
             >
-            invoke(
+            declareInstance(
         field: MessageField<PM, M>,
         builder: () -> B,
         props: ComponentProps<F> = ComponentProps {},
         defaultValue: M? = null,
         onBeforeBuild: (B) -> Unit = {},
         content: @Composable FormPartScope<M>.() -> Unit
-    ): F = Multipart(field, builder, props, defaultValue, onBeforeBuild) {
+    ): F = declareMultipartInstance(field, builder, props, defaultValue, onBeforeBuild) {
         FormPart(content)
     }
 
@@ -146,7 +146,7 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
      *   declaration site.
      */
     @Composable
-    protected open fun <B : ValidatingBuilder<out M>> Multipart(
+    protected fun <B : ValidatingBuilder<out M>> declareMultipartInstance(
         value: MutableState<M?>,
         builder: () -> B,
         props: ComponentProps<F> = ComponentProps {},
@@ -196,11 +196,11 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
      */
     context(FormFieldsScope<PM>)
     @Composable
-    protected open fun <
+    protected fun <
             PM : Message,
             B : ValidatingBuilder<out M>
             >
-            Multipart(
+            declareMultipartInstance(
         field: MessageField<PM, M>,
         builder: () -> B,
         props: ComponentProps<F> = ComponentProps {},
@@ -251,7 +251,7 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
      * @return A form's instance that has been created for this
      *   declaration site.
      */
-    protected open fun <B : ValidatingBuilder<out M>> create(
+    protected open fun <B : ValidatingBuilder<out M>> createInstance(
         value: MutableState<M?>,
         builder: () -> B,
         onBeforeBuild: (B) -> Unit = {},
@@ -284,50 +284,178 @@ public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
 ) : MessageFormCompanionBase<M, F>(createInstance) {
 
+    /**
+     * Declares a `MessageForm` instance, which is not bound to a parent
+     * form automatically, and can be bound to the respective data field
+     * manually as needed.
+     *
+     * The form's content that is specified with the [content] parameter is
+     * expected to include field editors for all message's fields, which
+     * are required to create a valid value of type [M].
+     *
+     * @param B A type of the message builder.
+     *
+     * @param value The message value to be edited within the form.
+     * @param builder A lambda that should create and return a new builder for
+     *   a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
     @Composable
-    public override fun <B : ValidatingBuilder<out M>> invoke(
+    public fun <B : ValidatingBuilder<out M>> invoke(
         value: MutableState<M?>,
         builder: () -> B,
         props: ComponentProps<F>,
         onBeforeBuild: (B) -> Unit,
         content: @Composable FormPartScope<M>.() -> Unit
-    ): F = super.invoke(value, builder, props, onBeforeBuild, content)
+    ): F = declareInstance(value, builder, props, onBeforeBuild, content)
 
+    /**
+     * Declares a `MessageForm` instance, which is automatically bound to
+     * edit a parent form's field identified by [field].
+     *
+     * The form's content that is specified with the [content] parameter is
+     * expected to include field editors for all message's fields, which
+     * are required to create a valid value of type [M].
+     *
+     * @receiver The context introduced by the parent form.
+     * @param PM Parent message type.
+     * @param B A type of the message builder.
+     *
+     * @param field The parent message's field whose message is to be edited
+     *   within this form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param defaultValue A value that should be displayed in the form
+     *   by default.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
     context(FormFieldsScope<PM>)
     @Composable
-    public override fun <PM : Message, B : ValidatingBuilder<out M>> invoke(
+    public fun <PM : Message, B : ValidatingBuilder<out M>> invoke(
         field: MessageField<PM, M>,
         builder: () -> B,
         props: ComponentProps<F>,
         defaultValue: M?,
         onBeforeBuild: (B) -> Unit,
         content: @Composable FormPartScope<M>.() -> Unit
-    ): F = super.invoke(field, builder, props, defaultValue, onBeforeBuild, content)
+    ): F = declareInstance(field, builder, props, defaultValue, onBeforeBuild, content)
 
+    /**
+     * Declares a multipart `MessageForm` instance, which is not bound to
+     * a parent form automatically, and can be bound to the respective data
+     * field manually as needed.
+     *
+     * The form's content that is specified with the [content] parameter
+     * should specify each form's part with using
+     * [FormPart][MultipartFormScope.FormPart] declarations, which, in turn,
+     * should contain the respective field editors.
+     *
+     * @param B A type of the message builder.
+     *
+     * @param value The message value to be edited within the form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
     @Composable
-    public override fun <B : ValidatingBuilder<out M>> Multipart(
+    public fun <B : ValidatingBuilder<out M>> Multipart(
         value: MutableState<M?>,
         builder: () -> B,
         props: ComponentProps<F>,
         onBeforeBuild: (B) -> Unit,
         content: @Composable MultipartFormScope<M>.() -> Unit
-    ): F = super.Multipart(value, builder, props, onBeforeBuild, content)
+    ): F = declareMultipartInstance(value, builder, props, onBeforeBuild, content)
 
+    /**
+     * Declares a multipart `MessageForm` instance, which is automatically
+     * bound to edit a message in a parent form's field identified
+     * by [field].
+     *
+     * The form's content that is specified with the [content] parameter
+     * should specify each form's part with using
+     * [FormPart][MultipartFormScope.FormPart] declarations, which, in turn,
+     * should contain the respective field editors.
+     *
+     * @receiver The context introduced by the parent form.
+     * @param PM Parent message type.
+     * @param B A type of the message builder.
+     *
+     * @param field The parent message's field whose message is to be edited
+     *   within this form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param props A lambda that can set any additional props on the form.
+     * @param defaultValue A value that should be displayed in the form by default.
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param content A form's content, which can contain an arbitrary
+     *   layout along with field editor declarations.
+     * @return a form's instance that has been created for this
+     *         declaration site.
+     */
     context(FormFieldsScope<PM>)
     @Composable
-    public override fun <PM : Message, B : ValidatingBuilder<out M>> Multipart(
+    public fun <PM : Message, B : ValidatingBuilder<out M>> Multipart(
         field: MessageField<PM, M>,
         builder: () -> B,
         props: ComponentProps<F>,
         defaultValue: M?,
         onBeforeBuild: (B) -> Unit,
         content: @Composable MultipartFormScope<M>.() -> Unit
-    ): F = super.Multipart(field, builder, props, defaultValue, onBeforeBuild, content)
+    ): F = declareMultipartInstance(field, builder, props, defaultValue, onBeforeBuild, content)
 
-    public override fun <B : ValidatingBuilder<out M>> create(
+    /**
+     * Creates a [MessageForm] instance without rendering it in
+     * the composable content with the same call.
+     *
+     * This method can be used to create a form's instance outside
+     * a composable context, and render it separately. A form's instance
+     * created in this way, has to be rendered  explicitly by calling either
+     * its [Content][MessageForm.Content] method (for singlepart forms) or its
+     * [MultipartContent][MessageForm.MultipartContent] method (for rendering a
+     * multipart form) in a composable context where it needs to be displayed.
+     *
+     * NOTE: this method creates a new instance each time it is invoked.
+     * When invoking it in context of a `@Composable` method, make sure to
+     * take this fact into account (e.g. caching the instance with
+     * [remember][androidx.compose.runtime.remember]). This method would
+     * typically not need to be invoked from `@Composable` methods though,
+     * and the regular `@Composable` declarations (using one of the [invoke]
+     * functions) would need to be used in the majority of cases.
+     *
+     * @param B A type of the message builder.
+     *
+     * @param value The message value to be edited within the form.
+     * @param builder A lambda that should create and return a new builder
+     *   for a message of type [M].
+     * @param onBeforeBuild A lambda that allows to amend the message
+     *   after any valid field is entered to it.
+     * @param props A lambda that can set any additional props on the form.
+     * @return A form's instance that has been created for this
+     *   declaration site.
+     */
+    public fun <B : ValidatingBuilder<out M>> create(
         value: MutableState<M?>,
         builder: () -> B,
         onBeforeBuild: (B) -> Unit,
         props: ComponentProps<F>
-    ): F = super.create(value, builder, onBeforeBuild, props)
+    ): F = super.createInstance(value, builder, onBeforeBuild, props)
 }

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormCompanion.kt
@@ -269,12 +269,12 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
 }
 
 /**
- * A class, which should be used for declaring companion objects of any custom
+ * A class, which should be used for a declaring companion object of any custom
  * [MessageForm] subclass [F], which is designed to edit some concrete message
  * type [M].
  *
- * Adding such a companion object to custom form subclasses is needed to ensure
- * that they can be declared or created in various usage scenarios, similarly
+ * Adding such a companion object to a custom form subclass is needed to ensure
+ * that it can be declared or created in various usage scenarios, similarly
  * to how any other [Component][io.spine.chords.core.Component] implementation
  * can be declared. See the "Implementing custom form components" section in
  * the [MessageForm]'s documentation.
@@ -284,9 +284,8 @@ public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
 ) : MessageFormCompanionBase<M, F>(createInstance) {
 
     /**
-     * Declares a `MessageForm` instance, which is not bound to a parent
-     * form automatically, and can be bound to the respective data field
-     * manually as needed.
+     * Declares a form instance, which edits a value stored in
+     * the [value] `MutableState`.
      *
      * The form's content that is specified with the [content] parameter is
      * expected to include field editors for all message's fields, which
@@ -315,8 +314,8 @@ public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
     ): F = declareInstance(value, builder, props, onBeforeBuild, content)
 
     /**
-     * Declares a `MessageForm` instance, which is automatically bound to
-     * edit a parent form's field identified by [field].
+     * Declares a form instance, which is automatically bound to edit a parent
+     * form's field identified by [field].
      *
      * The form's content that is specified with the [content] parameter is
      * expected to include field editors for all message's fields, which
@@ -352,9 +351,8 @@ public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
     ): F = declareInstance(field, builder, props, defaultValue, onBeforeBuild, content)
 
     /**
-     * Declares a multipart `MessageForm` instance, which is not bound to
-     * a parent form automatically, and can be bound to the respective data
-     * field manually as needed.
+     * Declares a multipart `MessageForm` instance, which edits a value stored
+     * in the [value] `MutableState`.
      *
      * The form's content that is specified with the [content] parameter
      * should specify each form's part with using
@@ -384,9 +382,8 @@ public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
     ): F = declareMultipartInstance(value, builder, props, onBeforeBuild, content)
 
     /**
-     * Declares a multipart `MessageForm` instance, which is automatically
-     * bound to edit a message in a parent form's field identified
-     * by [field].
+     * Declares a multipart form instance, which is automatically bound to edit
+     * a message in a parent form's field identified by [field].
      *
      * The form's content that is specified with the [content] parameter
      * should specify each form's part with using
@@ -422,8 +419,8 @@ public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
     ): F = declareMultipartInstance(field, builder, props, defaultValue, onBeforeBuild, content)
 
     /**
-     * Creates a [MessageForm] instance without rendering it in
-     * the composable content with the same call.
+     * Creates a form instance without rendering it in the composable content
+     * right away.
      *
      * This method can be used to create a form's instance outside
      * a composable context, and render it separately. A form's instance

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormDeclarationApi.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormDeclarationApi.kt
@@ -29,7 +29,7 @@ package io.spine.chords.proto.form
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import com.google.protobuf.Message
-import io.spine.chords.core.AbstractComponentCompanion
+import io.spine.chords.core.AbstractComponentDeclarationApi
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.runtime.MessageField
 import io.spine.protobuf.ValidatingBuilder
@@ -42,9 +42,9 @@ import io.spine.protobuf.ValidatingBuilder
  * be made public or used explicitly in a subclasses, depending on the needs of
  * actual implementation.
  */
-public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
+public open class MessageFormDeclarationApiBase<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
-) : AbstractComponentCompanion({ createInstance() }) {
+) : AbstractComponentDeclarationApi({ createInstance() }) {
 
     /**
      * Declares a `MessageForm` instance, which is not bound to a parent
@@ -285,9 +285,9 @@ public open class MessageFormCompanionBase<M: Message, F: MessageForm<M>>(
  * can be declared. See the "Implementing custom form components" section in
  * the [MessageForm]'s documentation.
  */
-public class MessageFormCompanion<M: Message, F: MessageForm<M>>(
+public open class MessageFormDeclarationApi<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
-) : MessageFormCompanionBase<M, F>(createInstance) {
+) : MessageFormDeclarationApiBase<M, F>(createInstance) {
 
     /**
      * Declares a form instance, which edits a value stored in

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
@@ -242,6 +242,13 @@ public sealed interface OneOfFieldsScope<M : Message> : FormFieldsScope<M> {
      */
     public val validationMessage: State<String?>
 
+    /**
+     * Informs the form component about the component, which is used as
+     * a selection toggle (e.g. radio button) for the specified oneof [field].
+     *
+     * This knowledge is required by the form component to be able to focus
+     * respective field selectors when needed.
+     */
     public fun <F: MessageFieldValue> registerFieldSelector(
         field: MessageField<M, F>,
         fieldSelector: FocusableComponent

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
@@ -242,8 +242,8 @@ public sealed interface OneOfFieldsScope<M : Message> : FormFieldsScope<M> {
      */
     public val validationMessage: State<String?>
 
-    public fun registerFieldSelector(
-        field: MessageField<M, MessageFieldValue>,
+    public fun <F: MessageFieldValue> registerFieldSelector(
+        field: MessageField<M, F>,
         fieldSelector: FocusableComponent
     )
 }
@@ -467,8 +467,8 @@ private class OneOfFieldsScopeImpl<M : Message>(
     ): MessageForm<M>.FormField =
         form.FormField(this, field, initialValue, formOneof)
 
-    override fun registerFieldSelector(
-        field: MessageField<M, MessageFieldValue>,
+    override fun <F: MessageFieldValue> registerFieldSelector(
+        field: MessageField<M, F>,
         fieldSelector: FocusableComponent
     ) {
         formOneof.registerFieldSelector(field, fieldSelector)

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
@@ -401,9 +401,9 @@ internal abstract class FormFieldsScopeImpl<M : Message>(
         defaultValue: V?,
         content: @Composable FormFieldScope<V>.() -> Unit
     ) {
-        // We have to store fields by their common base type MessageFieldValue
+        // We have to store fields by their common base type `MessageFieldValue`
         // in the form, and we cannot use neither `in` nor `out` for the type
-        // parameter since the respective field in MessageField is mutable.
+        // parameter since the respective field in `MessageField` is mutable.
         @Suppress("UNCHECKED_CAST")
         val baseTypedField = field as MessageField<M, MessageFieldValue>
         val formField = registerField(baseTypedField, defaultValue)

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetup.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetup.kt
@@ -29,7 +29,7 @@ package io.spine.chords.proto.form
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import com.google.protobuf.Message
-import io.spine.chords.core.AbstractComponentDeclarationApi
+import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.runtime.MessageField
 import io.spine.protobuf.ValidatingBuilder
@@ -42,9 +42,9 @@ import io.spine.protobuf.ValidatingBuilder
  * be made public or used explicitly in a subclasses, depending on the needs of
  * actual implementation.
  */
-public open class MessageFormDeclarationApiBase<M: Message, F: MessageForm<M>>(
+public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
-) : AbstractComponentDeclarationApi({ createInstance() }) {
+) : AbstractComponentSetup({ createInstance() }) {
 
     /**
      * Declares a `MessageForm` instance, which is not bound to a parent
@@ -285,9 +285,9 @@ public open class MessageFormDeclarationApiBase<M: Message, F: MessageForm<M>>(
  * can be declared. See the "Implementing custom form components" section in
  * the [MessageForm]'s documentation.
  */
-public open class MessageFormDeclarationApi<M: Message, F: MessageForm<M>>(
+public open class MessageFormSetup<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
-) : MessageFormDeclarationApiBase<M, F>(createInstance) {
+) : MessageFormSetupBase<M, F>(createInstance) {
 
     /**
      * Declares a form instance, which edits a value stored in

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetup.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetup.kt
@@ -41,6 +41,9 @@ import io.spine.protobuf.ValidatingBuilder
  * This class introduces only a set of protected methods, which may or may not
  * be made public or used explicitly in a subclasses, depending on the needs of
  * actual implementation.
+ *
+ * @see io.spine.chords.core.Component
+ * @see io.spine.chords.core.ComponentSetup
  */
 public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
@@ -284,6 +287,9 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
  * to how any other [Component][io.spine.chords.core.Component] implementation
  * can be declared. See the "Implementing custom form components" section in
  * the [MessageForm]'s documentation.
+ *
+ * @see io.spine.chords.core.Component
+ * @see io.spine.chords.core.ComponentSetup
  */
 public open class MessageFormSetup<M: Message, F: MessageForm<M>>(
     createInstance: () -> F

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -76,13 +76,15 @@ public class OneofRadioButton : FocusableComponent() {
             field: MessageField<M, F>,
             text: String
         ): OneofRadioButton = createAndRender({
-            @Suppress("UNCHECKED_CAST")
-            registerFieldSelector(field as MessageField<M, MessageFieldValue>, this)
+            registerFieldSelector(field, this)
         }) {
             RadioButtonWithText(
                 selected = selectedField.value == field,
                 onClick = {
-                    @Suppress("UNCHECKED_CAST")
+                    @Suppress(
+                        // selectedField treats all fields as MessageFieldValue
+                        "UNCHECKED_CAST"
+                    )
                     selectedField.value = field as MessageField<M, MessageFieldValue>
                 },
                 text = text,

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -82,7 +82,8 @@ public class OneofRadioButton : FocusableComponent() {
                 selected = selectedField.value == field,
                 onClick = {
                     @Suppress(
-                        // selectedField treats all fields as MessageFieldValue
+                        // `selectedField` treats all fields
+                        // as `MessageFieldValue`.
                         "UNCHECKED_CAST"
                     )
                     selectedField.value = field as MessageField<M, MessageFieldValue>

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -76,11 +76,13 @@ public class OneofRadioButton : FocusableComponent() {
             field: MessageField<M, F>,
             text: String
         ): OneofRadioButton = createAndRender({
+            @Suppress("UNCHECKED_CAST")
             registerFieldSelector(field as MessageField<M, MessageFieldValue>, this)
         }) {
             RadioButtonWithText(
                 selected = selectedField.value == field,
                 onClick = {
+                    @Suppress("UNCHECKED_CAST")
                     selectedField.value = field as MessageField<M, MessageFieldValue>
                 },
                 text = text,

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -28,7 +28,7 @@ package io.spine.chords.proto.form
 
 import androidx.compose.runtime.Composable
 import com.google.protobuf.Message
-import io.spine.chords.core.AbstractComponentDeclarationApi
+import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.FocusRequestDispatcher
 import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.primitive.RadioButtonWithText
@@ -42,7 +42,7 @@ import io.spine.protobuf.ValidatingBuilder
  * switch between oneof fields.
  */
 public class OneofRadioButton : FocusableComponent() {
-    public companion object : AbstractComponentDeclarationApi({ OneofRadioButton() }) {
+    public companion object : AbstractComponentSetup({ OneofRadioButton() }) {
 
         /**
          * The version of `OneofFields`, which expects the editor for

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -28,7 +28,7 @@ package io.spine.chords.proto.form
 
 import androidx.compose.runtime.Composable
 import com.google.protobuf.Message
-import io.spine.chords.core.AbstractComponentCompanion
+import io.spine.chords.core.AbstractComponentDeclarationApi
 import io.spine.chords.core.FocusRequestDispatcher
 import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.primitive.RadioButtonWithText
@@ -42,11 +42,7 @@ import io.spine.protobuf.ValidatingBuilder
  * switch between oneof fields.
  */
 public class OneofRadioButton : FocusableComponent() {
-
-    /**
-     * An instance declaration API.
-     */
-    public companion object : AbstractComponentCompanion({ OneofRadioButton() }) {
+    public companion object : AbstractComponentDeclarationApi({ OneofRadioButton() }) {
 
         /**
          * The version of `OneofFields`, which expects the editor for

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/BankAccountField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/BankAccountField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.money
 
 import io.spine.chords.proto.form.vBuildBasedParser
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.proto.value.money.BankAccount
 
@@ -35,7 +35,7 @@ import io.spine.chords.proto.value.money.BankAccount
  * A field that allows entering a bank account number.
  */
 public class BankAccountField : InputField<BankAccount>() {
-    public companion object : ComponentDeclarationApi<BankAccountField>({ BankAccountField() })
+    public companion object : ComponentSetup<BankAccountField>({ BankAccountField() })
 
     init {
         label = "Bank account"

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/BankAccountField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/BankAccountField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.money
 
 import io.spine.chords.proto.form.vBuildBasedParser
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.proto.value.money.BankAccount
 
@@ -35,11 +35,7 @@ import io.spine.chords.proto.value.money.BankAccount
  * A field that allows entering a bank account number.
  */
 public class BankAccountField : InputField<BankAccount>() {
-
-    /**
-     * An instance declaration API.
-     */
-    public companion object : ComponentCompanion<BankAccountField>({ BankAccountField() })
+    public companion object : ComponentDeclarationApi<BankAccountField>({ BankAccountField() })
 
     init {
         label = "Bank account"

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.text.font.FontFamily.Companion.Monospace
 import androidx.compose.ui.text.font.FontWeight.Companion.SemiBold
 import androidx.compose.ui.text.input.getSelectedText
 import androidx.compose.ui.unit.dp
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.DropdownListBox
 import io.spine.chords.core.DropdownListBoxScope
 import io.spine.chords.core.keyboard.KeyRange.Companion.Digit
@@ -85,7 +85,7 @@ private val defaultCurrency = USD
  * A field that allows entering [Money] values.
  */
 public class MoneyField : InputField<Money>() {
-    public companion object : ComponentDeclarationApi<MoneyField>({ MoneyField() })
+    public companion object : ComponentSetup<MoneyField>({ MoneyField() })
 
     /**
      * A list of item values to choose from.

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.text.font.FontFamily.Companion.Monospace
 import androidx.compose.ui.text.font.FontWeight.Companion.SemiBold
 import androidx.compose.ui.text.input.getSelectedText
 import androidx.compose.ui.unit.dp
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.DropdownListBox
 import io.spine.chords.core.DropdownListBoxScope
 import io.spine.chords.core.keyboard.KeyRange.Companion.Digit
@@ -85,11 +85,7 @@ private val defaultCurrency = USD
  * A field that allows entering [Money] values.
  */
 public class MoneyField : InputField<Money>() {
-
-    /**
-     * Instance declaration API.
-     */
-    public companion object : ComponentCompanion<MoneyField>({ MoneyField() })
+    public companion object : ComponentDeclarationApi<MoneyField>({ MoneyField() })
 
     /**
      * A list of item values to choose from.

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentCardNumberField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentCardNumberField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.money
 
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser.Companion.DigitsOnly
 import io.spine.chords.core.InputReviser.Companion.maxLength
@@ -65,7 +65,7 @@ private val PaymentCardNumberKt.maxValueLength get() = 19
  * A field that allows entering a payment card number.
  */
 public class PaymentCardNumberField : InputField<PaymentCardNumber>() {
-    public companion object : ComponentDeclarationApi<PaymentCardNumberField>({
+    public companion object : ComponentSetup<PaymentCardNumberField>({
         PaymentCardNumberField()
     })
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentCardNumberField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentCardNumberField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.money
 
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser.Companion.DigitsOnly
 import io.spine.chords.core.InputReviser.Companion.maxLength
@@ -65,11 +65,7 @@ private val PaymentCardNumberKt.maxValueLength get() = 19
  * A field that allows entering a payment card number.
  */
 public class PaymentCardNumberField : InputField<PaymentCardNumber>() {
-
-    /**
-     * Instance declaration API.
-     */
-    public companion object : ComponentCompanion<PaymentCardNumberField>({
+    public companion object : ComponentDeclarationApi<PaymentCardNumberField>({
         PaymentCardNumberField()
     })
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.dp
 import io.spine.chords.core.layout.InputRow
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
-import io.spine.chords.proto.form.MessageFormDeclarationApi
+import io.spine.chords.proto.form.MessageFormSetup
 import io.spine.chords.proto.form.OneofRadioButton
 import io.spine.chords.proto.form.OptionalMessageCheckbox
 import io.spine.chords.proto.form.invoke
@@ -48,7 +48,7 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
  * A component that edits a [PaymentMethod].
  */
 public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
-    public companion object : MessageFormDeclarationApi<PaymentMethod, PaymentMethodEditor>(
+    public companion object : MessageFormSetup<PaymentMethod, PaymentMethodEditor>(
         { PaymentMethodEditor() }
     )
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -50,7 +50,9 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
 public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
 
     /**
-     * A component instance declaration API.
+     * A component instance declaration API, as described in the "Implementing
+     * class-based components" documentation section of the base
+     * [Component][io.spine.chords.core.Component] class.
      */
     public companion object : MessageFormCompanionBase<PaymentMethod, PaymentMethodEditor>(
         { PaymentMethodEditor() }

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.dp
 import io.spine.chords.core.layout.InputRow
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
-import io.spine.chords.proto.form.MessageFormCompanionBase
+import io.spine.chords.proto.form.MessageFormDeclarationApi
 import io.spine.chords.proto.form.OneofRadioButton
 import io.spine.chords.proto.form.OptionalMessageCheckbox
 import io.spine.chords.proto.form.invoke
@@ -48,13 +48,7 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
  * A component that edits a [PaymentMethod].
  */
 public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
-
-    /**
-     * A component instance declaration API, as described in the "Implementing
-     * class-based components" documentation section of the base
-     * [Component][io.spine.chords.core.Component] class.
-     */
-    public companion object : MessageFormCompanionBase<PaymentMethod, PaymentMethodEditor>(
+    public companion object : MessageFormDeclarationApi<PaymentMethod, PaymentMethodEditor>(
         { PaymentMethodEditor() }
     )
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import io.spine.chords.core.layout.InputRow
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
+import io.spine.chords.proto.form.MessageFormCompanionBase
 import io.spine.chords.proto.form.OneofRadioButton
 import io.spine.chords.proto.form.OptionalMessageCheckbox
 import io.spine.chords.proto.form.invoke
@@ -47,6 +48,14 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
  * A component that edits a [PaymentMethod].
  */
 public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
+
+    /**
+     *
+     */
+    public companion object : MessageFormCompanionBase<PaymentMethod, PaymentMethodEditor>(
+        { PaymentMethodEditor() }
+    )
+
     init {
         builder = { PaymentMethod.newBuilder() }
     }

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -50,7 +50,7 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
 public class PaymentMethodEditor : MessageForm<PaymentMethod>() {
 
     /**
-     *
+     * A component instance declaration API.
      */
     public companion object : MessageFormCompanionBase<PaymentMethod, PaymentMethodEditor>(
         { PaymentMethodEditor() }

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/EmailField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/EmailField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.core.ValueParseException
 import io.spine.net.EmailAddress
@@ -40,7 +40,7 @@ private const val EmailRegex = """^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}${'$'}"""
  * An input field that allows editing a [EmailAddress] field.
  */
 public class EmailField : InputField<EmailAddress>() {
-    public companion object : ComponentDeclarationApi<EmailField>({ EmailField() })
+    public companion object : ComponentSetup<EmailField>({ EmailField() })
 
     init {
         label = "Email"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/EmailField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/EmailField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.core.ValueParseException
 import io.spine.net.EmailAddress
@@ -40,7 +40,7 @@ private const val EmailRegex = """^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}${'$'}"""
  * An input field that allows editing a [EmailAddress] field.
  */
 public class EmailField : InputField<EmailAddress>() {
-    public companion object : ComponentCompanion<EmailField>({ EmailField() })
+    public companion object : ComponentDeclarationApi<EmailField>({ EmailField() })
 
     init {
         label = "Email"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/InternetDomainField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/InternetDomainField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.core.exceptionBasedParser
 import io.spine.net.InternetDomain
@@ -36,11 +36,9 @@ import io.spine.net.InternetDomains
  * A field that allows entering an [InternetDomain] value.
  */
 public class InternetDomainField : InputField<InternetDomain>() {
-
-    /**
-     * A component instance declaration API.
-     */
-    public companion object : ComponentCompanion<InternetDomainField>({ InternetDomainField() })
+    public companion object : ComponentDeclarationApi<InternetDomainField>(
+        { InternetDomainField() }
+    )
 
     override fun parseValue(rawText: String): InternetDomain = exceptionBasedParser(
         IllegalArgumentException::class,

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/InternetDomainField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/InternetDomainField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.core.exceptionBasedParser
 import io.spine.net.InternetDomain
@@ -36,7 +36,7 @@ import io.spine.net.InternetDomains
  * A field that allows entering an [InternetDomain] value.
  */
 public class InternetDomainField : InputField<InternetDomain>() {
-    public companion object : ComponentDeclarationApi<InternetDomainField>(
+    public companion object : ComponentSetup<InternetDomainField>(
         { InternetDomainField() }
     )
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.net
 
 import androidx.compose.ui.input.key.KeyEvent
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser
 import io.spine.chords.core.RawTextContent
@@ -44,11 +44,7 @@ import io.spine.chords.proto.value.net.parse
  * A field for entering an IP address.
  */
 public class IpAddressField : InputField<IpAddress>() {
-
-    /**
-     * An instance declaration API.
-     */
-    public companion object : ComponentCompanion<IpAddressField>({ IpAddressField() })
+    public companion object : ComponentDeclarationApi<IpAddressField>({ IpAddressField() })
 
     init {
         label = "IP address"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.net
 
 import androidx.compose.ui.input.key.KeyEvent
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser
 import io.spine.chords.core.RawTextContent
@@ -44,7 +44,7 @@ import io.spine.chords.proto.value.net.parse
  * A field for entering an IP address.
  */
 public class IpAddressField : InputField<IpAddress>() {
-    public companion object : ComponentDeclarationApi<IpAddressField>({ IpAddressField() })
+    public companion object : ComponentSetup<IpAddressField>({ IpAddressField() })
 
     init {
         label = "IP address"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/UrlField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/UrlField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser.Companion.NonWhitespaces
 import io.spine.chords.core.exceptionBasedParser
@@ -37,11 +37,7 @@ import io.spine.chords.proto.value.net.parse
  * A field that allows entering a URL.
  */
 public class UrlField : InputField<Url>() {
-
-    /**
-     * An instance declaration API.
-     */
-    public companion object : ComponentCompanion<UrlField>({ UrlField() })
+    public companion object : ComponentDeclarationApi<UrlField>({ UrlField() })
 
     init {
         label = "URL"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/UrlField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/UrlField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser.Companion.NonWhitespaces
 import io.spine.chords.core.exceptionBasedParser
@@ -37,7 +37,7 @@ import io.spine.chords.proto.value.net.parse
  * A field that allows entering a URL.
  */
 public class UrlField : InputField<Url>() {
-    public companion object : ComponentDeclarationApi<UrlField>({ UrlField() })
+    public companion object : ComponentSetup<UrlField>({ UrlField() })
 
     init {
         label = "URL"

--- a/proto/src/main/kotlin/io/spine/chords/proto/people/PersonNameField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/people/PersonNameField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.people
 
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.InputField
 import io.spine.chords.core.exceptionBasedParser
 import io.spine.people.PersonName
@@ -37,7 +37,7 @@ import io.spine.chords.proto.value.person.parse
  * A field that allows editing a [PersonName] value.
  */
 public class PersonNameField : InputField<PersonName>() {
-    public companion object : ComponentDeclarationApi<PersonNameField>({ PersonNameField() })
+    public companion object : ComponentSetup<PersonNameField>({ PersonNameField() })
 
     init {
         label = "Person name"

--- a/proto/src/main/kotlin/io/spine/chords/proto/people/PersonNameField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/people/PersonNameField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.people
 
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.InputField
 import io.spine.chords.core.exceptionBasedParser
 import io.spine.people.PersonName
@@ -37,11 +37,7 @@ import io.spine.chords.proto.value.person.parse
  * A field that allows editing a [PersonName] value.
  */
 public class PersonNameField : InputField<PersonName>() {
-
-    /**
-     * A component instance declaration API.
-     */
-    public companion object : ComponentCompanion<PersonNameField>({ PersonNameField() })
+    public companion object : ComponentDeclarationApi<PersonNameField>({ PersonNameField() })
 
     init {
         label = "Person name"

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.input.getSelectedText
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
-import io.spine.chords.core.ComponentDeclarationApi
+import io.spine.chords.core.ComponentSetup
 import io.spine.chords.core.keyboard.KeyRange
 import io.spine.chords.core.keyboard.matches
 import io.spine.chords.core.InputField
@@ -75,7 +75,7 @@ public typealias DateTimePattern = String
  * A field that allows specifying date and time.
  */
 public class DateTimeField : InputField<Timestamp>() {
-    public companion object : ComponentDeclarationApi<DateTimeField>({ DateTimeField() })
+    public companion object : ComponentSetup<DateTimeField>({ DateTimeField() })
 
     /**
      * A pattern for parsing and formatting a date component (as used with

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.input.getSelectedText
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
-import io.spine.chords.core.ComponentCompanion
+import io.spine.chords.core.ComponentDeclarationApi
 import io.spine.chords.core.keyboard.KeyRange
 import io.spine.chords.core.keyboard.matches
 import io.spine.chords.core.InputField
@@ -75,11 +75,7 @@ public typealias DateTimePattern = String
  * A field that allows specifying date and time.
  */
 public class DateTimeField : InputField<Timestamp>() {
-
-    /**
-     * Instance declaration API.
-     */
-    public companion object : ComponentCompanion<DateTimeField>({ DateTimeField() })
+    public companion object : ComponentDeclarationApi<DateTimeField>({ DateTimeField() })
 
     /**
      * A pattern for parsing and formatting a date component (as used with

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.42")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.43")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.41")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.42")


### PR DESCRIPTION
This PR includes:
- Adds a missing companion object for `PaymentMethodEditor`, which is required to declare instances of this component.
- Renames the parent class for component companions from `ComponentCompanion` to `ComponentSetup` (and renames all other respective classes in this hierarchy accordingly).
- Introduces the `MessageFormSetup` class for creating companion objects of custom `MessageForm` implementations (similar to `PaymentMethodEditor`), and reworks companion objects of `MessageForm` and `CommandMessageForm` to reuse respective code with it.
- Revises the documentation of `Component` and its related companion classes to elaborate on the notion and usage of companion objects of class-based components.
- Makes companion object definitions in existing class-based components to look more compact in the code by removing the documentation section for it (in favor of renaming the base class and elaborating the respective documentation).
- Some `protected` properties (`onBeforeBuild` and `builder`) within `MessageForm` have been changed to have an `internal` visibility instead. This was done for properties, which are only used from the respective companion objects, and need a minimum visibility scope that allows that. 

  Up to now they had a `protected` visibility scope for a companion implementation of the `CommandMessageForm` subclass to be able to initialize them. The respective properties initialization has now been reused by creating a base class for component objects (`MessageFormSetupBase`), which was itself extracted out of being declared inside of the form implementation classes. Hence visibility has been changed accordingly.