### PR TITLE
Application-wide components customization

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -664,7 +664,8 @@ public abstract class Component {
      */
     protected open fun updateProps() {
         if (componentInitializer == null) {
-            componentInitializer = app.componentDefaults.componentInitializer(javaClass) ?: {}
+            componentInitializer =
+                app.componentDefaults.componentDefaultsInitializer(javaClass) ?: {}
         }
         componentInitializer!!.invoke(this)
         props?.run { configure() }

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -657,10 +657,12 @@ public abstract class Component {
      * properties match any property declarations that are specified for
      * the dialog.
      *
-     * This includes both assigning the application-wide properties, and
-     * instance-specific properties. If there are conflicts in declarations,
-     * instance-specific property declarations override application-wide
-     * property declarations.
+     * This includes both assigning the default property values applicable
+     * to this component from application-wide component customizations (see
+     * [Application.componentDefaults][io.spine.chords.core.appshell.Application.componentDefaults]),
+     * and setting instance-specific properties. If there are conflicts between
+     * these two sources of property values, instance-specific property
+     * declarations override application-wide property declarations.
      */
     protected open fun updateProps() {
         if (componentInitializer == null) {

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.MutableState
+import io.spine.chords.core.appshell.Application
 import io.spine.chords.core.appshell.app
 
 /**
@@ -550,7 +551,15 @@ public abstract class Component {
      */
     private val initialized = mutableStateOf(false)
 
-    private var componentInitializer: ((Component) -> Unit)? = null
+    /**
+     * A lambda that assigns default property values that are applicable for
+     * this component according to the application-wide configuration.
+     *
+     * @see Application.componentDefaults
+     */
+    private val setDefaultProps: ((Component) -> Unit)? by lazy {
+        app.componentDefaults.componentDefaultsInitializer(javaClass)
+    }
 
     /**
      * A component's lifecycle method, which is invoked right after the
@@ -665,11 +674,7 @@ public abstract class Component {
      * declarations override application-wide property declarations.
      */
     protected open fun updateProps() {
-        if (componentInitializer == null) {
-            componentInitializer =
-                app.componentDefaults.componentDefaultsInitializer(javaClass) ?: {}
-        }
-        componentInitializer!!.invoke(this)
+        setDefaultProps?.invoke(this)
         props?.run { configure() }
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -32,7 +32,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.window.application
 import io.spine.chords.core.layout.Dialog
+import io.spine.chords.core.layout.ConfirmationDialog
 import io.spine.chords.core.layout.DialogSetup
+import io.spine.chords.core.layout.DialogDisplayMode
 import io.spine.chords.core.writeOnce
 import java.awt.Dimension
 
@@ -71,11 +73,69 @@ public var app: Application by writeOnce()
  * this, the [signInScreenContent] method has to be implemented to render
  * the respective composable content, and invoke the sign-in callback as needed.
  *
+ * ## Customizing default values for different component types
+ *
+ * It is possible to customize default values for properties for all instances
+ * of any given component type(s). To do this, override the [componentDefaults]
+ * function, and use a [defaultsTo][ComponentDefaultsScope.defaultsTo] infix
+ * call per each component type whose default property values you need
+ * to customize.
+ *
+ * Here's an example:
+ * ```
+ *     override fun ComponentDefaultsScope.componentDefaults() {
+ *         Dialog::class defaultsTo {
+ *             displayMode = DesktopWindow
+ *             look = Look(
+ *                 buttonsPanelPadding = 20.pt
+ *             }
+ *         }
+ *         ConfirmationDialog::class defaultsTo {
+ *             displayMode = Lightweight
+ *         }
+ *     }
+ * ```
+ *
+ * If you then have a usage of `MyCustomDialog` component that extends [Dialog]
+ * like this in your application:
+ * ```
+ *     MyCustomDialog.open {
+ *         dialogWidth = 600.dp
+ *         dialogHeight = 400.dp
+ *     }
+ * ```
+ *
+ * Then the dialog instance that will actually be created will implicitly have
+ * all of these property values:
+ * ```
+ * {
+ *     displayMode = DesktopWindow
+ *     look = Look(
+ *         buttonsPanelPadding = 20.pt
+ *     }
+ *     dialogWidth = 600.dp
+ *     dialogHeight = 400.dp
+ * }
+ * ```
+ *
+ * Note that for any given component, all default property values specified in
+ * all of its base classes will be applied as well (if any such declarations
+ * are present).
+ *
+ * If there are any conflicts in property declarations across multiple
+ * component's base classes, the declarations specified in child classes will
+ * override those found in base classes. In the example above, since
+ * [ConfirmationDialog] extends [Dialog], all instances of `ConfirmationDialog`
+ * declared within the application will get a value of
+ * [displayMode][ConfirmationDialog.displayMode] equal to
+ * [Lightweight][DialogDisplayMode.Lightweight].
+ *
  * @param name An application's name, which is in particular displayed in
  *   the application window's title.
  * @param views The list of application's views.
- * @param initialView Allows to specify a view from the list of [views], if any view other
- *   than the first one has to be displayed when the application starts.
+ * @param initialView Allows to specify a view from the list of [views], if any
+ *   view other than the first one has to be displayed when
+ *   the application starts.
  * @param minWindowSize The minimal size of the application window.
  */
 public open class Application(
@@ -147,13 +207,13 @@ public open class Application(
      * Here's an example:
      * ```
      *     override fun ComponentDefaultsScope.componentDefaults() {
-     *         component(Dialog::class) {
+     *         Dialog::class defaultsTo {
      *             onBeforeCancel = {
      *                 message = "Are you sure you want to close the dialog?"
      *                 description = "Any entered data will be lost in this case."
      *             }
      *         }
-     *         component(ConfirmationDialog::class) {
+     *         ConfirmationDialog::class defaultsTo {
      *             displayMode = Lightweight
      *         }
      *     }

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -167,6 +167,9 @@ public open class Application(
             return _ui!!
         }
 
+    /**
+     * The registry of default property values for different component types.
+     */
     internal val componentDefaults = ComponentDefaults()
 
     private var _ui: ApplicationUI? = null

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -118,9 +118,13 @@ public var app: Application by writeOnce()
  * }
  * ```
  *
+ * Property values specified for the actual component instance declaration
+ * always have a priority over respective default values, so this way you can
+ * override default property values whenever needed in their specific usages.
+ *
  * Note that for any given component, all default property values specified in
  * all of its base classes will be applied as well (if any such declarations
- * are present).
+ * for parent classes have been defined in the `componentDefaults` method).
  *
  * If there are any conflicts in property declarations across multiple
  * component's base classes, the declarations specified in child classes will

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -103,6 +103,8 @@ public open class Application(
             return _ui!!
         }
 
+    internal val componentDefaults = ComponentDefaults()
+
     private var _ui: ApplicationUI? = null
 
     /**
@@ -123,6 +125,10 @@ public open class Application(
         }
         app = this
 
+        with(componentDefaults) {
+            componentDefaults()
+        }
+
         application(exitProcessOnExit = exitProcessOnClose) {
             val appWindow = remember {
                 val appWindow = createAppWindow(::exitApplication)
@@ -131,6 +137,29 @@ public open class Application(
             }
             appWindowContent(appWindow)
         }
+    }
+
+    /**
+     * An implementation of the application ([Application]'s subclass) can
+     * override this method to specify application-wide default property values
+     * for individual component types.
+     *
+     * Here's an example:
+     * ```
+     *     override fun ComponentDefaultsScope.componentDefaults() {
+     *         component(Dialog::class) {
+     *             onBeforeCancel = {
+     *                 message = "Are you sure you want to close the dialog?"
+     *                 description = "Any entered data will be lost in this case."
+     *             }
+     *         }
+     *         component(ConfirmationDialog::class) {
+     *             displayMode = Lightweight
+     *         }
+     *     }
+     * ```
+     */
+    protected open fun ComponentDefaultsScope.componentDefaults() {
     }
 
     private fun createAppWindow(onCloseRequest: () -> Unit): AppWindow {

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/ComponentDefaults.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/ComponentDefaults.kt
@@ -56,13 +56,36 @@ public interface ComponentDefaultsScope {
 }
 
 /**
- * An implementation of [ComponentDefaultsScope], which stores component
- * defaults that were configured for the application, and provides an API
- * that allows to apply the default properties to components.
+ * An implementation of [ComponentDefaultsScope], which serves as a registry for
+ * component defaults that were configured to be applicable across the entire
+ * application, and provides an API that allows to apply the default properties
+ * to components.
  */
 internal class ComponentDefaults : ComponentDefaultsScope{
+
+    /**
+     * The raw data about which properties are registered for which types of
+     * components (without including properties registered for parent classes).
+     *
+     * This data structure serves as a source of truth about default properties,
+     * but it is not optimized for quick access per se.
+     *
+     * @see componentConfiguratorsPrepared
+     */
     private val componentConfiguratorsRaw:
             MutableMap<Class<*>, List<ComponentProps<*>>> = HashMap()
+
+    /**
+     * A cache of per-component-type property initialization lambdas that were
+     * derived from [componentConfiguratorsRaw] to represent a quickest possible
+     * way of setting all properties available for a certain component type.
+     *
+     * Unlike [componentConfiguratorsRaw], the per-component-type property
+     * assignment lambdas here contain property initializers that were
+     * registered for all parent classes as well.
+     *
+     * @see componentConfiguratorsRaw
+     */
     private val componentConfiguratorsPrepared:
             MutableMap<Class<*>, ((Component) -> Unit)?> = HashMap()
 
@@ -92,7 +115,7 @@ internal class ComponentDefaults : ComponentDefaultsScope{
      *
      * @param componentClass A class of component whose default properties
      *   initializer needs to be obtained.
-     * @return a lambda, which, given a component instance of type [C], assigns
+     * @return A lambda, which, given a component instance of type [C], assigns
      *   default property values to it and its parent classes, or `null` if no
      *   default property values are declared for the [componentClass] and any
      *   of its parent classes.

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/ComponentDefaults.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/ComponentDefaults.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.appshell
+
+import io.spine.chords.core.Component
+import io.spine.chords.core.ComponentProps
+import kotlin.reflect.KClass
+
+public interface ComponentDefaultsScope {
+    public fun <C : Component> component(componentClass: KClass<out C>, props: ComponentProps<C>)
+}
+
+public class ComponentDefaults : ComponentDefaultsScope{
+    private val componentConfiguratorsRaw:
+            MutableMap<Class<*>, List<ComponentProps<*>>> = HashMap()
+    private val componentConfiguratorsPrepared:
+            MutableMap<Class<*>, ((Component) -> Unit)?> = HashMap()
+
+    override fun <C : Component> component(
+        componentClass: KClass<out C>,
+        props: ComponentProps<C>
+    ) {
+        val initializerForClass = componentConfiguratorsRaw.getOrPut(
+            componentClass.java as Class<*>, { ArrayList<ComponentProps<C>>() }
+        ) as MutableList<ComponentProps<C>>
+        initializerForClass += props
+    }
+
+    public fun <C : Component> componentInitializer(componentClass: Class<C>): ((C) -> Unit)? {
+        val initializers: ((Component) -> Unit)? = componentConfiguratorsPrepared.getOrPut(
+            componentClass
+        ) {
+            val initializers: java.util.ArrayList<ComponentProps<C>> = ArrayList()
+            var cls: Class<*>? = componentClass
+            while (cls != null) {
+                val props = componentConfiguratorsRaw[cls] as List<ComponentProps<C>>?
+                if (props != null) {
+                    initializers.addAll(props)
+                }
+                cls = cls.superclass
+            }
+
+            if (initializers.isEmpty()) {
+                null
+            } else {
+                val result: (Component) -> Unit = { component ->
+                    with(component as C) {
+                        for (initializer: ComponentProps<C> in initializers) {
+                            initializer.run { configure() }
+                        }
+                    }
+                }
+                result
+            }
+        }
+        return initializers
+    }
+}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -244,10 +244,7 @@ public abstract class Dialog : Component() {
      *     init {
      *         onBeforeCancel = {
      *             ConfirmationDialog.ask {
-     *                 message = "Are you sure you want to close the dialog?"
-     *                 description = "Any entered data will be lost in this case."
-     *                 confirmButtonText = "Discard changes"
-     *                 cancelButtonText = "Continue editing"
+     *                 message = "Are you sure you want to cancel the dialog?"
      *             }
      *         }
      *         ...
@@ -281,9 +278,7 @@ public abstract class Dialog : Component() {
      *         onBeforeSubmit = {
      *             ConfirmationDialog.ask {
      *                 message = "Are you sure you want to proceed?"
-     *                 description = "This action is irreversible."
-     *                 confirmButtonText = "Yes"
-     *                 cancelButtonText = "No"
+     *                 description = "This action is irreversible!"
      *             }
      *         }
      *         ...

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.50`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.51`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 23 18:47:57 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 25 14:45:23 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.50`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.51`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Sat Nov 23 18:47:57 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 23 18:48:08 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 25 14:45:26 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.50`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.51`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Sat Nov 23 18:48:08 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 23 18:48:29 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 25 14:45:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.50`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.51`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Sat Nov 23 18:48:29 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 23 18:48:45 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 25 14:45:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.50`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.51`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Sat Nov 23 18:48:45 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 23 18:49:08 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 25 14:45:33 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.50`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.51`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Sat Nov 23 18:49:08 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 23 18:49:21 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 25 14:45:36 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.50</version>
+<version>2.0.0-SNAPSHOT.51</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.50")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.51")


### PR DESCRIPTION
This PR adds an ability to specify default property values for arbitrary component types on an application-wide basis.

See the `Application` class's KDocs for the description of this functionality.