### PR TITLE
Rename the "component setup" term to "component usage"

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -40,7 +40,7 @@ import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.appshell.client
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
-import io.spine.chords.proto.form.MessageFormSetupBase
+import io.spine.chords.proto.form.MessageFormUsageBase
 import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
 import kotlinx.coroutines.TimeoutCancellationException
@@ -151,7 +151,7 @@ import kotlinx.coroutines.TimeoutCancellationException
  */
 public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
     public companion object :
-        MessageFormSetupBase<CommandMessage, CommandMessageForm<CommandMessage>>(
+        MessageFormUsageBase<CommandMessage, CommandMessageForm<CommandMessage>>(
             { CommandMessageForm() }
         ) {
 

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -93,7 +93,7 @@ import io.spine.chords.core.appshell.app
  *
  * A component's constructor would actually not need to be used directly in most
  * cases! Instead of using the constructor, such expressions work thanks to
- * the [invoke][ComponentSetup.invoke] operator function being declared
+ * the [invoke][ComponentUsage.invoke] operator function being declared
  * on the component's companion object, which is in particular required to
  * prevent creating a new component's instance upon each composition, and use
  * a cached instance instead.
@@ -145,7 +145,7 @@ import io.spine.chords.core.appshell.app
  *
  * - Create a subclass of [Component].
  *
- * - Add a companion object of type [ComponentSetup], which introduces
+ * - Add a companion object of type [ComponentUsage], which introduces
  *   the instance declaration API (which is technically being an invocation).
  *
  *   You can consider the presence of this companion object as a kind of
@@ -523,7 +523,7 @@ import io.spine.chords.core.appshell.app
  *
  * @constructor A constructor, which is used internally by the component's
  *   implementation (its companion object). As an application developer, use
- *   [companion object][ComponentSetup]'s [invoke][ComponentSetup.invoke]
+ *   [companion object][ComponentUsage]'s [invoke][ComponentUsage.invoke]
  *   operator for instantiating and rendering any specific
  *   component's implementation.
  *
@@ -540,7 +540,7 @@ public abstract class Component {
      *
      * In most cases this property would not need to be used by the
      * application's code directly, since it would be set automatically by
-     * [ComponentSetup.invoke] or an analogous component
+     * [ComponentUsage.invoke] or an analogous component
      * declaration function.
      */
     internal var props: ComponentProps<Component>? = null
@@ -643,7 +643,7 @@ public abstract class Component {
      *   lifecycle, including instance creation, property updates, and
      *   rendering, which removes the need to perform any of those steps
      *   explicitly. See the "Using class-based components" section in
-     *   [Component] class description, and the [ComponentSetup.invoke]
+     *   [Component] class description, and the [ComponentUsage.invoke]
      *   operator functions for details.
      *
      * - The component's composable content has to be specified by overriding
@@ -714,12 +714,12 @@ public abstract class Component {
  *
  * It generally doesn't need to be used directly when using the components,
  * since it would be implicitly created by a lambda that is passed to the
- * [ComponentSetup.invoke] function.
+ * [ComponentUsage.invoke] function.
  * It is a part of an internal implementation of [Component], and, in case of
  * some advanced components, can also be used when creating new components.
  *
  * @See Component
- * @see ComponentSetup.invoke
+ * @see ComponentUsage.invoke
  * @see Component.props
  */
 public fun interface ComponentProps <C: Component> {
@@ -742,16 +742,16 @@ public fun interface ComponentProps <C: Component> {
  * components" sections of the [Component] class for general information about
  * how class-based components are used in an application.
  *
- * In most cases custom class-based components would use [ComponentSetup]
+ * In most cases custom class-based components would use [ComponentUsage]
  * for to introduce the component's _instance declaration API_. However, in some
  * rare case a component might require different instance declaration API. In
  * such cases those companion objects would use this class as a base class for
  * a companion object instead.
  *
  * @param createInstance A lambda that should create a component's instance.
- * @see ComponentSetup
+ * @see ComponentUsage
  */
-public abstract class AbstractComponentSetup(
+public abstract class AbstractComponentUsage(
     protected val createInstance: (() -> Component)? = null
 ) {
 
@@ -862,11 +862,11 @@ public abstract class AbstractComponentSetup(
  * @constructor Creates a companion object for a component of type [C].
  * @param createInstance A lambda that should create a component's instance of
  *   type [C] with the given properties configuration callback.
- * @see AbstractComponentSetup
+ * @see AbstractComponentUsage
  */
-public open class ComponentSetup<C: Component>(
+public open class ComponentUsage<C: Component>(
     createInstance: () -> C
-) : AbstractComponentSetup(createInstance) {
+) : AbstractComponentUsage(createInstance) {
 
     /**
      * Declares an instance of component of type [C] with the respective

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -155,7 +155,7 @@ import kotlinx.coroutines.launch
 // All class's functions are better to have in this class.
 @Suppress("TooManyFunctions", "LargeClass")
 public class DropdownListBox<I> : Component() {
-    public companion object : AbstractComponentSetup() {
+    public companion object : AbstractComponentUsage() {
 
         /**
          * Declares an instance of [DropdownListBox] with the respective

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -87,7 +87,7 @@ public class AppWindow(
      * dialog that the user can interact with at a time. It's possible to
      * display nested dialogs though. That is, when some dialog is already
      * displayed, another dialog can be open (see
-     * [DialogSetup][io.spine.chords.core.layout.DialogSetup.open]), which means
+     * [DialogSetup][io.spine.chords.core.layout.DialogUsage.open]), which means
      * that the first dialog still remains opened, but cannot be interacted with
      * until the second one (which is displayed on top of it) is closed.
      *

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.window.application
 import io.spine.chords.core.layout.Dialog
 import io.spine.chords.core.layout.ConfirmationDialog
-import io.spine.chords.core.layout.DialogSetup
+import io.spine.chords.core.layout.DialogUsage
 import io.spine.chords.core.layout.DialogDisplayMode
 import io.spine.chords.core.writeOnce
 import java.awt.Dimension
@@ -335,7 +335,7 @@ public class ApplicationUI(private val appWindow: AppWindow) {
      * @param dialog The [Dialog] instance, which needs to be displayed.
      *
      * @see Dialog
-     * @see DialogSetup
+     * @see DialogUsage
      * @see closeDialog
      */
     internal fun openDialog(dialog: Dialog) {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -14,7 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.spine.chords.core.AbstractComponentSetup
+import io.spine.chords.core.AbstractComponentUsage
 import io.spine.chords.core.ComponentProps
 import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.future.await
@@ -24,7 +24,7 @@ import kotlinx.coroutines.future.await
  * (e.g. approve or deny some action).
  */
 public class ConfirmationDialog : Dialog() {
-    public companion object : AbstractComponentSetup({ ConfirmationDialog() }) {
+    public companion object : AbstractComponentUsage({ ConfirmationDialog() }) {
 
         /**
          * Displays the confirmation dialog, and waits until the user

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -72,7 +72,7 @@ import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
-import io.spine.chords.core.AbstractComponentSetup
+import io.spine.chords.core.AbstractComponentUsage
 import io.spine.chords.core.Component
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.core.appshell.app
@@ -90,7 +90,7 @@ private val submitShortcutKey = Ctrl(Enter.key)
  * submitting data.
  *
  * Note that an implementation of this class has to add a companion object of
- * type [DialogSetup]. Here's an example of how a custom dialog can be created:
+ * type [DialogUsage]. Here's an example of how a custom dialog can be created:
  *
  * ```
  * public class MyDialog : Dialog() {
@@ -302,7 +302,7 @@ public abstract class Dialog : Component() {
      * some reason.
      *
      * In most cases the most convenient way to open a dialog would be using its
-     * companion object's [open][DialogSetup.open] method instead, like this:
+     * companion object's [open][DialogUsage.open] method instead, like this:
      *
      * ```
      *     MyDialog.open()
@@ -703,9 +703,9 @@ internal class LightweightDisplayMode(
  *
  * @see Dialog
  */
-public open class DialogSetup<D: Dialog>(
+public open class DialogUsage<D: Dialog>(
     createInstance: () -> D
-) : AbstractComponentSetup(createInstance) {
+) : AbstractComponentUsage(createInstance) {
 
     /**
      * Displays the modal dialog [D].

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/CustomMessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/CustomMessageForm.kt
@@ -47,7 +47,7 @@ import io.spine.chords.core.Component
  *   constructor's parameter.
  *
  * - Add a companion object of type
- *   [ComponentSetup][io.spine.chords.core.ComponentSetup] to ensure that the
+ *   [ComponentSetup][io.spine.chords.core.ComponentUsage] to ensure that the
  *   component can actually be used (like any other class-based [Component]]).
  *
  * - Override either [customContent] (for rendering ordinary singlepart forms),

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
@@ -29,7 +29,7 @@ package io.spine.chords.proto.form
 import androidx.compose.runtime.Composable
 import com.google.protobuf.Message
 import io.spine.chords.core.ComponentProps
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputComponent
 import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageFieldValue
@@ -117,7 +117,7 @@ import io.spine.chords.runtime.MessageFieldValue
  *   instance. It is invoked before each recomposition of the component.
  * @return A component's instance that has been created for this
  *   declaration site.
- * @see ComponentSetup.invoke
+ * @see ComponentUsage.invoke
  */
 context(FormFieldsScope<M>)
 @Composable
@@ -125,7 +125,7 @@ public operator fun <
         C : InputComponent<V>,
         M : Message,
         V : MessageFieldValue
-> ComponentSetup<C>.invoke(
+> ComponentUsage<C>.invoke(
     field: MessageField<M, V>,
     props: ComponentProps<C>? = null
 ): C {
@@ -145,7 +145,7 @@ public operator fun <
  *
  * A regular way to both lazily instantiate and render a component is via
  * the respective component's companion object's `invoke` operator (see the
- * [ComponentSetup.invoke] operator functions).
+ * [ComponentUsage.invoke] operator functions).
  *
  * @receiver A context introduced by the parent form whose fields need to
  *   be edited.

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -430,7 +430,7 @@ import io.spine.validate.ValidationException
 // Seems all class's functions are better to have in this class.
 @Suppress("TooManyFunctions")
 public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
-    public companion object : MessageFormSetupBase<Message, MessageForm<Message>>(
+    public companion object : MessageFormUsageBase<Message, MessageForm<Message>>(
         { MessageForm() }
     ) {
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormUsageBase.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormUsageBase.kt
@@ -29,7 +29,7 @@ package io.spine.chords.proto.form
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import com.google.protobuf.Message
-import io.spine.chords.core.AbstractComponentSetup
+import io.spine.chords.core.AbstractComponentUsage
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.runtime.MessageField
 import io.spine.protobuf.ValidatingBuilder
@@ -43,11 +43,11 @@ import io.spine.protobuf.ValidatingBuilder
  * actual implementation.
  *
  * @see io.spine.chords.core.Component
- * @see io.spine.chords.core.ComponentSetup
+ * @see io.spine.chords.core.ComponentUsage
  */
-public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
+public open class MessageFormUsageBase<M: Message, F: MessageForm<M>>(
     createInstance: () -> F
-) : AbstractComponentSetup({ createInstance() }) {
+) : AbstractComponentUsage({ createInstance() }) {
 
     /**
      * Declares a `MessageForm` instance, which is not bound to a parent

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OneofRadioButton.kt
@@ -28,7 +28,7 @@ package io.spine.chords.proto.form
 
 import androidx.compose.runtime.Composable
 import com.google.protobuf.Message
-import io.spine.chords.core.AbstractComponentSetup
+import io.spine.chords.core.AbstractComponentUsage
 import io.spine.chords.core.FocusRequestDispatcher
 import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.primitive.RadioButtonWithText
@@ -46,7 +46,7 @@ import io.spine.protobuf.ValidatingBuilder
  * @param F A type of the oneof field.
  */
 public class OneofRadioButton<M : Message, F: MessageFieldValue> : FocusableComponent() {
-    public companion object : OneofRadioButtonSetup()
+    public companion object : OneofRadioButtonUsage()
 
     /**
      * The scope where this `OneofRadioButton` is declared.
@@ -82,7 +82,7 @@ public class OneofRadioButton<M : Message, F: MessageFieldValue> : FocusableComp
     }
 }
 
-public open class OneofRadioButtonSetup : AbstractComponentSetup(
+public open class OneofRadioButtonUsage : AbstractComponentUsage(
     { OneofRadioButton<Message, MessageFieldValue>() }
 ) {
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/BankAccountField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/BankAccountField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.money
 
 import io.spine.chords.proto.form.vBuildBasedParser
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.proto.value.money.BankAccount
 
@@ -35,7 +35,7 @@ import io.spine.chords.proto.value.money.BankAccount
  * A field that allows entering a bank account number.
  */
 public class BankAccountField : InputField<BankAccount>() {
-    public companion object : ComponentSetup<BankAccountField>({ BankAccountField() })
+    public companion object : ComponentUsage<BankAccountField>({ BankAccountField() })
 
     init {
         label = "Bank account"

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.text.font.FontFamily.Companion.Monospace
 import androidx.compose.ui.text.font.FontWeight.Companion.SemiBold
 import androidx.compose.ui.text.input.getSelectedText
 import androidx.compose.ui.unit.dp
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.DropdownListBox
 import io.spine.chords.core.DropdownListBoxScope
 import io.spine.chords.core.keyboard.KeyRange.Companion.Digit
@@ -85,7 +85,7 @@ private val defaultCurrency = USD
  * A field that allows entering [Money] values.
  */
 public class MoneyField : InputField<Money>() {
-    public companion object : ComponentSetup<MoneyField>({ MoneyField() })
+    public companion object : ComponentUsage<MoneyField>({ MoneyField() })
 
     /**
      * A list of item values to choose from.

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentCardNumberField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentCardNumberField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.money
 
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser.Companion.DigitsOnly
 import io.spine.chords.core.InputReviser.Companion.maxLength
@@ -65,7 +65,7 @@ private val PaymentCardNumberKt.maxValueLength get() = 19
  * A field that allows entering a payment card number.
  */
 public class PaymentCardNumberField : InputField<PaymentCardNumber>() {
-    public companion object : ComponentSetup<PaymentCardNumberField>({
+    public companion object : ComponentUsage<PaymentCardNumberField>({
         PaymentCardNumberField()
     })
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -34,7 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.ValidationErrorText
 import io.spine.chords.proto.form.CustomMessageForm
 import io.spine.chords.proto.form.FormPartScope
@@ -52,7 +52,7 @@ import io.spine.chords.proto.value.money.PaymentMethodDef.paymentCard
 public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
     { PaymentMethod.newBuilder() }
 ) {
-    public companion object : ComponentSetup<PaymentMethodEditor>({ PaymentMethodEditor() })
+    public companion object : ComponentUsage<PaymentMethodEditor>({ PaymentMethodEditor() })
 
     /**
      * Identifies the component's appearance parameters.

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/EmailField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/EmailField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.core.ValueParseException
 import io.spine.net.EmailAddress
@@ -40,7 +40,7 @@ private const val EmailRegex = """^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}${'$'}"""
  * An input field that allows editing a [EmailAddress] field.
  */
 public class EmailField : InputField<EmailAddress>() {
-    public companion object : ComponentSetup<EmailField>({ EmailField() })
+    public companion object : ComponentUsage<EmailField>({ EmailField() })
 
     init {
         label = "Email"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/InternetDomainField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/InternetDomainField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.core.exceptionBasedParser
 import io.spine.net.InternetDomain
@@ -36,7 +36,7 @@ import io.spine.net.InternetDomains
  * A field that allows entering an [InternetDomain] value.
  */
 public class InternetDomainField : InputField<InternetDomain>() {
-    public companion object : ComponentSetup<InternetDomainField>(
+    public companion object : ComponentUsage<InternetDomainField>(
         { InternetDomainField() }
     )
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.net
 
 import androidx.compose.ui.input.key.KeyEvent
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser
 import io.spine.chords.core.RawTextContent
@@ -44,7 +44,7 @@ import io.spine.chords.proto.value.net.parse
  * A field for entering an IP address.
  */
 public class IpAddressField : InputField<IpAddress>() {
-    public companion object : ComponentSetup<IpAddressField>({ IpAddressField() })
+    public companion object : ComponentUsage<IpAddressField>({ IpAddressField() })
 
     init {
         label = "IP address"

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/UrlField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/UrlField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.net
 
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser.Companion.NonWhitespaces
 import io.spine.chords.core.exceptionBasedParser
@@ -37,7 +37,7 @@ import io.spine.chords.proto.value.net.parse
  * A field that allows entering a URL.
  */
 public class UrlField : InputField<Url>() {
-    public companion object : ComponentSetup<UrlField>({ UrlField() })
+    public companion object : ComponentUsage<UrlField>({ UrlField() })
 
     init {
         label = "URL"

--- a/proto/src/main/kotlin/io/spine/chords/proto/people/PersonNameField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/people/PersonNameField.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.proto.people
 
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.InputField
 import io.spine.chords.core.exceptionBasedParser
 import io.spine.people.PersonName
@@ -37,7 +37,7 @@ import io.spine.chords.proto.value.person.parse
  * A field that allows editing a [PersonName] value.
  */
 public class PersonNameField : InputField<PersonName>() {
-    public companion object : ComponentSetup<PersonNameField>({ PersonNameField() })
+    public companion object : ComponentUsage<PersonNameField>({ PersonNameField() })
 
     init {
         label = "Person name"

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.input.getSelectedText
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
-import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.ComponentUsage
 import io.spine.chords.core.keyboard.KeyRange
 import io.spine.chords.core.keyboard.matches
 import io.spine.chords.core.InputField
@@ -75,7 +75,7 @@ public typealias DateTimePattern = String
  * A field that allows specifying date and time.
  */
 public class DateTimeField : InputField<Timestamp>() {
-    public companion object : ComponentSetup<DateTimeField>({ DateTimeField() })
+    public companion object : ComponentUsage<DateTimeField>({ DateTimeField() })
 
     /**
      * A pattern for parsing and formatting a date component (as used with


### PR DESCRIPTION
This (so far draft) PR considers the idea of renaming the "component setup" term (which is used for naming a hierarchy of classes, which are used as compont class's companion objects) into the "component usage" term.

The reasoning behind this renaming proposition:
- **The term "setup"** can feel misleading in some aspects. While we imply "setup" to be a synonym (or a metaphor) for "embedding an instance of component into the composition":
  - First, it doesn't feel to match the notion of "embedding an instance" nicely: it's not a general term encompasses the notion of "embedding an instance" as one of its variants, but the one that pretends to be specific and, being that, still feels to be somewhat off.
  - There can be more scenarios than "embedding an instance" (e.g. `MessageForm` also provides an extra `create` function for creating a form's instance), or even some components that don't include the "embedding an instance" scenario at all (e.g. `ConfirmationDialog` is currently just used imperatively, and its companion object contains the respective `ask` function for that purpose).
  
    Thus the "setup" metaphor doesn't match the entire variety of usage scenarios in general.

- **The term "usage"** on the other hand:
  - Still as concise so the names are equally compact.
  - Represents a general term that reflects the idea that this object introduces a way of how a component's class can actually be _used_ (an entry point to using the component). 
  
    It also appears to suit both usage scenarios: when components need to be used by declaring their instance, and when they need to be used with some imperative API (e.g. like `create` for forms, or the `open` and `ask` APIs of various dialog components).