### PR TITLE
Fix dependency on `codegenPluginsPublish` task for modules that require code generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,35 @@ allprojects {
     }
 }
 
+spinePublishing {
+    modules = productionModules
+        .map { project -> project.name }.toSet()
+
+    destinations = setOf(
+        PublishingRepos.gitHub("Chords"),
+        PublishingRepos.cloudArtifactRegistry
+    )
+    artifactPrefix = ChordsPublishing.artifactPrefix
+}
+
+val codegenPluginsPublishToMavenLocal = tasks
+    .register<BuildCodegenPlugins>("buildCodegenPlugins") {
+        directory = "${rootDir}/codegen/plugins"
+        task("publishToMavenLocal")
+        dependsOn(
+            project(":runtime").tasks.named("publishToMavenLocal")
+        )
+    }
+
+val codegenPluginsPublish = tasks
+    .register<BuildCodegenPlugins>("publishCodegenPlugins") {
+        directory = "${rootDir}/codegen/plugins"
+        task("publish")
+        dependsOn(
+            project(":runtime").tasks.named("publishToMavenLocal")
+        )
+    }
+
 // The set of modules that require Chords code generation.
 val modulesWithChordsCodegen = setOf("proto-values", "codegen-tests")
 
@@ -91,15 +120,18 @@ subprojects {
         plugin("jvm-module")
     }
     apply<JavaPlugin>()
-    // Apply codegen Gradle plugin to modules that require code generation.
+
     if (modulesWithChordsCodegen.contains(name)) {
+        // Apply codegen Gradle plugin to modules that require code generation.
         applyGradleCodegenPlugin()
+        // Add dependencies on `codegen-plugins` publishing for `publish`
+        // and `publishToMavenLocal` tasks.
+        dependOnCodegenPluginsPublishing()
     }
 }
 
-/**
- * Applies and configures `io.spine.chords` Gradle plugin.
- */
+// Applies and configures `io.spine.chords` Gradle plugin.
+//
 fun Project.applyGradleCodegenPlugin() {
     apply {
         plugin(Spine.Chords.GradlePlugin.id)
@@ -115,41 +147,16 @@ fun Project.applyGradleCodegenPlugin() {
         Spine.Chords.CodegenPlugins.artifact(version.toString())
 }
 
-spinePublishing {
-    modules = productionModules
-        .map { project -> project.name }.toSet()
-
-    destinations = setOf(
-        PublishingRepos.gitHub("Chords"),
-        PublishingRepos.cloudArtifactRegistry
-    )
-    artifactPrefix = ChordsPublishing.artifactPrefix
+// Adds dependency on `codegen-plugins` publishing for `publish`
+// and `publishToMavenLocal` tasks.
+//
+fun Project.dependOnCodegenPluginsPublishing() {
+    // Some projects may be not configured for publishing, e.g. `codegen-tests`.
+    tasks.findByName("publishToMavenLocal")
+        ?.dependsOn(codegenPluginsPublishToMavenLocal)
+    tasks.findByName("publish")
+        ?.dependsOn(codegenPluginsPublish)
 }
 
 PomGenerator.applyTo(project)
 LicenseReporter.mergeAllReports(project)
-
-val codegenPluginsPublishToMavenLocal = tasks
-    .register<BuildCodegenPlugins>("buildCodegenPlugins") {
-        directory = "${rootDir}/codegen/plugins"
-        task("publishToMavenLocal")
-        dependsOn(
-            project(":runtime").tasks.named("publishToMavenLocal")
-        )
-    }
-
-tasks.named("publishToMavenLocal") {
-    dependsOn(codegenPluginsPublishToMavenLocal)
-}
-
-val codegenPluginsPublish = tasks.register<BuildCodegenPlugins>("publishCodegenPlugins") {
-    directory = "${rootDir}/codegen/plugins"
-    task("publish")
-    dependsOn(
-        project(":runtime").tasks.named("publishToMavenLocal")
-    )
-}
-
-tasks.named("publish") {
-    dependsOn(codegenPluginsPublish)
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,23 +94,21 @@ spinePublishing {
     artifactPrefix = ChordsPublishing.artifactPrefix
 }
 
-val codegenPluginsPublishToMavenLocal = tasks
-    .register<BuildCodegenPlugins>("buildCodegenPlugins") {
-        directory = "${rootDir}/codegen/plugins"
-        task("publishToMavenLocal")
-        dependsOn(
-            project(":runtime").tasks.named("publishToMavenLocal")
-        )
-    }
+tasks.register<BuildCodegenPlugins>("buildCodegenPlugins") {
+    directory = "${rootDir}/codegen/plugins"
+    task("publishToMavenLocal")
+    dependsOn(
+        project(":runtime").tasks.named("publishToMavenLocal")
+    )
+}
 
-val codegenPluginsPublish = tasks
-    .register<BuildCodegenPlugins>("publishCodegenPlugins") {
-        directory = "${rootDir}/codegen/plugins"
-        task("publish")
-        dependsOn(
-            project(":runtime").tasks.named("publishToMavenLocal")
-        )
-    }
+tasks.register<BuildCodegenPlugins>("publishCodegenPlugins") {
+    directory = "${rootDir}/codegen/plugins"
+    task("publish")
+    dependsOn(
+        project(":runtime").tasks.named("publishToMavenLocal")
+    )
+}
 
 // The set of modules that require Chords code generation.
 val modulesWithChordsCodegen = setOf("proto-values", "codegen-tests")
@@ -152,10 +150,12 @@ fun Project.applyGradleCodegenPlugin() {
 //
 fun Project.dependOnCodegenPluginsPublishing() {
     // Some projects may be not configured for publishing, e.g. `codegen-tests`.
-    tasks.findByName("publishToMavenLocal")
-        ?.dependsOn(codegenPluginsPublishToMavenLocal)
-    tasks.findByName("publish")
-        ?.dependsOn(codegenPluginsPublish)
+    tasks.findByName("publishToMavenLocal")?.dependsOn(
+        rootProject.tasks.named("buildCodegenPlugins")
+    )
+    tasks.findByName("publish")?.dependsOn(
+        rootProject.tasks.named("publishCodegenPlugins")
+    )
 }
 
 PomGenerator.applyTo(project)

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.45`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -111,7 +111,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -230,7 +230,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -750,7 +750,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -992,7 +992,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 08 00:07:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 09 20:06:19 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.45`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Fri Nov 08 00:07:02 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 08 00:07:05 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 09 20:06:20 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.45`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1992,7 +1992,7 @@ This report was generated on **Fri Nov 08 00:07:05 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2107,7 +2107,7 @@ This report was generated on **Fri Nov 08 00:07:05 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2596,7 +2596,7 @@ This report was generated on **Fri Nov 08 00:07:05 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2838,7 +2838,7 @@ This report was generated on **Fri Nov 08 00:07:05 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2912,12 +2912,12 @@ This report was generated on **Fri Nov 08 00:07:05 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 08 00:07:06 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 09 20:06:21 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.45`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2996,7 +2996,7 @@ This report was generated on **Fri Nov 08 00:07:06 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3111,7 +3111,7 @@ This report was generated on **Fri Nov 08 00:07:06 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3600,7 +3600,7 @@ This report was generated on **Fri Nov 08 00:07:06 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3842,7 +3842,7 @@ This report was generated on **Fri Nov 08 00:07:06 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3916,12 +3916,12 @@ This report was generated on **Fri Nov 08 00:07:06 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 08 00:07:08 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 09 20:06:22 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.45`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Fri Nov 08 00:07:08 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 08 00:07:10 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 09 20:06:23 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.45`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Fri Nov 08 00:07:10 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 08 00:07:11 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 09 20:06:24 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.44</version>
+<version>2.0.0-SNAPSHOT.45</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -73,7 +73,7 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.compose.desktop</groupId>
-    <artifactId>desktop-jvm-windows-x64</artifactId>
+    <artifactId>desktop-jvm-macos-x64</artifactId>
     <version>1.5.12</version>
     <scope>compile</scope>
   </dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.44")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.45")


### PR DESCRIPTION
### Problem
Publishing sometimes fails for modules that rely on code generation because `codegen-plugins` project has not yet been published.

### Cause
A dependency on the `codegenPluginsPublish` task was set at the root project level; however, it did not ensure that this task would be executed before publishing certain subprojects.

Root `build.gradle.kts`:
```
tasks.named("publish") {
    dependsOn(codegenPluginsPublish)
}
```

### Solution
A direct dependency on the `codegenPluginsPublish` task was added for projects that require code generation.

