### PR TITLE
Support disabling `CommandForm` during posting

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -330,8 +330,8 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      * Note: if `disableOnPosting` is `false`, no automatic disabling is
      * performed during posting the command.
      */
-    override val editorsEnabledSource: Boolean
-        get() = super.editorsEnabledSource && (!posting || !disableOnPosting)
+    override val shouldEnableEditors: Boolean
+        get() = super.shouldEnableEditors && (!posting || !disableOnPosting)
 
     override fun initialize() {
         super.initialize()

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -306,9 +306,9 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      * A state, which reports whether the form is currently in progress of
      * posting the command.
      *
-     * More precisely, it contains `true`, if the command has been posted using
-     * the [postCommand] method, but no response or error has been received yet,
-     * and `false` otherwise.
+     * More precisely, it is set to `true`, if the command has been posted using
+     * the [postCommand] method, but no response or timeout error has been
+     * received yet, and `false` otherwise.
      *
      * This property is backed by a [State] object, so it can be used as part of
      * a composition, which will be updated automatically when this property
@@ -360,13 +360,13 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      *   throws [TimeoutCancellationException].
      *
      * @return `true` if the command was successfully built without any
-     *         validation errors, and `false` if the command message could not
-     *         be successfully built from the currently entered data (validation
-     *         errors are displayed to the user in this case).
+     *   validation errors, and `false` if the command message could not be
+     *   successfully built from the currently entered data (validation errors
+     *   are displayed to the user in this case).
      * @throws TimeoutCancellationException If the event doesn't arrive within
      *   a reasonable timeout defined by the implementation.
-     * @throws IllegalStateException If the method is invoked while still
-     *   the [postCommand] is still being handled (when [posting] is
+     * @throws IllegalStateException If the method is invoked while
+     *   the [postCommand] invocation is still being handled (when [posting] is
      *   still `true`).
      */
     public suspend fun postCommand(): Boolean {

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -28,7 +28,9 @@ package io.spine.chords.client.form
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import io.spine.chords.core.appshell.app
 import io.spine.base.CommandMessage
 import io.spine.base.EventMessage
@@ -307,6 +309,11 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
         }
     }
 
+    private var posting: Boolean by mutableStateOf(false)
+
+    override val editorsEnabledSource: Boolean
+        get() = super.editorsEnabledSource && !posting
+
     /**
      * Posts the command based on all currently entered data and awaits
      * the feedback upon processing the command.
@@ -343,8 +350,9 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
             "CommandMessageForm's value should be not null since it was just " +
             "checked to be valid within postCommand."
         }
+        val subscription = eventSubscription(command)
         return try {
-            val subscription = eventSubscription(command)
+            posting = true
             app.client.command(command)
             subscription.awaitEvent()
             true
@@ -360,6 +368,8 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
             e: Exception
         ) {
             false
+        } finally {
+            posting = false
         }
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -57,8 +57,6 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      */
     private lateinit var commandMessageForm: CommandMessageForm<C>
 
-    protected override val submissionInProgress: Boolean get() = commandMessageForm.posting
-
     /**
      * Creates the [commandMessageForm] in which the command field editors
      * are rendered.

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -30,7 +30,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import io.spine.base.CommandMessage
 import io.spine.base.EventMessage
@@ -39,7 +39,7 @@ import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.core.layout.Dialog
 import io.spine.chords.proto.form.FormFieldsScope
 import io.spine.chords.proto.form.FormPartScope
-import io.spine.chords.proto.form.ValidationDisplayMode
+import io.spine.chords.proto.form.ValidationDisplayMode.MANUAL
 import io.spine.protobuf.ValidatingBuilder
 
 /**
@@ -57,6 +57,8 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      */
     private lateinit var commandMessageForm: CommandMessageForm<C>
 
+    protected override val submissionInProgress: Boolean get() = commandMessageForm.posting
+
     /**
      * Creates the [commandMessageForm] in which the command field editors
      * are rendered.
@@ -64,22 +66,16 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
     @Composable
     protected override fun formContent() {
         commandMessageForm = CommandMessageForm(
-            {
-                createCommandBuilder()
-            },
-            onBeforeBuild = {
-                beforeBuild(it)
-            },
+            ::createCommandBuilder,
+            onBeforeBuild = ::beforeBuild,
             props = {
-                validationDisplayMode = ValidationDisplayMode.MANUAL
-                eventSubscription = {
-                    subscribeToEvent(it)
-                }
+                validationDisplayMode = MANUAL
+                eventSubscription = ::subscribeToEvent
             }
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = CenterHorizontally
             ) {
                 content()
             }

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -29,6 +29,7 @@ package io.spine.chords.client.layout
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import io.spine.base.CommandMessage
@@ -82,6 +83,10 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
             ) {
                 content()
             }
+        }
+
+        LaunchedEffect(Unit) {
+            commandMessageForm.focus()
         }
     }
 

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -196,7 +196,6 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
     }
 
     override fun validate(): Boolean {
-        checkNotNull(pageForm)
         pageForm.updateValidationDisplay(true)
         return pageForm.valueValid.value
     }

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -29,16 +29,16 @@ package io.spine.chords.client.layout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import com.google.protobuf.Message
-import io.spine.chords.proto.form.FormFieldsScope
-import io.spine.chords.proto.form.MessageForm
-import io.spine.chords.proto.form.FormPartScope
-import io.spine.chords.proto.form.ValidationDisplayMode.MANUAL
 import io.spine.base.CommandMessage
 import io.spine.base.EventMessage
 import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.core.layout.AbstractWizardPage
 import io.spine.chords.core.layout.Wizard
+import io.spine.chords.proto.form.FormFieldsScope
+import io.spine.chords.proto.form.FormPartScope
+import io.spine.chords.proto.form.MessageForm
+import io.spine.chords.proto.form.ValidationDisplayMode.MANUAL
 import io.spine.chords.runtime.MessageField
 import io.spine.protobuf.ValidatingBuilder
 
@@ -188,11 +188,6 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
                 }
             }
         }
-
-        if (wizard.lastFocusedPage != this) {
-            wizard.lastFocusedPage = this
-            pageForm.focus()
-        }
     }
 
     /**
@@ -202,6 +197,11 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
      */
     @Composable
     protected abstract fun FormPartScope<M>.content()
+
+    override fun show() {
+        super.show()
+        pageForm.focus()
+    }
 
     override fun validate(): Boolean {
         checkNotNull(pageForm)

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -62,10 +62,8 @@ import io.spine.protobuf.ValidatingBuilder
  * - This means that you can place respective [Field][FormFieldsScope.Field]
  *   declarations right in the [content][CommandWizardPage.content] method.
  *
- * @param C
- *         a type of the command message constructed in the wizard.
- * @param B
- *         a type of the command message builder.
+ * @param C A type of the command message constructed in the wizard.
+ * @param B A type of the command message builder.
  */
 @Stable
 public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<out C>> : Wizard() {
@@ -74,8 +72,7 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
         CommandMessageForm.create(
             { createCommandBuilder() },
             onBeforeBuild = { beforeBuild(it) }
-        )
-        {
+        ) {
             validationDisplayMode = MANUAL
             eventSubscription = { subscribeToEvent(it) }
         }
@@ -89,11 +86,6 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
     protected abstract override fun createPages():
             List<CommandWizardPage<out Message, out ValidatingBuilder<out Message>>>
 
-    /**
-     * The page of this wizard on which the focus was the last time.
-     */
-    internal var lastFocusedPage:
-            CommandWizardPage<out Message, out ValidatingBuilder<out Message>>? = null
 
     /**
      * A function that should be implemented to create and return a new builder

--- a/core/src/main/kotlin/io/spine/chords/core/Delegates.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Delegates.kt
@@ -36,16 +36,16 @@ import kotlin.reflect.KProperty
  * ```
  *   var prop: String by writeOnce()
  *
- *   // print(prop) would throw IllegalStateException here, when
- *   // the property is read before it is set for the first time
+ *   // `print(prop)` would throw `IllegalStateException` here, when
+ *   // the property is read before it is set for the first time.
  *
  *   prop = "Hello"
- *   print(prop) // prints "Hello" as expected
+ *   print(prop) // Prints "Hello" as expected.
  *
- *   prop = "Something else" // throws IllegalStateException if set again
+ *   prop = "Something else" // Throws `IllegalStateException` if set again.
  *
  *   // ...
- *   print(prop) // still prints "Hello" despite additional set attempt(s)
+ *   print(prop) // Still prints "Hello" despite additional set attempt(s).
  * ```
  *
  * @param T

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -451,7 +451,6 @@ public class DropdownListBox<I> : Component() {
             }
         }
 
-
         LaunchedEffect(noneItemEnabled) {
             if (!noneItemEnabled) {
                 noneItemHeight = 0
@@ -840,7 +839,7 @@ public class DropdownListBox<I> : Component() {
      * Handles user's key presses when drop-down list is not expanded.
      *
      * @param event A key event that was triggered in the invoker.
-     * @return `true` If further event's propagation should be prevented, and
+     * @return `true` if further event's propagation should be prevented, and
      *   `false` otherwise.
      */
     private fun handleKeyEventWhenDropdownNotExpanded(event: KeyEvent): Boolean = when {

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -46,8 +46,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.ShapeDefaults.ExtraSmall
 import androidx.compose.material3.Surface
@@ -121,8 +121,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
- * A component that attaches a drop-down list attached to a custom composable
- * invoker, and allows selecting a single item in this list.
+ * A component that displays a customizable composable [invoker] content, and
+ * attaches a drop-down list to that content, which allows selecting a single
+ * item in this list.
  *
  * The drop-down list is displayed when the user presses the Up/Down keys with
  * or without the Alt modifier (customizable with [expandKey] property).
@@ -160,15 +161,14 @@ public class DropdownListBox<I> : Component() {
          * Declares an instance of [DropdownListBox] with the respective
          * property value specifications.
          *
-         * @param I
-         *         a type of items displayed in the drop-down list.
-         * @param props
-         *         a lambda that is invoked on a component's instance, and
-         *         should configure its properties in a way that is needed for
-         *         this component's instance. It is invoked before each
-         *         recomposition of the component.
-         * @return a component's instance that has been created for this
-         *         declaration site.
+         * @param I A type of items displayed in the drop-down list.
+         *
+         * @param props A lambda that is invoked on a component's instance, and
+         *   should configure its properties in a way that is needed for this
+         *   component's instance. It is invoked before each recomposition of
+         *   the component.
+         * @return A component's instance that has been created for this
+         *   declaration site.
          */
         @Composable
         public operator fun <I> invoke(
@@ -190,6 +190,12 @@ public class DropdownListBox<I> : Component() {
      * A list of items to display in the drop-down list.
      */
     public var items: Iterable<I> = emptyList()
+
+    /**
+     * Specifies whether clicking the invoker triggers displaying of the
+     * drop-down list box.
+     */
+    public var enabled: Boolean by mutableStateOf(true)
 
     /**
      * Currently selected item in the drop-down list,
@@ -425,6 +431,12 @@ public class DropdownListBox<I> : Component() {
         val coroutineScope = rememberCoroutineScope()
         val scrollState = rememberScrollState(0)
 
+        LaunchedEffect(enabled) {
+            if (!enabled) {
+                expanded.value = false
+            }
+        }
+
         val expanded = expanded.value
         LaunchedEffect(expanded) {
             expandedBeforeDismissRequest = expanded
@@ -438,6 +450,7 @@ public class DropdownListBox<I> : Component() {
                 }
             }
         }
+
 
         LaunchedEffect(noneItemEnabled) {
             if (!noneItemEnabled) {
@@ -604,7 +617,7 @@ public class DropdownListBox<I> : Component() {
     private fun onInvokerClick() {
         if (clearSelectedItemPressed) {
             clearSelectedItemPressed = false
-        } else {
+        } else if (enabled) {
             expanded.value = !expandedBeforeDismissRequest
             expandedBeforeDismissRequest = !expandedBeforeDismissRequest
         }
@@ -826,10 +839,9 @@ public class DropdownListBox<I> : Component() {
     /**
      * Handles user's key presses when drop-down list is not expanded.
      *
-     * @param event
-     *         a key event that was triggered in the invoker.
-     * @return `true` if further event's propagation should be prevented, and
-     *         `false` otherwise.
+     * @param event A key event that was triggered in the invoker.
+     * @return `true` If further event's propagation should be prevented, and
+     *   `false` otherwise.
      */
     private fun handleKeyEventWhenDropdownNotExpanded(event: KeyEvent): Boolean = when {
         event matches expandKey.down -> {
@@ -839,8 +851,12 @@ public class DropdownListBox<I> : Component() {
         }
 
         event matches expandKey.up -> {
-            expanded.value = true
-            true
+            if (enabled) {
+                expanded.value = true
+                true
+            } else {
+                false
+            }
         }
 
         else -> false
@@ -849,12 +865,10 @@ public class DropdownListBox<I> : Component() {
     /**
      * Composable for wrapping items in a column within the drop-down list.
      *
-     * @receiver
-     *         a [BoxScope], the scope within which this function
-     *         is intended to be used.
-     * @param scrollState
-     *         a [ScrollState], whose value indicates current
-     *         drop-down list scrollbar position.
+     * @receiver A [BoxScope], the scope within which this function is intended
+     *   to be used.
+     * @param scrollState A [ScrollState], whose value indicates current
+     *   drop-down list scrollbar position.
      */
     @Composable
     private fun BoxScope.DropdownListContent(scrollState: ScrollState) {
@@ -1215,7 +1229,7 @@ private fun DropdownListNoItems(content: @Composable (() -> Unit)) {
     ) {
         StyledContent(
             contentColor = colorScheme.secondary.copy(alpha = 0.5f),
-            textStyle = MaterialTheme.typography.titleSmall,
+            textStyle = typography.titleSmall,
             content = content
         )
     }

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.core
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -91,8 +91,7 @@ import java.util.*
  * Like any [InputComponent][io.spine.chords.core.InputComponent], this
  * component identifies the currently selected item using its [value] property.
  *
- * @param I
- *         a type of items from which the selection is made by this component.
+ * @param I A type of items from which the selection is made by this component.
  */
 @Stable
 public abstract class DropdownSelector<I> : InputComponent<I>() {
@@ -206,6 +205,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
             noneItemEnabled = !valueRequired
             onSelectItem = ::onSelectItem
             expanded = this@DropdownSelector.expanded
+            enabled = this@DropdownSelector.enabled
             preselectNoneByDefault = searchString.trim().length == 0
             itemContent = {
                 val itemText = itemText(it)
@@ -251,7 +251,8 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
                 TrailingIcons(
                     valueRequired,
                     selectedItem != null,
-                    expanded.value
+                    expanded.value,
+                    enabled
                 )
             }
         )
@@ -408,29 +409,29 @@ private fun String.annotateSubstring(
  * The trailing `DropdownSelector`'s icons that are helpful to see and control
  * the component's state.
  *
- * @param valueRequired
- *         the value of `valueRequired` property of `DropdownSelector`.
- * @param containsValue
- *         `true`, if `DropdownSelector` currently contains a value, and
- *         `false` otherwise.
- * @param expanded
- *         `true`, if `DropdownSelector` is currently expanded, and
- *         `false` otherwise.
+ * @param valueRequired The value of `valueRequired` property
+ *   of `DropdownSelector`.
+ * @param containsValue `true`, if `DropdownSelector` currently contains
+ *   a value, and `false` otherwise.
+ * @param expanded `true`, if `DropdownSelector` is currently expanded, and
+ *   `false` otherwise.
+ * @param enabled Specifies whether the `DropdownSelector` is currently enabled.
  */
 @Composable
 private fun DropdownListBoxScope.TrailingIcons(
     valueRequired: Boolean,
     containsValue: Boolean,
-    expanded: Boolean
+    expanded: Boolean,
+    enabled: Boolean
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalArrangement = spacedBy(10.dp),
         verticalAlignment = CenterVertically
     ) {
-        if (!valueRequired) {
+        if (!valueRequired && enabled) {
             ClearValueIcon(containsValue)
         }
-        DropdownExpansionIcon(expanded)
+        DropdownExpansionIcon(expanded, enabled)
     }
 }
 
@@ -449,7 +450,7 @@ private fun DropdownListBoxScope.ClearValueIcon(containsValue: Boolean) {
     var isClearIconHovered by remember { mutableStateOf(false) }
     Box(
         modifier = Modifier
-            .pointerHoverIcon(if (containsValue)  Hand else Text)
+            .pointerHoverIcon(if (containsValue) Hand else Text)
             .alpha(if (containsValue) 1f else 0f)
             .onPointerEvent(Press) { handleClearSelectedItemPress() }
             .onPointerEvent(Enter) { isClearIconHovered = true }
@@ -469,22 +470,22 @@ private fun DropdownListBoxScope.ClearValueIcon(containsValue: Boolean) {
 /**
  * A trailing `DropdownSelector`'s icon, which displays its expansion state.
  *
- * @param expanded
- *         `true`, if `DropdownSelector` is currently expanded, and
- *         `false` otherwise.
+ * @param expanded `true`, if the `DropdownSelector` is currently expanded, and
+ *   `false` otherwise.
+ * @param enabled Specifies whether the `DropdownSelector` is currently enabled.
  */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
-private fun DropdownExpansionIcon(expanded: Boolean) {
+private fun DropdownExpansionIcon(expanded: Boolean, enabled: Boolean) {
     var isTrailingIconHovered by remember { mutableStateOf(false) }
     Box(
         modifier = Modifier
-            .pointerHoverIcon(Hand)
+            .pointerHoverIcon(if (enabled) Hand else Text)
             .padding(end = 10.dp)
             .onPointerEvent(Enter) { isTrailingIconHovered = true }
             .onPointerEvent(Exit) { isTrailingIconHovered = false }
             .background(
-                if (isTrailingIconHovered) {
+                if (isTrailingIconHovered && enabled) {
                     colorScheme.primary.copy(alpha = 0.1f)
                 } else {
                     Transparent

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -122,11 +122,6 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
     public var label: String by mutableStateOf("")
 
     /**
-     * Indicates whether the field is enabled for receiving the user input.
-     */
-    public var enabled: Boolean by mutableStateOf(true)
-
-    /**
      * A [Modifier] to be applied to the component.
      */
     public var modifier: Modifier by mutableStateOf(Modifier)

--- a/core/src/main/kotlin/io/spine/chords/core/FocusableComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/FocusableComponent.kt
@@ -66,7 +66,13 @@ public abstract class FocusableComponent : Component() {
      */
     public open fun focus() {
         if (lazyFocusRequester.isInitialized()) {
-            lazyFocusRequester.value.requestFocus()
+            try {
+                lazyFocusRequester.value.requestFocus()
+            } catch (e: IllegalStateException) {
+                throw IllegalStateException(
+                    "Couldn't request focus for component ${javaClass.simpleName}", e
+                )
+            }
         } else {
             throw IllegalStateException(
                 "Make sure to either assign `lazyFocusRequester` onto some composable, or " +

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -262,6 +262,11 @@ public abstract class InputComponent<V> : FocusableComponent() {
             }
         }
 
+    /**
+     * Specifies whether the field is enabled for receiving the user's input.
+     */
+    public var enabled: Boolean by mutableStateOf(true)
+
     override fun initialize() {
         super.initialize()
         if (!this::value.isInitialized) {

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -242,11 +242,6 @@ public open class InputField<V> : InputComponent<V>() {
         }
 
     /**
-     * Indicates whether the field is enabled for receiving the user input.
-     */
-    public var enabled: Boolean by mutableStateOf(true)
-
-    /**
      * A callback, which is triggered after the value in the [MutableState] in
      * [value] has been updated with a newly edited value.
      */

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -200,6 +200,13 @@ public abstract class Dialog : Component() {
     protected open val submissionInProgress: Boolean = false
 
     /**
+     * Exposes [submissionInProgress] to other parts of dialog's implementation,
+     * which are outside of this class, while still ensuring that this API is
+     * internal to the library.
+     */
+    internal val submissionInProgressInternal: Boolean get() = submissionInProgress
+
+    /**
      * An object allowing adjustments of visual appearance parameters.
      *
      * @param padding The padding applied to the entire content of the dialog.
@@ -471,6 +478,7 @@ public abstract class DialogDisplayMode {
     @Suppress("LongParameterList")
     private fun DialogButtons(dialog: Dialog) {
         val coroutineScope = rememberCoroutineScope()
+        val enabled = !dialog.submissionInProgressInternal
 
         Row(
             modifier = Modifier.fillMaxWidth()
@@ -481,10 +489,10 @@ public abstract class DialogDisplayMode {
             Row(
                 horizontalArrangement = spacedBy(dialog.look.buttonsSpacing)
             ) {
-                DialogButton(dialog.cancelButtonText) {
+                DialogButton(dialog.cancelButtonText, enabled) {
                     coroutineScope.launch { dialog.handleCancelClick() }
                 }
-                DialogButton(dialog.submitButtonText) {
+                DialogButton(dialog.submitButtonText, enabled) {
                     coroutineScope.launch { dialog.handleSubmitClick() }
                 }
             }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
@@ -120,8 +120,13 @@ public abstract class Wizard : Component() {
             currentPageIndex = pageIndex
         }
 
-    private var currentPageIndex by mutableStateOf(0)
+    /**
+     * Specifies whether the wizard is in the submission state, which means
+     * that an asynchronous form submission has started, but not completed yet.
+     */
+    private var submitting: Boolean by mutableStateOf(false)
 
+    private var currentPageIndex by mutableStateOf(0)
     private val pages by lazy { createPages() }
 
     /**
@@ -138,6 +143,11 @@ public abstract class Wizard : Component() {
      *
      * `onCloseRequest` is triggerred right after the `submit` action,
      * so it is not needed to configure it manually.
+     *
+     * @return `true`, if submission was performed successfully, and the wizard
+     *   can be closed now, and `false` if submission didn't succeed (e.g. if
+     *   some validation errors were identified), and the wizard still needs to
+     *   be kept open.
      */
     protected abstract suspend fun submit(): Boolean
 
@@ -188,7 +198,8 @@ public abstract class Wizard : Component() {
                     },
                     onCancelClick = { onCloseRequest?.invoke() },
                     isOnFirstPage = isOnFirstPage(),
-                    isOnLastPage = isOnLastPage()
+                    isOnLastPage = isOnLastPage(),
+                    submitting
                 )
             }
         }
@@ -209,7 +220,13 @@ public abstract class Wizard : Component() {
 
     private suspend fun Wizard.handleFinishClick(currentPage: WizardPage) {
         if (currentPage.validate()) {
-            if (submit()) {
+            submitting = true
+            val submittedSuccessfully = try {
+                submit()
+            } finally {
+                submitting = false
+            }
+            if (submittedSuccessfully) {
                 onCloseRequest?.invoke()
             }
         }
@@ -259,13 +276,10 @@ public abstract class Wizard : Component() {
 /**
  * The title of the wizard.
  *
- * @param text
- *         the text to be title.
+ * @param text The text to be title.
  */
 @Composable
-private fun Title(
-    text: String
-) {
+private fun Title(text: String) {
     Text(
         text = text,
         style = MaterialTheme.typography.headlineLarge
@@ -296,7 +310,8 @@ private fun NavigationPanel(
     onFinishClick: () -> Unit,
     onCancelClick: () -> Unit,
     isOnFirstPage: Boolean,
-    isOnLastPage: Boolean
+    isOnLastPage: Boolean,
+    submitting: Boolean
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -310,12 +325,12 @@ private fun NavigationPanel(
         ) {
             TextButton(
                 onClick = onBackClick,
-                enabled = !isOnFirstPage
+                enabled = !isOnFirstPage && !submitting
             ) {
                 Text("Back")
             }
             if (isOnLastPage) {
-                Button(onClick = onFinishClick) {
+                Button(onClick = onFinishClick, enabled = !submitting) {
                     Text("Finish")
                 }
             } else {
@@ -332,13 +347,10 @@ private fun NavigationPanel(
  * respective UI as per the wizard's requirements (e.g. adding page scrolling
  * support, etc.).
  *
- * @param page
- *         a page that has to be displayed in the container.
+ * @param page A page that has to be displayed in the container.
  */
 @Composable
-private fun PageContainer(
-    page: WizardPage
-) {
+private fun PageContainer(page: WizardPage) {
     val stateVertical = rememberScrollState(0, page)
     val stateHorizontal = rememberScrollState(0, page)
     Box(

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
@@ -45,8 +45,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -169,7 +171,12 @@ public abstract class Wizard : Component() {
                             }
                         }
                 ) {
-                    PageContainer(currentPage)
+                    key(currentPage) {
+                        PageContainer(currentPage)
+                    }
+                    LaunchedEffect(currentPage) {
+                        currentPage.show()
+                    }
                 }
                 NavigationPanel(
                     onNextClick = { handleNextClick(currentPage) },

--- a/core/src/main/kotlin/io/spine/chords/core/primitive/CheckboxWithText.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/primitive/CheckboxWithText.kt
@@ -37,7 +37,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.Key.Companion.Spacebar
 import androidx.compose.ui.semantics.Role.Companion.Checkbox
 import androidx.compose.ui.unit.dp
 import io.spine.chords.core.FocusRequestDispatcher
@@ -49,22 +49,17 @@ import io.spine.chords.core.keyboard.on
 /**
  * A checkbox that includes a given text on the right.
  *
- * @param checked
- *         indicates whether the checkbox is checked.
- * @param onChange
- *         invoked when the user tries to change the "checked" state.
- *         This handler has to be implemented in a way that updates the value of
- *         the [checked] parameter.
- * @param text
- *         a text displayed to the right of the checkbox.
- * @param enabled
- *         indicates whether the component is enabled for receiving
- *         the user input.
- * @param focusRequestDispatcher
- *         a [FocusRequestDispatcher], which specifies when the component should
- *         be focused.
- * @param externalValidationMessage
- *         a validation error that should be displayed by the component.
+ * @param checked Indicates whether the checkbox is checked.
+ * @param onChange Invoked when the user tries to change the "checked" state.
+ *   This handler has to be implemented in a way that updates the value of
+ *   the [checked] parameter.
+ * @param text A text displayed to the right of the checkbox.
+ * @param enabled Indicates whether the component is enabled for receiving
+ *   the user input.
+ * @param focusRequestDispatcher A [FocusRequestDispatcher], which specifies
+ *   when the component should be focused.
+ * @param externalValidationMessage A validation error that should be displayed
+ *   by the component.
  */
 @Composable
 public fun CheckboxWithText(
@@ -84,11 +79,11 @@ public fun CheckboxWithText(
                 enabled = enabled,
                 onClick = { toggle() },
                 role = Checkbox
-            ).on(Key.Spacebar.key.up) {
+            ).on(Spacebar.key.up) {
                 toggle()
             },
         verticalAlignment = CenterVertically,
-        horizontalArrangement = spacedBy(5.dp)
+        horizontalArrangement = spacedBy(8.dp)
     ) {
         Checkbox(
             checked = checked,
@@ -100,15 +95,8 @@ public fun CheckboxWithText(
     }
     if (externalValidationMessage?.value != null) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(
-                    enabled = enabled,
-                    onClick = { onChange(!checked) },
-                    role = Checkbox
-                ),
-            verticalAlignment = CenterVertically,
-            horizontalArrangement = spacedBy(5.dp)
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = CenterVertically
         ) {
             ValidationErrorText(externalValidationMessage)
         }
@@ -122,20 +110,15 @@ public fun CheckboxWithText(
  * object, which is updated by the component automatically when the user changes
  * the state of checkbox.
  *
- * @param checked
- *         a [MutableState] that holds a boolean flag indicating whether
- *         the checkbox is checked. If that boolean value is null, displays
- *         an unchecked checkbox.
- * @param onChange
- *         invoked after the user has changed the "checked" state.
- * @param text
- *         a text displayed to the right of the checkbox.
- * @param enabled
- *         indicates whether the component is enabled for receiving
- *         the user input.
- * @param focusRequestDispatcher
- *         a [FocusRequestDispatcher], which specifies when the component should
- *         be focused.
+ * @param checked A [MutableState] that holds a boolean flag indicating whether
+ *   the checkbox is checked. If that boolean value is null, displays
+ *   an unchecked checkbox.
+ * @param onChange Invoked after the user has changed the "checked" state.
+ * @param text A text displayed to the right of the checkbox.
+ * @param enabled Indicates whether the component is enabled for receiving
+ *   the user input.
+ * @param focusRequestDispatcher A [FocusRequestDispatcher], which specifies
+ *   when the component should be focused.
  */
 @Composable
 public fun CheckboxWithText(

--- a/core/src/main/kotlin/io/spine/chords/core/primitive/RadioButtonWithText.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/primitive/RadioButtonWithText.kt
@@ -29,6 +29,8 @@ package io.spine.chords.core.primitive
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.ContentAlpha.disabled
+import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,44 +48,48 @@ import io.spine.chords.core.keyboard.on
 /**
  * A radio button that includes a given text on the right.
  *
- * @param selected
- *         a [MutableState] that holds a boolean flag indicating whether
- *         the radio button is selected.
- * @param onClick
- *         invoked when the user has selected this radio button. This function
- *         has to be implemented in a way that makes the [selected] parameter
- *         to be updated accordingly.
- * @param text
- *         a text displayed to the right of the radio button.
- * @param focusRequestDispatcher
- *         a [FocusRequestDispatcher], which should be attached to by this field
- *         for receiving and handling field focus requests.
+ * @param selected A [MutableState] that holds a boolean flag indicating whether
+ *   the radio button is selected.
+ * @param onClick Invoked when the user has selected this radio button. This
+ *   function has to be implemented in a way that makes the [selected]
+ *   parameter to be updated accordingly.
+ * @param text A text displayed to the right of the radio button.
+ * @param focusRequestDispatcher A [FocusRequestDispatcher], which should be
+ *   attached to by this field for receiving and handling field focus requests.
  */
 @Composable
 public fun RadioButtonWithText(
     selected: Boolean,
     onClick: () -> Unit,
     text: String,
+    enabled: Boolean = true,
     modifier: Modifier = Modifier,
     focusRequestDispatcher: FocusRequestDispatcher? = null
 ) {
     Row(
         modifier = modifier
             .focusRequestDispatcher(focusRequestDispatcher)
-            .selectable(
-                selected = selected,
-                onClick = onClick,
-                role = RadioButton
-            ).on(Key.Spacebar.key.up) {
-                onClick()
+            .run {
+                if (enabled) {
+                    selectable(
+                        selected = selected,
+                        onClick = onClick,
+                        role = RadioButton
+                    ).on(Key.Spacebar.key.up) {
+                        onClick()
+                    }
+                } else {
+                    this
+                }
             },
         verticalAlignment = CenterVertically,
-        horizontalArrangement = spacedBy(5.dp)
+        horizontalArrangement = spacedBy(8.dp)
     ) {
         RadioButton(
             selected = selected,
+            enabled = enabled,
             onClick = null
         )
-        Text(text)
+        Text(text, color = if (enabled) colors.onSurface else colors.onSurface.copy(disabled))
     }
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.52`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 25 14:45:23 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 00:18:52 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.52`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Mon Nov 25 14:45:23 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 25 14:45:26 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 00:18:55 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.52`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2912,12 +2912,12 @@ This report was generated on **Mon Nov 25 14:45:26 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 25 14:45:28 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 00:18:57 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.52`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3916,12 +3916,12 @@ This report was generated on **Mon Nov 25 14:45:28 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 25 14:45:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 00:18:59 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.52`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Mon Nov 25 14:45:30 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 25 14:45:33 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 00:19:01 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.51`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.52`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Mon Nov 25 14:45:33 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 25 14:45:36 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 03 00:19:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.51</version>
+<version>2.0.0-SNAPSHOT.52</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/CheckBoxWithTextExt.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/CheckBoxWithTextExt.kt
@@ -59,12 +59,13 @@ public fun <M : Message>FormFieldsScope<M>.CheckboxWithText(
     onChange: ((Boolean) -> Unit)? = null,
     enabled: Boolean = true
 ) {
+    val form = formPartScope.formScope.form
     Field(field, defaultValue) {
         io.spine.chords.core.primitive.CheckboxWithText(
             checked = fieldValue,
             onChange = onChange,
             text = text,
-            enabled = enabled,
+            enabled = enabled && form.editorsEnabled.value,
             focusRequestDispatcher = focusRequestDispatcher,
             externalValidationMessage = externalValidationMessage
         )

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
@@ -125,8 +125,7 @@ public operator fun <
         C : InputComponent<V>,
         M : Message,
         V : MessageFieldValue
-        >
-        ComponentSetup<C>.invoke(
+> ComponentSetup<C>.invoke(
     field: MessageField<M, V>,
     props: ComponentProps<C>? = null
 ): C {
@@ -164,7 +163,7 @@ context(FormFieldsScope<M>)
 internal fun <
         M : Message,
         V : MessageFieldValue
-        > InputComponent<V>.ContentWithinField(
+> InputComponent<V>.ContentWithinField(
     field: MessageField<M, V>,
     defaultValue: V? = null
 ) {
@@ -174,6 +173,7 @@ internal fun <
         this@InputComponent.externalValidationMessage = this@Field.externalValidationMessage
         this@InputComponent.onDirtyStateChange = { this@Field.notifyDirtyStateChanged(it) }
         this@InputComponent.valueRequired = this@Field.fieldRequired
+        this@InputComponent.enabled = this@Field.fieldEnabled.value
         this@Field.focusRequestDispatcher.handleFocusRequest = { focus() }
         registerFieldValueEditor(this@InputComponent)
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1133,6 +1133,14 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     public val editorsEnabled: State<Boolean> get() = editorsEnabledInternal
     private lateinit var editorsEnabledInternal: MutableState<Boolean>
 
+    /**
+     * A property that serves as the source of truth about whether form's
+     * editors should be enabled (if `true`) or disabled (if `false`).
+     *
+     * By default, it reflects the value of the [enabled] property, but can be
+     * overridden by subclasses if they have some logic on top of
+     * the [enabled] property's.
+     */
     protected open val editorsEnabledSource: Boolean get() = enabled
 
     /**

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1134,14 +1134,16 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     private lateinit var editorsEnabledInternal: MutableState<Boolean>
 
     /**
-     * A property that serves as the source of truth about whether form's
-     * editors should be enabled (if `true`) or disabled (if `false`).
+     * A property that serves as the source of truth for filling in the value
+     * in the state referred to by the `editorsEnabled` property.
      *
-     * By default, it reflects the value of the [enabled] property, but can be
-     * overridden by subclasses if they have some logic on top of
-     * the [enabled] property's.
+     * It is needed as a separate protected property because it can be
+     * overridden in a subclass to customize the actual value provided
+     * via `editorsEnabled`. By default, it reflects the value of the [enabled]
+     * property, but can be overridden by subclasses if they have some logic on
+     * top of the [enabled] property's.
      */
-    protected open val editorsEnabledSource: Boolean get() = enabled
+    protected open val shouldEnableEditors: Boolean get() = enabled
 
     /**
      * A current form-wide validation error (the one that is not related to any
@@ -1240,7 +1242,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         _dirty = identifyInitialDirtyState(value.value)
         enteringNonNullValue.value = identifyInitialEnteringNonNullValue()
         lastObservedEnteringNonNullValue = enteringNonNullValue.value
-        editorsEnabledInternal = mutableStateOf(editorsEnabledSource)
+        editorsEnabledInternal = mutableStateOf(shouldEnableEditors)
     }
 
     /**
@@ -1421,7 +1423,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         }
         lastObservedEnteringNonNullValue = enteringNonNullValue
 
-        editorsEnabledInternal.value = editorsEnabledSource
+        editorsEnabledInternal.value = shouldEnableEditors
     }
 
     private fun identifyInitialDirtyState(initialMessageValue: M?): Boolean = when {

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
@@ -348,6 +348,11 @@ public sealed interface FormFieldScope<V : MessageFieldValue> {
     public val externalValidationMessage: State<String?>
 
     /**
+     * A boolean state that indicates whether the field has to be enabled.
+     */
+    public val fieldEnabled: State<Boolean>
+
+    /**
      * A focus request dispatcher that has to be attached to the field editor
      * component to enable its focusing by the form validation functionality.
      */
@@ -548,12 +553,12 @@ internal class FormPartScopeImpl<M : Message>(
  * @param V A type of field's value.
  *
  * @param formField A field represented by this scope object.
- * @param form A form to which this field belongs.
  */
 internal class FormFieldScopeImpl<M : Message, V : MessageFieldValue>(
-    private val formField: MessageForm<M>.FormField,
-    val form: MessageForm<M>
+    private val formField: MessageForm<M>.FormField
 ) : FormFieldScope<V> {
+    private val form: MessageForm<M> = formField.formFieldsScopeImpl.formScope.form
+
     override val fieldRequired = formField.required
     override val fieldValue: MutableState<V?>
         // Fields are stored as a base `MessageFieldValue` type internally.
@@ -563,7 +568,8 @@ internal class FormFieldScopeImpl<M : Message, V : MessageFieldValue>(
         get() = formField.valueValid
     override val externalValidationMessage: MutableState<String?>
         get() = formField.externalValidationMessage
-
+    override val fieldEnabled: State<Boolean>
+        get() = form.editorsEnabled
     override val focusRequestDispatcher: FocusRequestDispatcher
         get() = formField.focusRequestDispatcher
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetupBase.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetupBase.kt
@@ -113,8 +113,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
     protected open fun <
             PM : Message,
             B : ValidatingBuilder<out M>
-            >
-            declareInstance(
+    > declareInstance(
         field: MessageField<PM, M>,
         builder: () -> B,
         props: ComponentProps<F> = ComponentProps {},
@@ -205,8 +204,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
     protected fun <
             PM : Message,
             B : ValidatingBuilder<out M>
-            >
-            declareMultipartInstance(
+    > declareMultipartInstance(
         field: MessageField<PM, M>,
         builder: () -> B,
         props: ComponentProps<F> = ComponentProps {},

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -84,6 +84,7 @@ public class OneofRadioButton : FocusableComponent() {
                     )
                     selectedField.value = field as MessageField<M, MessageFieldValue>
                 },
+                enabled = formPartScope.formScope.form.editorsEnabled.value,
                 text = text,
                 focusRequestDispatcher = FocusRequestDispatcher(focusRequester)
             )
@@ -100,8 +101,8 @@ public class OneofRadioButton : FocusableComponent() {
          * field's message.
          *
          * @receiver A scope of type [OneOfFieldsScope], which is introduced
-         *         by the parent [OneOfFields][FormPartScope.OneOfFields]
-         *         declaration that corresponds to the oneof being edited.
+         *    by the parent [OneOfFields][FormPartScope.OneOfFields] declaration
+         *    that corresponds to the oneof being edited.
          * @param M A type of message to which the respective oneof
          *   field belongs.
          * @param F A type of message that is edited in the field associated

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OptionalMessageCheckbox.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OptionalMessageCheckbox.kt
@@ -46,8 +46,7 @@ import io.spine.chords.core.primitive.CheckboxWithText
  * value based on the currently entered form field values. When the checkbox is
  * unchecked, the form's message value will be `null`.
  *
- * @param text
- *         a checkbox's text.
+ * @param text A checkbox's text.
  */
 @Composable
 public fun <M : Message> FormPartScope<M>.OptionalMessageCheckbox(
@@ -60,19 +59,19 @@ public fun <M : Message> FormPartScope<M>.OptionalMessageCheckbox(
  * Same as the other `OptionalMessageCheckbox`, suitable for being placed inside
  * a multipart version of `MessageForm` (see [MessageForm.MultipartContent]).
  *
- * @param text
- *         a checkbox's text.
+ * @param text A checkbox's text.
  */
 @Composable
 public fun <M : Message> MultipartFormScope<M>.OptionalMessageCheckbox(
     text: String
 ) {
     check(!form.valueRequired) {
-        "OptionalMessageCheckbox can only be used with forms whose valueRequired is false."
+        "`OptionalMessageCheckbox` can only be used with forms whose `valueRequired` is false."
     }
     CheckboxWithText(
         checked = form.enteringNonNullValue.value,
         onChange = { form.enteringNonNullValue.value = it },
-        text
+        text = text,
+        enabled = form.editorsEnabled.value
     )
 }

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -135,14 +135,13 @@ public class MoneyField : InputField<Money>() {
     override fun formatValue(value: Money): String = value.formatAmount()
 
     @Composable
-    @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
     override fun content() {
         val currentFocusManager = LocalFocusManager.current
 
         DropdownListBox<Currency> {
             items = filteredCurrencyItems
             selectedItem = selectedCurrency
-            onSelectItem = ::onSelectItem
+            onSelectItem = ::onSelectCurrencyItem
             expanded = this@MoneyField.expanded
             searchSelectionEnabled = true
             onSearchSelectionChange = { filteredCurrencyItems = getFilteredItems(it) }
@@ -234,10 +233,9 @@ public class MoneyField : InputField<Money>() {
     /**
      * Selects currency item from the drop-down menu.
      *
-     * @param item
-     *         a drop-down menu currency item to be selected.
+     * @param item A drop-down menu currency item to be selected.
      */
-    private fun onSelectItem(item: Currency?) {
+    private fun onSelectCurrencyItem(item: Currency?) {
         expanded.value = false
 
         if (item == null || selectedCurrency == item) {

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -29,7 +29,9 @@ package io.spine.chords.proto.money
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.spine.chords.core.ComponentSetup
@@ -62,12 +64,16 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
      *
      * @param interFieldPadding A horizontal distance between the payment card
      *   and bank account fields.
-     * @paRAM selectorsOffset A vertical distance between radio button selectors
+     * @param selectorsOffset A vertical distance between radio button selectors
      *   and their respective fields.
+     * @param optionalCheckboxOffset A vertical distance between the checkbox,
+     *   which is displayed when [valueRequired] is `false`, and the rest of
+     *   the controls within the component.
      */
     public data class Look(
         public var interFieldPadding: Dp = 40.dp,
-        public var selectorsOffset: Dp = 8.dp
+        public var selectorsOffset: Dp = 8.dp,
+        public var optionalCheckboxOffset: Dp = 12.dp
     )
 
     @Composable
@@ -77,6 +83,7 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
                 Row {
                     OptionalMessageCheckbox("Specify payment method")
                 }
+                Row(modifier = Modifier.height(look.selectorsOffset)) {}
             }
             OneOfFields(method) {
                 Row(horizontalArrangement = spacedBy(look.interFieldPadding)) {

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -73,7 +73,7 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
     public data class Look(
         public var interFieldPadding: Dp = 40.dp,
         public var selectorsOffset: Dp = 8.dp,
-        public var optionalCheckboxOffset: Dp = 12.dp
+        public var optionalCheckboxOffset: Dp = 16.dp
     )
 
     @Composable
@@ -83,7 +83,7 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
                 Row {
                     OptionalMessageCheckbox("Specify payment method")
                 }
-                Row(modifier = Modifier.height(look.selectorsOffset)) {}
+                Row(modifier = Modifier.height(look.optionalCheckboxOffset)) {}
             }
             OneOfFields(method) {
                 Row(horizontalArrangement = spacedBy(look.interFieldPadding)) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.51")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.52")


### PR DESCRIPTION
This PR introduces the functionality of disabling field editors inside `CommandForm` when the command posted by the form is being handled (until the completion event or until the respective timeout period elapses).

Besides, the PR contains the following:
- Adds the `enabled` property to `InputComponent` and ensures that implementations support it.
  - Corrected disabling of `DropdownSelector` so that it can't be opened when in the disabled state and its buttons are not highlighted on hovering.
- Made `CheckboxWithText` to pick up the form's `editorsEnabled` state from the context as well.
- Made submission buttons of `CommandDialog` and `CommandWizard` to be disabled while the command is being posted.
- Other misc. corrections that were made along the way:
  - Fixed focusing the form if the first form's field belongs to oneof. The oneof radio button wasn't focused in this case.
  - Simplifies form's usage in command wizard by using a declarative approach instead of an imperative form creation.
  - Revised the `MessageForm`'s KDoc a bit.