### PR TITLE
Support nested dialogs, use them for confirmations

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -146,13 +146,11 @@
     <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparatorNotSerializable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="false" />
     </inspection_tool>
     <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantConditions" enabled="true" level="TYPO" enabled_by_default="true">
@@ -194,7 +192,6 @@
       <option name="ignoreLocalVariables" value="false" />
       <option name="ignorePrivateMethodsAndFields" value="false" />
     </inspection_tool>
-    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DisjointPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -578,7 +575,6 @@
     </inspection_tool>
     <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonStaticFinalLogger" enabled="true" level="WARNING" enabled_by_default="true">
@@ -623,6 +619,9 @@
     </inspection_tool>
     <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OnDemandImport" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="OptionalOfNullableMisuse" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true" />
+    </inspection_tool>
     <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInconvertibleTypes" value="true" />
     </inspection_tool>
@@ -690,7 +689,6 @@
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
-    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -711,7 +709,6 @@
     <inspection_tool class="SamePackageImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SameParameterValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
@@ -750,13 +747,10 @@
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="onlyWarnOnLoop" value="true" />
     </inspection_tool>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -790,7 +784,6 @@
     <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
-    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="3" />
     </inspection_tool>
@@ -811,7 +804,6 @@
     <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TrivialIf" enabled="true" level="TYPO" enabled_by_default="true" />
-    <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Problems" level="INFO" enabled="true">

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -132,10 +132,10 @@ import androidx.compose.runtime.MutableState
  *     }
  * ```
  *
- * NOTE: It is strongly recommended to use the property configuration lambda
- * in component declarations only for performing component property assignments,
- * which is conceptually similar to how you would pass respective parameters to
- * a function-based component.
+ * NOTE: It is highly discouraged to put any other statements besides component
+ *       property assignments inside such component instance declarations.
+ *       This preserves conceptual clarity, and is similar to how you would pass
+ *       respective parameters to a function-based component.
  *
  * See also below how to implement such components.
  *

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -600,7 +600,7 @@ public abstract class Component {
      *
      * @param propertyInitialized The [isInitialized] property access expression
      *   for the `lateinit` property being checked
-     *   (e.g. `::property.isInitialized`).
+     *   (e.g. `::property1.isInitialized`).
      * @param propertyName The name of the property being checked
      *   (e.g. "property1").
      * @throws IllegalArgumentException If the property referred to by the

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -271,7 +271,7 @@ import androidx.compose.runtime.MutableState
  * invoking `super.content()`!
  *
  * The example above just outlines the main aspects of creating an extended
- * component, the [content] method would in most cases in practice not be
+ * component, and the [content] method would in most cases in practice not be
  * overridden at all.
  *
  * Overriding [content] without calling `super.content()`

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -39,7 +39,7 @@ import androidx.compose.runtime.remember
  * provides an alternative way for implementing components with utilizing
  * the features of the object-oriented paradigm.
  *
- * ### Using class-based components
+ * ## Using class-based components
  *
  * The syntax for using such components is similar to that of using the regular
  * function-based components. Considering a function-based component declaration
@@ -82,7 +82,7 @@ import androidx.compose.runtime.remember
  *     val someComponent = SomeComponent { ... }
  * ```
  *
- * #### Component instance declarations vs constructors
+ * ### Component instance declarations vs constructors
  *
  * It should be noted that such _component instance declarations_ as shown above
  * are a main way of using class-based components, but they are technically not
@@ -95,7 +95,7 @@ import androidx.compose.runtime.remember
  * prevent creating a new component's instance upon each composition, and use
  * a cached instance instead.
  *
- * #### Preferred instance declarations style
+ * ### Preferred instance declarations style
  *
  * Note that the component instance declaration examples above are technically
  * a shorthand notation for using the `invoke` function on the component's
@@ -131,9 +131,14 @@ import androidx.compose.runtime.remember
  *     }
  * ```
  *
+ * NOTE: It is strongly recommended to use the property configuration lambda
+ * in component declarations only for performing component property assignments,
+ * which is conceptually similar to how you would pass respective parameters to
+ * a function-based component.
+ *
  * See also below how to implement such components.
  *
- * ### Implementing class-based components
+ * ## Implementing class-based components
  *
  * - Create a subclass of [Component].
  *
@@ -188,7 +193,7 @@ import androidx.compose.runtime.remember
  * classes* though, since companion objects here serve the purpose that is
  * similar to a class's constructor.
  *
- * ### When to write class-based and function-based components?
+ * ## When to write class-based and function-based components?
  *
  * A class-based components writing style is only a convenience that can be used
  * if it provides some benefits relative to function-based ones. Function-based
@@ -198,7 +203,7 @@ import androidx.compose.runtime.remember
  * Both paradigms are mutually compatible: functional components can be used in
  * class-based ones, and class-based ones can be used in functional ones.
  *
- * ### Benefits of writing class-based components
+ * ## Benefits of writing class-based components
  *
  * A class-based component implementation provides the following benefits
  * in particular:
@@ -252,7 +257,7 @@ import androidx.compose.runtime.remember
  *   data (stored in its properties) to be implicitly available in each of such
  *   functions without explicitly passing them around with parameters.
  *
- * ### Converting function-based components into class-based ones
+ * ## Converting function-based components into class-based ones
  *
  * The points below can be used as a rule of thumb when converting existing
  * function-based components to class-based ones. This can also be helpful for
@@ -302,7 +307,7 @@ import androidx.compose.runtime.remember
  *   into class methods would make respective class's properties to be available
  *   to such methods implicitly.
  *
- * ### Optimizing performance
+ * ## Optimizing performance
  *
  * These recommendations are optional, but can be considered in cases when UI's
  * performance becomes an issue for some components or when you're creating

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -244,6 +244,8 @@ import androidx.compose.runtime.MutableState
  *
  *         @Composable
  *         override fun content() {
+ *             // CAUTION: In practice, `content` should not be overridden
+ *             //          in most cases. See the documentation below.
  *             Text(
  *                 text = "Hello, $name",
  *                 style = style,
@@ -284,7 +286,7 @@ import androidx.compose.runtime.MutableState
  * the parent `content` method, be sure to follow the spirit of OOP, and rework
  * the parent class to extract the parts that need to be overridden into
  * corresponding separate `protected open` methods (or use whatever other proper
- * means that are needed).
+ * means that are needed to properly customize the parent component's display).
  *
  * See also some of the other base component classes that extend the [Component]
  * class, such as [FocusableComponent], [InputComponent], [InputField],

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -159,6 +159,20 @@ import androidx.compose.runtime.remember
  *
  * - Declare a mutable property for each "parameter" of your component.
  *
+ *   NOTE: in order for dynamic changes of property values to be reflected by
+ *   the component's composition automatically, make sure that such properties
+ *   are backed by a [MutableState] value. In practice this means declaring
+ *   each component's configurable public property (except lambda-typed ones) in
+ *   the following style:
+ *   ```
+ *       public var someProp by mutableStateOf<String>("")
+ *   ```
+ *
+ *   Note the `String` type parameter of `mutableStateOf` above, which
+ *   practically means the type of the property. As a result, from the user's
+ *   perspective this would just be a `someProp` property that can be configured
+ *   with any `String` value.
+ *
  * Here's an example of creating an input component that allows entering
  * a string value:
  *
@@ -168,7 +182,7 @@ import androidx.compose.runtime.remember
  *             HelloComponent()
  *         })
  *
- *         public var name: String = ""
+ *         public var name by mutableStateOf: String = ""
  *
  *         @Composable
  *         override fun content() {

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -94,10 +94,9 @@ public class AppWindow(
      * This means that at any given moment in time there is essentially a stack
      * of dialogs (zero or more nested dialogs). This property refers to the
      * very first dialog that was displayed among all these dialogs (the bottom
-     * of the stack).
-     *
+     * of the dialogs stack).
      */
-    private var bottomDialog: Dialog? = null
+    private var bottomDialog: MutableState<Dialog?> = mutableStateOf(null)
 
     /**
      * Renders the application window's content.
@@ -119,7 +118,7 @@ public class AppWindow(
             ) {
                 currentScreen.value()
             }
-            bottomDialog?.Content()
+            bottomDialog?.value!!.Content()
         }
     }
 
@@ -143,7 +142,7 @@ public class AppWindow(
         check(currentScreen.value == mainScreen) {
             "Another modal screen is visible already."
         }
-        check(bottomDialog == null) {
+        check(bottomDialog.value == null) {
             "Cannot display the modal screen when a dialog is displayed."
         }
         currentScreen.value = screen
@@ -168,13 +167,13 @@ public class AppWindow(
      * @param dialog An instance of the dialog that should be displayed.
      */
     internal fun openDialog(dialog: Dialog) {
-        check(bottomDialog != dialog) { "This dialog is already open." }
+        check(bottomDialog.value != dialog) { "This dialog is already open." }
 
-        dialog.isBottomDialog = bottomDialog == null
+        dialog.isBottomDialog = bottomDialog.value == null
         if (dialog.isBottomDialog) {
-            bottomDialog = dialog
+            bottomDialog.value = dialog
         } else {
-            bottomDialog!!.openNestedDialog(dialog)
+            bottomDialog.value!!.openNestedDialog(dialog)
         }
     }
 
@@ -182,15 +181,15 @@ public class AppWindow(
      * Closes the currently displayed dialog window.
      */
     internal fun closeDialog(dialog: Dialog) {
-        checkNotNull(bottomDialog) {
+        checkNotNull(bottomDialog.value) {
             "No such dialog is displayed currently."
         }
-        if (dialog == bottomDialog) {
-            check(bottomDialog!!.nestedDialog == null) {
+        if (dialog == bottomDialog.value) {
+            check(bottomDialog.value!!.nestedDialog == null) {
                 "Cannot close a dialog while it has nested dialog(s) displayed."
             }
-            bottomDialog = null
+            bottomDialog.value = null
         }
-        bottomDialog!!.hideNestedDialog(dialog)
+        bottomDialog.value!!.hideNestedDialog(dialog)
     }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Window
 import io.spine.chords.core.layout.Dialog
 import java.awt.Dimension
-import java.util.*
 
 /**
  * Represents the main application window and provides API to display
@@ -47,7 +46,7 @@ import java.util.*
  *
  * @param signInScreenContent A content for the sign-in screen.
  * @param views The list of application's views.
- * @param initialView Allows to specify a view from the list of [views], if any
+ * @param initialView Allows to specify a view from the list of `views`, if any
  *   view other than the first one has to be displayed when
  *   the application starts.
  * @param onCloseRequest An action that should be performed on window closing.
@@ -179,7 +178,11 @@ public class AppWindow(
     }
 
     /**
-     * Closes the currently displayed dialog window.
+     * Closes the specified dialog.
+     *
+     * This is a part of an internal dialog management API.
+     *
+     * @param dialog The dialog that needs to be closed.
      */
     internal fun closeDialog(dialog: Dialog) {
         checkNotNull(bottomDialog) { "No dialogs are displayed currently." }

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -86,10 +86,11 @@ public class AppWindow(
      *
      * Dialogs are modal windows, which means that there can be at most once
      * dialog that the user can interact with at a time. It's possible to
-     * display nested dialogs. That is, a dialog can trigger displaying another
-     * dialog, which means that the first dialog still remains opened, but
-     * cannot be interacted with until the second one (which is displayed on top
-     * of it) is closed.
+     * display nested dialogs though. That is, when some dialog is already
+     * displayed, another dialog can be open (see
+     * [DialogSetup][io.spine.chords.core.layout.DialogSetup.open]), which means
+     * that the first dialog still remains opened, but cannot be interacted with
+     * until the second one (which is displayed on top of it) is closed.
      *
      * This means that at any given moment in time there is essentially a stack
      * of dialogs (zero or more nested dialogs). This property refers to the

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -240,22 +240,26 @@ public class ApplicationUI(private val appWindow: AppWindow) {
      *
      * @see Dialog
      * @see DialogSetup
-     * @see closeCurrentDialog
+     * @see closeDialog
      */
     internal fun openDialog(dialog: Dialog) {
         appWindow.openDialog(dialog)
     }
 
     /**
-     * Closes the currently displayed dialog window while ignoring any data
-     * that might have been entered in it.
+     * Closes the specified dialog if it doesn't have any nested
+     * dialogs displayed.
+     *
+     * Note that this method ignores any data that might have been entered
+     * in it.
      *
      * On a par with [openDialog], this is a part of an internal API for
      * [Dialog]s to be able to control their display lifecycle.
      *
+     * @para dialog The dialog that needs to be closed.
      * @see openDialog
      */
-    internal fun closeCurrentDialog() {
-        appWindow.closeCurrentDialog()
+    internal fun closeDialog(dialog: Dialog) {
+        appWindow.closeDialog(dialog)
     }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -256,7 +256,7 @@ public class ApplicationUI(private val appWindow: AppWindow) {
      * On a par with [openDialog], this is a part of an internal API for
      * [Dialog]s to be able to control their display lifecycle.
      *
-     * @para dialog The dialog that needs to be closed.
+     * @param dialog The dialog that needs to be closed.
      * @see openDialog
      */
     internal fun closeDialog(dialog: Dialog) {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -14,16 +14,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.AbstractComponentSetup
+import io.spine.chords.core.ComponentProps
 
 /**
  * A confirmation dialog that prompts the user to confirm or deny
  * the cancellation of some window, typically used for modal ones.
  */
-public class ConfirmCancellationDialog : Dialog() {
-    public companion object : ComponentSetup<ConfirmCancellationDialog>(
-        { ConfirmCancellationDialog() }
-    )
+public class ConfirmationDialog : Dialog() {
+    public companion object : AbstractComponentSetup({ ConfirmationDialog() }) {
+        public suspend fun askAndAwait(props: ComponentProps<ConfirmationDialog>? = null) {
+            val dialog = create(config = props)
+            dialog.onConfirm = {}
+            dialog.onCancel = {}
+            dialog.open()
+        }
+    }
 
     /**
      * Initializes the `confirmButtonText` and the size of the dialog.
@@ -39,6 +45,9 @@ public class ConfirmCancellationDialog : Dialog() {
      * The title of the dialog.
      */
     public override val title: String = confirmButtonText
+
+    public var onConfirm: (() -> Unit)? = null
+    public var onCancel: (() -> Unit)? = null
 
     /**
      * Creates the content of the dialog.

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -40,8 +40,8 @@ public class ConfirmationDialog : Dialog() {
      * Initializes the `confirmButtonText` and the size of the dialog.
      */
     init {
-        confirmButtonText = "Confirm"
-        cancelButtonText = "Reject"
+        confirmButtonText = "Yes"
+        cancelButtonText = "No"
         dialogWidth = 420.dp
         dialogHeight = 230.dp
     }
@@ -49,7 +49,7 @@ public class ConfirmationDialog : Dialog() {
     /**
      * The title of the dialog.
      */
-    public override val title: String = "Confirm"
+    public override var title: String = "Confirm"
 
     public var message: String = "Are you sure?"
     public var description: String = ""

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -40,7 +40,7 @@ public class ConfirmationDialog : Dialog() {
      * Initializes the `confirmButtonText` and the size of the dialog.
      */
     init {
-        confirmButtonText = "Yes"
+        submitButtonText = "Yes"
         cancelButtonText = "No"
         dialogWidth = 420.dp
         dialogHeight = 230.dp
@@ -51,7 +51,16 @@ public class ConfirmationDialog : Dialog() {
      */
     public override var title: String = "Confirm"
 
+    /**
+     * The main message of the confirmation dialog, which is usually expected
+     * to contain the question presented to the user.
+     */
     public var message: String = "Are you sure?"
+
+    /**
+     * An optional auxiliary text displayed below the message, which can provide
+     * an extra context about the question being asked.
+     */
     public var description: String = ""
 
     internal var onConfirm: (() -> Unit)? = null
@@ -63,6 +72,7 @@ public class ConfirmationDialog : Dialog() {
     @Composable
     protected override fun formContent() {
         val textStyle = typography.bodyLarge
+
         Column {
             Row(
                 modifier = Modifier.padding(bottom = 6.dp)

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -20,15 +20,15 @@ import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.future.await
 
 /**
- * A confirmation dialog that prompts the user to confirm or deny
- * the cancellation of some window, typically used for modal ones.
+ * A dialog that prompts the user either to make a boolean decision
+ * (e.g. approve or deny some action).
  */
 public class ConfirmationDialog : Dialog() {
     public companion object : AbstractComponentSetup({ ConfirmationDialog() }) {
 
         /**
-         * Displays the confirmation dialog, and waits until the user makes
-         * a decision.
+         * Displays the confirmation dialog, and waits until the user
+         * makes a decision.
          *
          * @return `true`, if the user makes a positive decision (presses the
          *   Submit button), and `false`, if the user makes a negative decision
@@ -36,7 +36,7 @@ public class ConfirmationDialog : Dialog() {
          */
         public suspend fun ask(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
             val dialog = create(config = props)
-            return dialog.askAndWait()
+            return dialog.ask()
         }
     }
 
@@ -100,10 +100,10 @@ public class ConfirmationDialog : Dialog() {
     }
 
     /**
-     * Displays the confirmation dialog, and waits until the user either
+     * Displays the confirmation dialog, and waits until the user
      * makes a decision.
      */
-    public suspend fun askAndWait(): Boolean {
+    public suspend fun ask(): Boolean {
         var confirmed = false
         val dialogClosure = CompletableFuture<Unit>()
         onBeforeSubmit = {
@@ -116,7 +116,6 @@ public class ConfirmationDialog : Dialog() {
 
         open()
         dialogClosure.await()
-
         return confirmed
     }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -27,8 +27,12 @@ public class ConfirmationDialog : Dialog() {
     public companion object : AbstractComponentSetup({ ConfirmationDialog() }) {
 
         /**
-         * Displays the confirmation dialog, and waits until the user either
-         * accepts or rejects the confirmation.
+         * Displays the confirmation dialog, and waits until the user makes
+         * a choice.
+         *
+         * @return `true`, if the user makes a positive choice (presses the
+         *   Submit button), and `false`, if the user makes a negative choice
+         *   (presses the Cancel button).
          */
         public suspend fun askAndAwait(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
             val dialog = create(config = props)
@@ -63,9 +67,6 @@ public class ConfirmationDialog : Dialog() {
      */
     public var description: String = ""
 
-    internal var onConfirm: (() -> Unit)? = null
-    internal var onCancel: (() -> Unit)? = null
-
     /**
      * Creates the content of the dialog.
      */
@@ -91,16 +92,6 @@ public class ConfirmationDialog : Dialog() {
         }
     }
 
-    override suspend fun handleCancelClick() {
-        onCancel?.invoke()
-        super.handleCancelClick()
-    }
-
-    override suspend fun  handleSubmitClick() {
-        onConfirm?.invoke()
-        super.handleSubmitClick()
-    }
-
     /**
      * Just returns `true` on form submission since there is no data to submit.
      */
@@ -110,16 +101,16 @@ public class ConfirmationDialog : Dialog() {
 
     /**
      * Displays the confirmation dialog, and waits until the user either
-     * accepts or rejects the confirmation.
+     * makes a choice.
      */
     public suspend fun askAndWait(): Boolean {
         var confirmed = false
         val dialogClosure = CompletableFuture<Unit>()
-        onConfirm = {
+        onBeforeSubmit = {
             confirmed = true
             dialogClosure.complete(Unit)
         }
-        onCancel = {
+        onBeforeCancel = {
             dialogClosure.complete(Unit)
         }
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -28,13 +28,13 @@ public class ConfirmationDialog : Dialog() {
 
         /**
          * Displays the confirmation dialog, and waits until the user makes
-         * a choice.
+         * a decision.
          *
-         * @return `true`, if the user makes a positive choice (presses the
-         *   Submit button), and `false`, if the user makes a negative choice
+         * @return `true`, if the user makes a positive decision (presses the
+         *   Submit button), and `false`, if the user makes a negative decision
          *   (presses the Cancel button).
          */
-        public suspend fun askAndAwait(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
+        public suspend fun ask(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
             val dialog = create(config = props)
             return dialog.askAndWait()
         }
@@ -101,7 +101,7 @@ public class ConfirmationDialog : Dialog() {
 
     /**
      * Displays the confirmation dialog, and waits until the user either
-     * makes a choice.
+     * makes a decision.
      */
     public suspend fun askAndWait(): Boolean {
         var confirmed = false

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -86,9 +86,9 @@ public class ConfirmationDialog : Dialog() {
         super.handleCancelClick()
     }
 
-    override suspend fun  handleConfirmClick() {
+    override suspend fun  handleSubmitClick() {
         onConfirm?.invoke()
-        super.handleConfirmClick()
+        super.handleSubmitClick()
     }
 
     /**

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -169,10 +169,25 @@ public abstract class Dialog : Component() {
     public var dialogHeight: Dp = 450.dp
 
     /**
-     * The [DialogConfig] property that allows adjustments
-     * to visual appearance settings.
+     * Specifies appearance-related parameters.
      */
-    public var config: DialogConfig = DialogConfig()
+    public var look: Look = Look()
+
+    /**
+     * An object allowing adjustments of visual appearance parameters.
+     *
+     * @param padding The padding applied to the entire content of the dialog.
+     * @param titlePadding The padding applied to the title of the dialog.
+     * @param buttonsPanelPadding The padding applied to the buttons panel of
+     *   the dialog.
+     * @param buttonsSpacing The space between the buttons of the dialog.
+     */
+    public data class Look(
+        public var padding: PaddingValues = PaddingValues(24.dp),
+        public var titlePadding: PaddingValues = PaddingValues(bottom = 16.dp),
+        public var buttonsPanelPadding: PaddingValues = PaddingValues(top = 24.dp),
+        public var buttonsSpacing: Dp = 12.dp
+    )
 
     /**
      * This property is automatically set to `true` by the application, if
@@ -368,10 +383,10 @@ internal fun closeNestedDialog(dialog: Dialog) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(config.padding),
+                    .padding(look.padding),
             ) {
                 val coroutineScope = rememberCoroutineScope()
-                DialogTitle(title, config.titlePadding)
+                DialogTitle(title, look.titlePadding)
                 Column(
                     Modifier.weight(1F)
                         .on(Ctrl(Enter.key).up) {
@@ -383,8 +398,8 @@ internal fun closeNestedDialog(dialog: Dialog) {
                 DialogButtons(
                     submitButtonText, { coroutineScope.launch { handleSubmitClick() } },
                     cancelButtonText, { coroutineScope.launch { handleCancelClick() } },
-                    config.buttonsPanelPadding,
-                    config.buttonsSpacing
+                    look.buttonsPanelPadding,
+                    look.buttonsSpacing
                 )
             }
         }
@@ -513,22 +528,6 @@ public open class DialogSetup<D: Dialog>(
         return dialog
     }
 }
-
-/**
- * Configuration of the dialog, allowing adjustments
- * to visual appearance settings.
- *
- * @param padding The padding applied to the entire content of the dialog.
- * @param titlePadding The padding applied to the title of the dialog.
- * @param buttonsPanelPadding The padding applied to the buttons panel of the dialog.
- * @param buttonsSpacing The space between the buttons of the dialog.
- */
-public data class DialogConfig(
-    public var padding: PaddingValues = PaddingValues(24.dp),
-    public var titlePadding: PaddingValues = PaddingValues(bottom = 16.dp),
-    public var buttonsPanelPadding: PaddingValues = PaddingValues(top = 24.dp),
-    public var buttonsSpacing: Dp = 12.dp
-)
 
 
 /**

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -152,26 +152,6 @@ public abstract class Dialog : Component() {
     public var cancelButtonText: String = "Cancel"
 
     /**
-     * A callback that should be handled to close the dialog (exclude it from
-     * the composition).
-     *
-     * This callback is triggered when the user closes the dialog or after
-     * successful submission.
-     *
-     * // TODO:2024-11-12:dmitry.pikhulya: Remove this property after
-     *      introducing native dialogs instead of popup-based ones.
-     */
-//    internal var onCloseRequest: (() -> Unit)? = { close() }
-
-//    /**
-//     * A callback used to confirm that the user wants to cancel the dialog.
-//     *
-//     * This callback is triggered when the user closes the dialog
-//     * by pressing the cancel button.
-//     */
-//    private var onCancelConfirmation: (() -> Unit)? = null
-
-    /**
      * The width of the dialog.
      *
      * The default value is `700.dp`.
@@ -234,12 +214,6 @@ public abstract class Dialog : Component() {
      * of the dialog.
      */
     public var onBeforeSubmit: suspend () -> Boolean = { true }
-
-//    private val cancelConfirmationDialog: CancelConfirmationDialog? = { onConfirm, onCancel ->
-//        onCloseRequest = onConfirm
-//        onCancelConfirmation = onCancel
-//        ConfirmCancellationDialog().Content()
-//    }
 
     /**
      * Displays the modal dialog.
@@ -321,17 +295,6 @@ public abstract class Dialog : Component() {
         }
     }
 
-
-//    private val cancelConfirmationShown = remember { mutableStateOf(false) }
-//
-//    private fun showCancelConfirmation() {
-//        cancelConfirmationShown.value = true
-//    }
-//
-//    private fun hideCancelConfirmation() {
-//        cancelConfirmationShown.value = false
-//    }
-
     /**
      * Renders the dialog's frame, which makes up main elements that are common
      * for all dialogs, including dialog's title and buttons, while delegating
@@ -397,25 +360,12 @@ private fun lightweightPlatform(
             onDismissRequest = close,
             properties = PopupProperties(focusable = true),
             onPreviewKeyEvent = { false },
-            onKeyEvent = escapePressHandler {
-                //                if (cancelConfirmationDialog != null) {
-                //                    showCancelConfirmation()
-                //                } else {
-                close()
-                //                }
-            }
+            onKeyEvent = escapePressHandler { close() }
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Black.copy(alpha = 0.5f))
-                //                    .pointerInput(::close) {
-                //                        detectTapGestures(onPress = {
-                //                            if (cancelConfirmationDialog == null) {
-                //                                close()
-                //                            }
-                //                        })
-                //                    }
                 ,
                 contentAlignment = Center
             ) {
@@ -424,9 +374,6 @@ private fun lightweightPlatform(
                         detectTapGestures(onPress = {})
                     }
                 ) {
-                    //                    onCancelConfirmation = {
-                    //                        showCancelConfirmation()
-                    //                    }
                     dialogContent()
                 }
             }
@@ -451,23 +398,6 @@ private fun lightweightPlatform(
     }
 
     nestedDialog ?.Content()
-
-//            if (nestedDialog != null) {
-//
-//                CancelConfirmationDialogContainer(
-//                    onCancel = { hideCancelConfirmation() },
-//                    onConfirm = { close() },
-//                    content = cancelConfirmationDialog
-//                )
-//            }
-
-//            if (cancelConfirmationShown.value && cancelConfirmationDialog != null) {
-//                CancelConfirmationDialogContainer(
-//                    onCancel = { hideCancelConfirmation() },
-//                    onConfirm = { close() },
-//                    content = cancelConfirmationDialog
-//                )
-//            }
 }
 
 /**
@@ -522,19 +452,6 @@ public open class DialogSetup<D: Dialog>(
         return dialog
     }
 }
-
-
-///**
-// * A type of the cancel confirmation dialog.
-// *
-// * The cancel confirmation dialog prompts the user to confirm whether they want
-// * to close the modal. It receives two parameters:
-// * - `onConfirm`: A callback triggered when the user confirms the cancellation.
-// * - `onCancel`: A callback triggered when the user cancels the cancellation
-// *   (i.e., decides not to close the modal).
-// */
-//private typealias CancelConfirmationDialog =
-//        @Composable BoxScope.(onConfirm: () -> Unit, onCancel: () -> Unit) -> Unit
 
 /**
  * Configuration of the dialog, allowing adjustments
@@ -652,61 +569,3 @@ private val centerWindowPositionProvider = object : PopupPositionProvider {
         popupContentSize: IntSize
     ): IntOffset = IntOffset.Zero
 }
-
-///**
-// * The container for the cancel confirmation dialog of the [Dialog] component.
-// *
-// * This dialog confirms or denies the intention of the user to close the main modal window.
-// *
-// * @param onCancel The callback triggered on the dialog cancellation.
-// * @param onConfirm The callback triggered on the confirmation to cancel the main modal window.
-// * @param content The content to display as a dialog.
-// */
-//@Composable
-//private fun CancelConfirmationDialogContainer(
-//    onCancel: () -> Unit,
-//    onConfirm: () -> Unit,
-//    content: CancelConfirmationDialog
-//) {
-//    Popup(
-//        popupPositionProvider = centerWindowPositionProvider,
-//        properties = PopupProperties(focusable = true),
-//        onPreviewKeyEvent = { false }
-//    ) {
-//        Box(
-//            modifier = Modifier
-//                .fillMaxSize()
-//                .background(Black.copy(alpha = 0.5f)),
-//            contentAlignment = Center
-//        ) {
-//            Box {
-//                content(onConfirm, onCancel)
-//            }
-//        }
-//    }
-//}
-
-//
-//@Composable
-//private fun NestedDialogContainer(
-//    onCancel: () -> Unit,
-//    onConfirm: () -> Unit,
-//    dialog: Dialog
-//) {
-//    Popup(
-//        popupPositionProvider = centerWindowPositionProvider,
-//        properties = PopupProperties(focusable = true),
-//        onPreviewKeyEvent = { false }
-//    ) {
-//        Box(
-//            modifier = Modifier
-//                .fillMaxSize()
-//                .background(Black.copy(alpha = 0.5f)),
-//            contentAlignment = Center
-//        ) {
-//            Box {
-////                content(onConfirm, onCancel)
-//            }
-//        }
-//    }
-//}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -42,7 +42,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Modifier
@@ -190,7 +193,7 @@ public abstract class Dialog : Component() {
 
     internal var isBottomDialog: Boolean = true
 
-    internal var nestedDialog: Dialog? = null
+    internal var nestedDialog by mutableStateOf<Dialog?>(null)
 
 //    private val cancelConfirmationDialog: CancelConfirmationDialog? = { onConfirm, onCancel ->
 //        onCloseRequest = onConfirm
@@ -258,9 +261,7 @@ public abstract class Dialog : Component() {
     }
 
     internal fun openNestedDialog(dialog: Dialog) {
-        check(nestedDialog != dialog) {
-            "This dialog is already open."
-        }
+        check(nestedDialog != dialog) { "This dialog is already open." }
         if (nestedDialog == null) {
             nestedDialog = dialog
         } else {
@@ -268,17 +269,16 @@ public abstract class Dialog : Component() {
         }
     }
 
-    internal fun hideNestedDialog(dialog: Dialog) {
-        checkNotNull(nestedDialog) {
-            "No such dialog is displayed currently."
-        }
+    internal fun closeNestedDialog(dialog: Dialog) {
+        checkNotNull(nestedDialog) { "This dialog is not displayed currently." }
         if (dialog == nestedDialog) {
-            check(nestedDialog!!.nestedDialog == null) {
-                "Cannot close a dialog while it has nested dialog(s) displayed."
+            check(dialog.nestedDialog == null) {
+                "Cannot close a dialog while it has a nested dialog open."
             }
             nestedDialog = null
+        } else {
+            nestedDialog!!.closeNestedDialog(dialog)
         }
-        nestedDialog!!.hideNestedDialog(dialog)
     }
 
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -341,8 +341,8 @@ public abstract class Dialog : Component() {
         if (ConfirmationDialog.askAndAwait {
                 message = "Are you sure you want to close the dialog?"
                 description = "Any entered data will be lost in this case."
-                confirmButtonText = "Discard Changes"
-                cancelButtonText = "Continue Editing"
+                confirmButtonText = "Discard changes"
+                cancelButtonText = "Continue editing"
             }
         ) {
             close()

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -192,8 +192,10 @@ public abstract class Dialog : Component() {
     /**
      * This property is automatically set to `true` by the application, if
      * this dialog is a bottom-most one (the first dialog that was invoked in
-     * the sequence of nested dialogs display). If it's a nested dialog of
-     * another dialog, this property is set to `false`.
+     * the sequence of nested dialogs display).
+     *
+     * If it's a nested dialog of another dialog, this property is set
+     * to `false`.
      */
     internal var isBottomDialog: Boolean = true
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.48`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.49`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 13 00:56:38 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 02:40:52 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.48`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.49`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Wed Nov 13 00:56:38 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 13 00:56:41 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 02:40:54 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.48`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.49`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Wed Nov 13 00:56:41 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 13 00:56:44 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 02:40:56 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.48`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.49`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Wed Nov 13 00:56:44 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 13 00:56:48 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 02:40:58 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.48`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.49`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Wed Nov 13 00:56:48 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 13 00:56:51 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 02:41:00 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.48`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.49`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Wed Nov 13 00:56:51 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 13 00:56:53 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 22 02:41:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.48</version>
+<version>2.0.0-SNAPSHOT.49</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1206,10 +1206,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
 
     override fun initialize() {
         super.initialize()
-        // TODO:2024-03-15:dmitry.pikhulya: document specifying required properties
-        require(this::builder.isInitialized) {
-            "MessageForm's `builder` property must be specified."
-        }
+        requireProperty(::builder.isInitialized, "builder")
 
         lastEmittedMessageValue = value.value
         _dirty = identifyInitialDirtyState(value.value)

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -59,19 +59,14 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
 
     /**
      * An object, which defines the component's appearance parameters.
+     *
+     * @param interFieldPadding A horizontal distance between the payment card
+     *   and bank account fields.
+     * @paRAM selectorsOffset A vertical distance between radio button selectors
+     *   and their respective fields.
      */
     public data class Look(
-
-        /**
-         * A horizontal distance between the payment card and bank
-         * account fields.
-         */
         public var interFieldPadding: Dp = 40.dp,
-
-        /**
-         * A vertical distance between radio button selectors and their
-         * respective fields.
-         */
         public var selectorsOffset: Dp = 8.dp
     )
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.48")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.49")


### PR DESCRIPTION
`ConfirmCancellationDialog` extends `Dialog`, but so far it still used its special mechanism of its displaying because displaying nested `Dialog` components were technically not supported yet.

This PR does the following:
- Makes it possible to display arbitrary nested dialogs while retaining the simplicity of dialog implementations (no special per-dialog code is needed for this).

  This does not change the API of using the dialogs. It's just now possible to open dialogs recursively.

- Update `ConfirmCancellationDialog` to be a regular dialog, and still be displayed as a nested one like it is now. It has a custom companion object to introduce a convenient confirmation-specific usage API.
- The specialized `ConfirmCancellationDialog` was replaced with a generic `ConfirmationDialog`, which can be used for displaying confirmations throughout the application's code now.
- Reintroduces the capability to customize cancel confirmations in the `Dialog`'s API, and also adds an ability to display a submission confirmation as well for consistency.
- Extends `Component`'s documentation with additional general component authoring related information.