### PR TITLE
Handle command reaction timeout in `CommandMessageForm`

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.MutableState
 import com.google.protobuf.Message
 import io.spine.base.CommandMessage
 import io.spine.base.EntityState
+import io.spine.base.Error
 import io.spine.base.EventMessage
 import io.spine.base.EventMessageField
 import io.spine.core.UserId
@@ -77,6 +78,8 @@ import java.util.concurrent.CompletableFuture
      * Posts a command to the server.
      *
      * @param cmd A command that has to be posted.
+     * @throws CommandPostingError If some error has occurred during posting and
+     *   acknowledging the command on the server.
      */
     public fun command(cmd: CommandMessage)
 
@@ -157,4 +160,34 @@ public interface EventSubscription<E: EventMessage> {
      *   by the implementation.
      */
     public suspend fun awaitEvent(): E
+}
+
+/**
+ * Signifies an error that has occurred during the process of posting the
+ * command and acknowledging it on the server.
+ */
+public open class CommandPostingError(message: String? = null, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+{
+    public companion object {
+        private const val serialVersionUID: Long = 3555883899622560720L
+    }
+}
+
+/**
+ * Signifies an error that has occurred when delivering events.
+ */
+public class StreamingError(error: Throwable) : CommandPostingError(cause = error) {
+    public companion object {
+        private const val serialVersionUID: Long = -5438430153458733051L
+    }
+}
+
+/**
+ * Signifies an error that has occurred on the server (e.g. a validation error).
+ */
+public class ServerError(public val error: Error) : CommandPostingError(error.message) {
+    public companion object {
+        private const val serialVersionUID: Long = -5438430153458733051L
+    }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -132,9 +132,9 @@ import java.util.concurrent.CompletableFuture
      */
     public fun <E : EventMessage> observeEvent(
         event: Class<E>,
-        onEmit: (E) -> Unit,
         field: EventMessageField,
-        fieldValue: Message
+        fieldValue: Message,
+        onEmit: (E) -> Unit
     )
 }
 

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -50,8 +50,10 @@ private const val ReactionTimeoutMillis = 15_000L
 /**
  * Provides API to interact with the application server via gRPC.
  *
- * @param host The host of the application server to which client should connect.
- * @param port The port on which the application server is listening for gRPC connections.
+ * @param host The host of the application server to which client
+ *   should connect.
+ * @param port The port on which the application server is listening for
+ *   gRPC connections.
  * @param user The callback that should return the user ID on whose behalf
  *   the `DesktopClient` should send requests to the server.
  *   If the callback return `null` the client will send requests
@@ -84,10 +86,10 @@ public class DesktopClient(
      * as well.
      *
      * @param entityClass A class of entities that should be read and observed.
-     * @param targetList A [MutableState] that contains a list whose content should be
-     *   populated and kept up to date by this function.
-     * @param entityIdField Reads the value of the entity's field that can uniquely identify
-     *   an entity.
+     * @param targetList A [MutableState] that contains a list whose content
+     *   should be populated and kept up to date by this function.
+     * @param entityIdField Reads the value of the entity's field that can
+     *   uniquely identify an entity.
      */
     public override fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
@@ -144,7 +146,8 @@ public class DesktopClient(
      *   the command.
      * @param field A field that should be used for identifying the event to be
      *   awaited for.
-     * @param fieldValue A value of the field that identifies the event to be awaited for.
+     * @param fieldValue A value of the field that identifies the event to be
+     *   awaited for.
      * @return An event specified in the parameters, which was emitted in
      *   response to the command.
      * @throws kotlinx.coroutines.TimeoutCancellationException
@@ -234,8 +237,8 @@ public class DesktopClient(
      *
      * @param targetList A [MutableState] that contains a list to be updated.
      * @param entity An item that has to be merged into the list.
-     * @param entityIdField A function that, given a list item, or a value of [entity],
-     *   returns the value of its field, which uniquely identifies
+     * @param entityIdField A function that, given a list item, or a value of
+     *   [entity], returns the value of its field, which uniquely identifies
      *   the respective instance.
      */
     private fun <E : EntityState> updateList(

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -121,7 +121,7 @@ public class DesktopClient(
         if (entities.isEmpty()) {
             return null
         }
-        return entities[0];
+        return entities[0]
     }
 
     /**
@@ -182,12 +182,10 @@ public class DesktopClient(
         val eventReceival = CompletableFuture<E>()
         observeEvent(
             event = event,
-            onEmit = { evt ->
-                eventReceival.complete(evt)
-            },
             field = field,
-            fieldValue = fieldValue
-        )
+            fieldValue = fieldValue) { evt ->
+                eventReceival.complete(evt)
+            }
         return FutureEventSubscription(eventReceival)
     }
 
@@ -201,17 +199,17 @@ public class DesktopClient(
      */
     override fun <E : EventMessage> observeEvent(
         event: Class<E>,
-        onEmit: (E) -> Unit,
         field: EventMessageField,
-        fieldValue: Message
+        fieldValue: Message,
+        onEmit: (E) -> Unit
     ) {
         clientRequest()
             .subscribeToEvent(event)
-            ?.where(eq(field, fieldValue))
-            ?.observe { evt ->
+            .where(eq(field, fieldValue))
+            .observe { evt ->
                 onEmit(evt)
             }
-            ?.post()
+            .post()
     }
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -28,6 +28,7 @@ package io.spine.chords.client.form
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -333,6 +334,8 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
     override val shouldEnableEditors: Boolean
         get() = super.shouldEnableEditors && (!posting || !disableOnPosting)
 
+    @Composable
+    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         check(this::eventSubscription.isInitialized) {

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -40,7 +40,6 @@ import io.spine.chords.client.appshell.client
 import io.spine.chords.core.ComponentProps
 import io.spine.chords.core.appshell.app
 import io.spine.chords.core.layout.MessageDialog.Companion.showMessage
-import io.spine.chords.core.writeOnce
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.MessageForm
 import io.spine.chords.proto.form.MessageFormSetupBase
@@ -337,7 +336,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
     override val shouldEnableEditors: Boolean
         get() = super.shouldEnableEditors && (!posting || !disableOnPosting)
 
-    private var coroutineScope: CoroutineScope by writeOnce()
+    private lateinit var coroutineScope: CoroutineScope
 
     override fun initialize() {
         super.initialize()

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -28,19 +28,17 @@ package io.spine.chords.client.form
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import io.spine.chords.core.appshell.app
 import io.spine.base.CommandMessage
 import io.spine.base.EventMessage
-import io.spine.chords.core.ComponentProps
 import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.appshell.client
-import io.spine.chords.core.layout.MessageDialog
+import io.spine.chords.core.ComponentProps
+import io.spine.chords.core.appshell.app
 import io.spine.chords.core.layout.MessageDialog.Companion.showMessage
 import io.spine.chords.core.writeOnce
 import io.spine.chords.proto.form.FormPartScope
@@ -50,7 +48,6 @@ import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.launch
 
 /**
  * A form that allows entering a value of a command message and posting
@@ -342,15 +339,18 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
 
     private var coroutineScope: CoroutineScope by writeOnce()
 
-    @Composable
-    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         check(this::eventSubscription.isInitialized) {
             "CommandMessageForm's `eventSubscription` property must " +
             "be specified."
         }
+    }
+
+    @Composable
+    override fun content() {
         coroutineScope = rememberCoroutineScope()
+        super.content()
     }
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -370,7 +370,8 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      *   an adequate delay from user's perspective, this method
      *   throws [TimeoutCancellationException].
      *
-     * @param responseHandler
+     * @param responseHandler Specifies the way that command response is
+     *   handled, e.g. the way how unexpected outcomes are processed.
      * @return `true` if the command was successfully built without any
      *   validation errors, and `false` if the command message could not be
      *   successfully built from the currently entered data (validation errors

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -60,11 +60,11 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
     private lateinit var commandMessageForm: CommandMessageForm<C>
 
     /**
-     * Creates the [commandMessageForm] in which the command field editors
-     * are rendered.
+     * Creates and renders the [commandMessageForm], and then delegates the
+     * rendering of the actual form's content to the [content] method.
      */
     @Composable
-    protected override fun contentSection() {
+    protected final override fun contentSection() {
         commandMessageForm = CommandMessageForm(
             ::createCommandBuilder,
             onBeforeBuild = ::beforeBuild,
@@ -124,14 +124,12 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      * fields have already been set from all form's field editors,
      * which currently have valid values.
      */
-    protected open fun beforeBuild(builder: B): B {
-        return builder
-    }
+    protected open fun beforeBuild(builder: B) {}
 
     /**
      * Posts the command message [C] created in this dialog.
      */
-    protected override suspend fun submitForm(): Boolean {
+    protected override suspend fun submitContent(): Boolean {
         return commandMessageForm.postCommand()
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -64,7 +64,7 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      * are rendered.
      */
     @Composable
-    protected override fun formContent() {
+    protected override fun contentSection() {
         commandMessageForm = CommandMessageForm(
             ::createCommandBuilder,
             onBeforeBuild = ::beforeBuild,

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -37,6 +37,7 @@ import io.spine.base.EventMessage
 import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.core.layout.Dialog
+import io.spine.chords.core.layout.OkCancelDialog
 import io.spine.chords.proto.form.FormFieldsScope
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.ValidationDisplayMode.MANUAL
@@ -50,7 +51,7 @@ import io.spine.protobuf.ValidatingBuilder
  * @param B A type of the command message builder.
  */
 public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>>
-    : Dialog() {
+    : OkCancelDialog() {
 
     /**
      * The [CommandMessageForm] used as a container for the message field editors.

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -37,7 +37,7 @@ import io.spine.base.EventMessage
 import io.spine.chords.client.EventSubscription
 import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.core.layout.Dialog
-import io.spine.chords.core.layout.OkCancelDialog
+import io.spine.chords.core.layout.SubmitOrCancelDialog
 import io.spine.chords.proto.form.FormFieldsScope
 import io.spine.chords.proto.form.FormPartScope
 import io.spine.chords.proto.form.ValidationDisplayMode.MANUAL
@@ -51,10 +51,11 @@ import io.spine.protobuf.ValidatingBuilder
  * @param B A type of the command message builder.
  */
 public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>>
-    : OkCancelDialog() {
+    : SubmitOrCancelDialog() {
 
     /**
-     * The [CommandMessageForm] used as a container for the message field editors.
+     * The [CommandMessageForm] used as a container for the message
+     * field editors.
      */
     private lateinit var commandMessageForm: CommandMessageForm<C>
 
@@ -108,8 +109,8 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      * response to handling that command.
      *
      * @param command A command, which is going to be posted.
-     * @return A subscription to the event that is expected to arrive in response
-     *         to handling [command]
+     * @return A subscription to the event that is expected to arrive in
+     *   response to handling [command].
      */
     protected abstract fun subscribeToEvent(command: C):
             EventSubscription<out EventMessage>

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -455,17 +455,18 @@ import io.spine.chords.core.appshell.app
  *      was invoked in the same place where the component's instance
  *      is declared).
  *
- *    - **Properties update + [initialize]** — when the component is composed
- *      (rendered for the first time):
+ *    - **Properties update([updateProps]) + [initialize]** — when the component
+ *      is composed (rendered for the first time):
  *
  *      - First, the component's properties are updated (including the
- *      [application-wide][Application] ones, and instance-specific ones)
+ *      [application-wide][Application] ones, and instance-specific ones).
  *
  *      - Then, the component's [initialize] method is called.
  *
- * -  Each time the component is rendered (composed or recomposed):
+ * -  Each time the component is rendered (composed or recomposed,
+ *    see [Content]):
  *
- *    - **Properties update**. This consists of two parts:
+ *    - **Properties update** (see [updateProps]). This consists of two parts:
  *
  *      - Application-wide properties that are applicable to this component type
  *        are applied. See the "Customizing default values for different
@@ -692,8 +693,8 @@ public abstract class Component {
      * Updates property values and renders the composable content that
      * represents this component.
      *
-     * NOTE: in most cases this method is not expected to be invoked or
-     * overridden by application developers, and is used internally within
+     * NOTE: in most cases this method is not expected to be invoked by
+     * application developers, and is used internally within
      * the component's implementation.
      *
      * - Instead of invoking this method explicitly, the component instance
@@ -708,7 +709,7 @@ public abstract class Component {
      *   the [content] method.
      */
     @Composable
-    public open fun Content(): Unit = recompositionWorkaround {
+    public fun Content(): Unit = recompositionWorkaround {
         updateProps()
         if (!initialized.value) {
             initialize()

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -622,15 +622,7 @@ public abstract class Component {
      * [props] callback (which is passed along with component instance's
      * declaration) has been invoked for the first time, and before
      * the component's composable content is rendered for the first time.
-     *
-     * This function is declared as being a read-only composable one for
-     * the implementations to be able to access the composition-related data,
-     * such as various [MaterialTheme][androidx.compose.material3.MaterialTheme]
-     * properties and other
-     * [CompositionLocal][androidx.compose.runtime.CompositionLocal] values.
      */
-    @Composable
-    @ReadOnlyComposable
     protected open fun initialize() {
         check(!initialized.value) {
             "Component.initialize() shouldn't be invoked more than once."

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -101,9 +101,10 @@ import io.spine.chords.core.appshell.app
  * ### Preferred instance declarations style
  *
  * Note that the component instance declaration examples above are technically
- * a shorthand notation for using the `invoke` function on the component's
- * companion object explicitly. So, theoretically, the same examples could be
- * written like this:
+ * a shorthand notation for using the
+ * [`invoke` operator function](https://kotlinlang.org/docs/operator-overloading.html#invoke-operator)
+ * on the component's companion object explicitly. So, theoretically, the same
+ * examples could be written like this:
  *
  * ```kotlin
  *     SomeComponent.Companion.invoke({
@@ -124,7 +125,7 @@ import io.spine.chords.core.appshell.app
  * ```
  *
  * Nevertheless, such explicit usage of `Companion` or `invoke` is not
- * recommended, and a shorthand form is recommended instead:
+ * recommended, and **a shorthand syntax is recommended** instead:
  *
  * ```kotlin
  *     SomeComponent {
@@ -354,7 +355,7 @@ import io.spine.chords.core.appshell.app
  *     }
  * ```
  *
- * # When to write class-based and function-based components?
+ * # When to write class-based components or function-based ones?
  *
  * A class-based components writing style is only a convenience that can be used
  * if it provides some benefits relative to function-based ones. Function-based
@@ -417,6 +418,61 @@ import io.spine.chords.core.appshell.app
  *   implementation boundaries more explicit, and also makes all component's
  *   data (stored in its properties) to be implicitly available in each of such
  *   functions without explicitly passing them around with parameters.
+ *
+ * # Component's lifecycle
+ *
+ * In most cases, what you would typically need to do when developing a new
+ * component, is just to implement the [content] method to specify how the
+ * component is rendered (similar to how you would do when writing a
+ * function-based component), and specify the component's companion object, as
+ * is generally described in the "Implementing class-based components"
+ * section above.
+ *
+ * Nevertheless, the [Component] class provides some extra `open` functions,
+ * which can be overridden to customize certain points in the
+ * component's lifecycle. Below is a description of the overall component's
+ * lifecycle (listed in the order of running the respective stages), including
+ * such overridable lifecycle methods.
+ *
+ * - Once per each component's instance:
+ *
+ *    - **Class's constructor** — typically, not expected to accept any
+ *      parameters, and doesn't need to be called directly, since component
+ *      instances are _declared_ by invoking component's companion object
+ *      instead (see the "Component instance declarations vs constructors"
+ *      section above).
+ *
+ *      Nevertheless, it is useful to understand that a new component's instance
+ *      is implicitly created during the component's composition, and the same
+ *      instance is then kept and being reused during subsequent recompositions.
+ *      In other words it happens when it was not "visible" (technically not
+ *      called in respective composable function before this), and it becomes
+ *      "visible" (gets called in some composable function for the first time,
+ *      or after being hidden by some conditional execution).
+ *
+ *      Formally, life span of the component's instance is repeats the life span
+ *      of the value calculated and remembered by the [remember] function (if it
+ *      was invoked in the same place where the component's instance
+ *      is declared).
+ *
+ *    - **Properties update + [initialize]** — when the component is composed
+ *      (rendered for the first time), first, the component's properties are
+ *      updated (as specified with `props` specified when [declaring a
+ *      component's instance][ComponentSetup.invoke]), and then the component's
+ *      [initialize] method is called.
+ *
+ * -  Each time the component is rendered (composed or recomposed):
+ *
+ *    - **Properties update**. This basically assigns property values as
+ *      specified with the `props` parameter specified when [declaring a
+ *      component's instance][ComponentSetup.invoke].
+ *
+ *    - **[beforeComposeContent]** — some optional logic that needs to be done
+ *      before the component is rendered.
+ *
+ *    - **[content]** — the component's content, which is analogous to the
+ *      content of a function-based component (see "Implementing
+ *      class-based components").
  *
  * # Converting function-based components into class-based ones
  *
@@ -573,6 +629,8 @@ public abstract class Component {
      * properties and other
      * [CompositionLocal][androidx.compose.runtime.CompositionLocal] values.
      */
+    @Composable
+    @ReadOnlyComposable
     protected open fun initialize() {
         check(!initialized.value) {
             "Component.initialize() shouldn't be invoked more than once."

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -169,7 +169,7 @@ import io.spine.chords.core.appshell.app
  *   each component's configurable public property (except lambda-typed ones) in
  *   the following style:
  *   ```
- *       public var someProp by mutableStateOf<String>("")
+ *       public var someProp: String by mutableStateOf("")
  *   ```
  *
  *   Note the `String` type parameter of `mutableStateOf` above, which
@@ -186,7 +186,7 @@ import io.spine.chords.core.appshell.app
  *             HelloComponent()
  *         })
  *
- *         public var name by mutableStateOf<String>("")
+ *         public var name: String by mutableStateOf("")
  *
  *         @Composable
  *         override fun content() {
@@ -236,9 +236,9 @@ import io.spine.chords.core.appshell.app
  *         })
  *
  *         // Add some more component customization properties...
- *         public var style by mutableStateOf<TextStyle>(MaterialTheme.typography.bodyMedium)
- *         public var color by mutableStateOf<Color>(MaterialTheme.colorScheme.onBackground)
- *         public var modifier by mutableStateOf<Modifier>(Modifier)
+ *         public var style: TextStyle by mutableStateOf(MaterialTheme.typography.bodyMedium)
+ *         public var color: Color by mutableStateOf(MaterialTheme.colorScheme.onBackground)
+ *         public var modifier: Modifier by mutableStateOf(Modifier)
  *
  *         init {
  *             // Amend default values for parent class's properties if needed...
@@ -456,16 +456,24 @@ import io.spine.chords.core.appshell.app
  *      is declared).
  *
  *    - **Properties update + [initialize]** — when the component is composed
- *      (rendered for the first time), first, the component's properties are
- *      updated (as specified with `props` specified when [declaring a
- *      component's instance][ComponentSetup.invoke]), and then the component's
- *      [initialize] method is called.
+ *      (rendered for the first time):
+ *
+ *      - First, the component's properties are updated (including the
+ *      [application-wide][Application] ones, and instance-specific ones)
+ *
+ *      - Then, the component's [initialize] method is called.
  *
  * -  Each time the component is rendered (composed or recomposed):
  *
- *    - **Properties update**. This basically assigns property values as
- *      specified with the `props` parameter specified when [declaring a
- *      component's instance][ComponentSetup.invoke].
+ *    - **Properties update**. This consists of two parts:
+ *
+ *      - Application-wide properties that are applicable to this component type
+ *        are applied. See the "Customizing default values for different
+ *        component types" section of the [Application] class's documentation.
+ *
+ *      - Instance-specific properties are applied. This basically assigns
+ *        property values as specified with the `props` parameter specified when
+ *        [declaring a component's instance][ComponentSetup.invoke].
  *
  *    - **[beforeComposeContent]** — some optional logic that needs to be done
  *      before the component is rendered.

--- a/core/src/main/kotlin/io/spine/chords/core/Delegates.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Delegates.kt
@@ -32,9 +32,44 @@ import kotlin.reflect.KProperty
 /**
  * Creates a delegate for defining a property that can be set only once.
  *
- * Usage example:
+ * More precisely, it has two variants of functioning, depending on the value of
+ * [identicalRewritesAllowed]. In either mode, reading a property before it has been
+ * assigned for the first time throws [IllegalStateException], and the first
+ * write of the property defines the value that the property will take for its
+ * entire lifetime.
+ *
+ * What [identicalRewritesAllowed] affects is it is set to `true` (the default
+ * value), then writing the property after it has been written for the first
+ * time can be performed as long as the value being set is referentially equal
+ * to the value written to it for the first time. Any attempt to write a value,
+ * which is not referentially equal to the first written value leads
+ * to throwing [IllegalStateException].
+ *
+ * If [identicalRewritesAllowed] is set to `false` though, any attempt to write
+ * the property after it has been written for the first time leads
+ * to [IllegalStateException].
+ *
+ * Usage example (with `identicalRewritesAllowed` equal to `true`):
  * ```
- *   var prop: String by writeOnce()
+ *   var prop: String by writeOnce() // `identicalRewritesAllowed` is `true` by default.
+ *
+ *   // `print(prop)` would throw `IllegalStateException` here, when
+ *   // the property is read before it is set for the first time.
+ *
+ *   prop = "Hello"
+ *   print(prop) // Prints "Hello" as expected.
+ *
+ *   prop = "Hello" // Nothing happens.
+ *   prop = "Hello" // Nothing happens.
+ *   prop = "Something else" // Throws `IllegalStateException`.
+ *
+ *   // ... if the property survives the exception ...
+ *   print(prop) // Still prints "Hello" despite additional set attempt(s).
+ * ```
+ *
+ * Usage example (with `identicalRewritesAllowed` equal to `false`):
+ * ```
+ *   var prop: String by writeOnce(false)
  *
  *   // `print(prop)` would throw `IllegalStateException` here, when
  *   // the property is read before it is set for the first time.
@@ -44,27 +79,39 @@ import kotlin.reflect.KProperty
  *
  *   prop = "Something else" // Throws `IllegalStateException` if set again.
  *
- *   // ...
+ *   // ... if the property survives the exception ...
  *   print(prop) // Still prints "Hello" despite additional set attempt(s).
  * ```
  *
- * @param T
- *         the property's type.
- * @return a respective [ReadWriteProperty], which has to be used as
- *         a property delegate.
+ * @param T The property's type.
+ *
+ * @param identicalRewritesAllowed If `true` (default), repeated writes of
+ *   the same value that was assigned initially are allowed. Otherwise, any
+ *   attempt to write a property with any value after it has been written for
+ *   the first time throw [IllegalStateException].
+ * @return A respective [ReadWriteProperty], which has to be used as
+ *   a property delegate.
  */
-public fun <T : Any> writeOnce(): ReadWriteProperty<Any?, T> = object : ReadWriteProperty<Any?, T> {
-    private var value: T? = null
+public fun <T : Any> writeOnce(
+    identicalRewritesAllowed: Boolean = true
+): ReadWriteProperty<Any?, T> =
+    object : ReadWriteProperty<Any?, T> {
+        private var value: T? = null
 
-    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        check(value != null) { "Value is being read but it hasn't been set yet." }
-        return value!!
-    }
-
-    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
-        check(this.value == null) {
-            "Value has already been set earlier and cannot be set more than once."
+        override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+            check(value != null) { "Value is being read but it hasn't been set yet." }
+            return value!!
         }
-        this.value = value
+
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+            check(this.value == null || (identicalRewritesAllowed && this.value === value)) {
+                if (identicalRewritesAllowed) {
+                    "A `writeOnce` property cannot be rewritten with another value."
+                } else {
+                    "A `writeOnce` property has already been written earlier " +
+                            "and cannot be written more than once."
+                }
+            }
+            this.value = value
+        }
     }
-}

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -65,8 +65,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomEnd
+import androidx.compose.ui.Alignment.Companion.CenterEnd
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Alignment.Companion.TopEnd
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -419,6 +419,17 @@ public class DropdownListBox<I> : Component() {
      */
     private val firstItemIndex: Int get() = if (noneItemEnabled) -1 else 0
 
+    private var scrollState: ScrollState by writeOnce()
+    private var coroutineScope: CoroutineScope by writeOnce()
+
+    @Composable
+    @ReadOnlyComposable
+    override fun initialize() {
+        super.initialize()
+        scrollState = rememberScrollState(0)
+        coroutineScope = rememberCoroutineScope()
+    }
+
     @Composable
     @ReadOnlyComposable
     override fun beforeComposeContent() {
@@ -428,9 +439,6 @@ public class DropdownListBox<I> : Component() {
 
     @Composable
     override fun content() {
-        val coroutineScope = rememberCoroutineScope()
-        val scrollState = rememberScrollState(0)
-
         LaunchedEffect(enabled) {
             if (!enabled) {
                 expanded.value = false
@@ -484,7 +492,7 @@ public class DropdownListBox<I> : Component() {
             }
 
             if (expanded) {
-                DropdownList(coroutineScope, scrollState)
+                DropdownList()
             }
         }
     }
@@ -772,7 +780,7 @@ public class DropdownListBox<I> : Component() {
         }
     }
 
-    private fun scrollPreselectionIntoView(scrollState: ScrollState) {
+    private fun scrollPreselectionIntoView() {
         val viewportTop = scrollState.value
         val itemPosTop = getItemPos(preselectedItemIndex)
         if (itemPosTop < viewportTop) {
@@ -866,12 +874,9 @@ public class DropdownListBox<I> : Component() {
      *
      * @receiver A [BoxScope], the scope within which this function is intended
      *   to be used.
-     * @param scrollState A [ScrollState], whose value indicates current
-     *   drop-down list scrollbar position.
      */
     @Composable
-    private fun BoxScope.DropdownListContent(scrollState: ScrollState) {
-
+    private fun BoxScope.DropdownListContent() {
         Column(
             modifier = Modifier
                 .width(MinWidth)
@@ -929,25 +934,18 @@ public class DropdownListBox<I> : Component() {
             }
         }
         VerticalScrollbar(scrollState) {
-            Modifier.align(Alignment.CenterEnd)
+            Modifier.align(CenterEnd)
         }
     }
 
     /**
      * A popup, which is displaying drop-down list.
-     *
-     * @param coroutineScope
-     *         a [CoroutineScope] used to launch a job which scrolls
-     *         vertical drop-down list scrollbar to desired position.
-     * @param scrollState
-     *         a [ScrollState], whose value indicates current
-     *         drop-down list scrollbar position.
      */
     @Composable
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun DropdownList(coroutineScope: CoroutineScope, scrollState: ScrollState) {
+    private fun DropdownList() {
         LaunchedEffect(preselectedItemIndex) {
-            scrollPreselectionIntoView(scrollState)
+            scrollPreselectionIntoView()
         }
 
         LaunchedEffect(totalItemsHeight) {
@@ -988,10 +986,10 @@ public class DropdownListBox<I> : Component() {
                         }
                     }
 
-                    DropdownListContent(scrollState)
+                    DropdownListContent()
                 }
                 if (showSearchSelection.value) {
-                    SearchSelectionField(coroutineScope)
+                    SearchSelectionField()
                 }
             }
         }
@@ -999,14 +997,10 @@ public class DropdownListBox<I> : Component() {
 
     /**
      * Composable for displaying search selection field.
-     *
-     * @param coroutineScope
-     *         a [CoroutineScope] used to launch a job which scrolls
-     *         vertical drop-down list scrollbar to desired position.
      */
     @Composable
     @OptIn(ExperimentalMaterial3Api::class)
-    private fun SearchSelectionField(coroutineScope: CoroutineScope) {
+    private fun SearchSelectionField() {
         val focusRequester = remember { FocusRequester() }
         val interactionSource = remember { MutableInteractionSource() }
         val searchSelectionContent = remember {

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -424,14 +424,6 @@ public class DropdownListBox<I> : Component() {
 
     @Composable
     @ReadOnlyComposable
-    override fun initialize() {
-        super.initialize()
-        scrollState = rememberScrollState(0)
-        coroutineScope = rememberCoroutineScope()
-    }
-
-    @Composable
-    @ReadOnlyComposable
     override fun beforeComposeContent() {
         super.beforeComposeContent()
         density = LocalDensity.current
@@ -439,6 +431,9 @@ public class DropdownListBox<I> : Component() {
 
     @Composable
     override fun content() {
+        scrollState = rememberScrollState(0)
+        coroutineScope = rememberCoroutineScope()
+
         LaunchedEffect(enabled) {
             if (!enabled) {
                 expanded.value = false

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -269,8 +269,6 @@ public abstract class InputComponent<V> : FocusableComponent() {
      */
     public var enabled: Boolean by mutableStateOf(true)
 
-    @Composable
-    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         if (!this::value.isInitialized) {

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -26,7 +26,9 @@
 
 package io.spine.chords.core
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -267,6 +269,8 @@ public abstract class InputComponent<V> : FocusableComponent() {
      */
     public var enabled: Boolean by mutableStateOf(true)
 
+    @Composable
+    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         if (!this::value.isInitialized) {

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -44,7 +44,7 @@ import java.awt.Dimension
  * This property automatically obtains a reference to the application
  * when the [Application]'s [run][Application.run] method is invoked.
  */
-public var app: Application by writeOnce()
+public var app: Application by writeOnce(false)
 
 /**
  * A desktop client application.

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -48,11 +48,15 @@ public class ConfirmationDialog : Dialog() {
          *     }
          * ```
          *
+         * @param props A lambda, which configures the confirmation
+         *   dialog's properties.
          * @return `true`, if the user makes a positive decision (presses the
          *   Submit button), and `false`, if the user makes a negative decision
          *   (presses the Cancel button).
          */
-        public suspend fun showConfirmation(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
+        public suspend fun showConfirmation(
+            props: ComponentProps<ConfirmationDialog>? = null
+        ): Boolean {
             val dialog = create(config = props)
             return dialog.showConfirmation()
         }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -90,28 +90,6 @@ public class ConfirmationDialog : Dialog() {
     public var description: String = ""
 
     /**
-     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
-     * to prevent any potential "recursive" confirmations display, which might
-     * be the case when confirmations are set for all dialogs by setting
-     * `onBeforeSubmit` for all dialogs on an application-wide level.
-     *
-     * @see showConfirmation
-     * @see updateProps
-     */
-    private var onBeforeSubmitInternal: suspend () -> Boolean = { true }
-
-    /**
-     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
-     * to prevent any potential "recursive" confirmations display, which might
-     * be the case when confirmations are set for all dialogs by setting
-     * `onBeforeCancel` for all dialogs on an application-wide level.
-     *
-     * @see showConfirmation
-     * @see updateProps
-     */
-    private var onBeforeCancelInternal: suspend () -> Boolean = { true }
-
-    /**
      * Creates the content of the dialog.
      */
     @Composable
@@ -150,12 +128,12 @@ public class ConfirmationDialog : Dialog() {
     public suspend fun showConfirmation(): Boolean {
         var confirmed = false
         val dialogClosure = CompletableFuture<Unit>()
-        onBeforeSubmitInternal = {
+        onBeforeSubmit = {
             confirmed = true
             dialogClosure.complete(Unit)
             true
         }
-        onBeforeCancelInternal = {
+        onBeforeCancel = {
             dialogClosure.complete(Unit)
             true
         }
@@ -163,12 +141,5 @@ public class ConfirmationDialog : Dialog() {
         open()
         dialogClosure.await()
         return confirmed
-    }
-
-    override fun updateProps() {
-        super.updateProps()
-
-        onBeforeSubmit = onBeforeSubmitInternal
-        onBeforeCancel = onBeforeCancelInternal
     }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -135,7 +135,7 @@ public class ConfirmationDialog : Dialog() {
     /**
      * Just returns `true` on form submission since there is no data to submit.
      */
-    protected override suspend fun submitForm(): Boolean {
+    protected override suspend fun submitContent(): Boolean {
         return true
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -30,6 +30,24 @@ public class ConfirmationDialog : Dialog() {
          * Displays the confirmation dialog, and waits until the user
          * makes a decision.
          *
+         * Here's a usage example:
+         * ```
+         *     val confirmed = ConfirmationDialog.showConfirmation {
+         *         message = "Are you sure that you want to continue?"
+         *         description = "This action is irreversible."
+         *         submitButtonText = "Proceed"
+         *         cancelButtonText = "Cancel"
+         *     }
+         * ```
+         *
+         * You can also import this function specifically and make its usages
+         * more concise, like this:
+         * ```
+         *     val confirmed = showConfirmation {
+         *         message = "Are you sure that you want to continue?"
+         *     }
+         * ```
+         *
          * @return `true`, if the user makes a positive decision (presses the
          *   Submit button), and `false`, if the user makes a negative decision
          *   (presses the Cancel button).
@@ -68,6 +86,28 @@ public class ConfirmationDialog : Dialog() {
     public var description: String = ""
 
     /**
+     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
+     * to prevent any potential "recursive" confirmations display, which might
+     * be the case when confirmations are set for all dialogs by setting
+     * `onBeforeSubmit` for all dialogs on an application-wide level.
+     *
+     * @see showConfirmation
+     * @see updateProps
+     */
+    private var onBeforeSubmitInternal: suspend () -> Boolean = { true }
+
+    /**
+     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
+     * to prevent any potential "recursive" confirmations display, which might
+     * be the case when confirmations are set for all dialogs by setting
+     * `onBeforeCancel` for all dialogs on an application-wide level.
+     *
+     * @see showConfirmation
+     * @see updateProps
+     */
+    private var onBeforeCancelInternal: suspend () -> Boolean = { true }
+
+    /**
      * Creates the content of the dialog.
      */
     @Composable
@@ -98,28 +138,6 @@ public class ConfirmationDialog : Dialog() {
     protected override suspend fun submitForm(): Boolean {
         return true
     }
-
-    /**
-     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
-     * to prevent any potential "recursive" confirmations display, which might
-     * be the case when confirmations are set for all dialogs by setting
-     * `onBeforeSubmit` for all dialogs on an application-wide level.
-     *
-     * @see showConfirmation
-     * @see updateProps
-     */
-    private var onBeforeSubmitInternal: suspend () -> Boolean = { true }
-
-    /**
-     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
-     * to prevent any potential "recursive" confirmations display, which might
-     * be the case when confirmations are set for all dialogs by setting
-     * `onBeforeCancel` for all dialogs on an application-wide level.
-     *
-     * @see showConfirmation
-     * @see updateProps
-     */
-    private var onBeforeCancelInternal: suspend () -> Boolean = { true }
 
     /**
      * Displays the confirmation dialog, and waits until the user

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -111,7 +111,7 @@ public class ConfirmationDialog : Dialog() {
      * Creates the content of the dialog.
      */
     @Composable
-    protected override fun formContent() {
+    protected override fun contentSection() {
         val textStyle = typography.bodyLarge
 
         Column {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -34,9 +34,9 @@ public class ConfirmationDialog : Dialog() {
          *   Submit button), and `false`, if the user makes a negative decision
          *   (presses the Cancel button).
          */
-        public suspend fun ask(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
+        public suspend fun showConfirmation(props: ComponentProps<ConfirmationDialog>? = null): Boolean {
             val dialog = create(config = props)
-            return dialog.ask()
+            return dialog.showConfirmation()
         }
     }
 
@@ -105,7 +105,7 @@ public class ConfirmationDialog : Dialog() {
      * be the case when confirmations are set for all dialogs by setting
      * `onBeforeSubmit` for all dialogs on an application-wide level.
      *
-     * @see ask
+     * @see showConfirmation
      * @see updateProps
      */
     private var onBeforeSubmitInternal: suspend () -> Boolean = { true }
@@ -116,7 +116,7 @@ public class ConfirmationDialog : Dialog() {
      * be the case when confirmations are set for all dialogs by setting
      * `onBeforeCancel` for all dialogs on an application-wide level.
      *
-     * @see ask
+     * @see showConfirmation
      * @see updateProps
      */
     private var onBeforeCancelInternal: suspend () -> Boolean = { true }
@@ -125,7 +125,7 @@ public class ConfirmationDialog : Dialog() {
      * Displays the confirmation dialog, and waits until the user
      * makes a decision.
      */
-    public suspend fun ask(): Boolean {
+    public suspend fun showConfirmation(): Boolean {
         var confirmed = false
         val dialogClosure = CompletableFuture<Unit>()
         onBeforeSubmitInternal = {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -35,8 +35,8 @@ public class ConfirmationDialog : Dialog() {
          *     val confirmed = ConfirmationDialog.showConfirmation {
          *         message = "Are you sure that you want to continue?"
          *         description = "This action is irreversible."
-         *         submitButtonText = "Proceed"
-         *         cancelButtonText = "Cancel"
+         *         yesButtonText = "Proceed"
+         *         noButtonText = "Cancel"
          *     }
          * ```
          *
@@ -63,16 +63,6 @@ public class ConfirmationDialog : Dialog() {
     }
 
     /**
-     * Initializes the `confirmButtonText` and the size of the dialog.
-     */
-    init {
-        submitButtonText = "Yes"
-        cancelButtonText = "No"
-        dialogWidth = 430.dp
-        dialogHeight = 210.dp
-    }
-
-    /**
      * The title of the dialog.
      */
     public override var title: String = "Confirm"
@@ -88,6 +78,34 @@ public class ConfirmationDialog : Dialog() {
      * an extra context about the question being asked.
      */
     public var description: String = ""
+
+    /**
+     * The label for the dialog's Yes button.
+     *
+     * The default value is `Yes`.
+     */
+    public var yesButtonText: String
+        get() = submitButtonText
+        set(value) { submitButtonText = value }
+
+    /**
+     * The label for the dialog's No button.
+     *
+     * The default value is `No`.
+     */
+    public var noButtonText: String
+        get() = cancelButtonText
+        set(value) { cancelButtonText = value }
+
+    init {
+        submitAvailable = true
+        cancelAvailable = true
+
+        yesButtonText = "Yes"
+        noButtonText = "No"
+        dialogWidth = 430.dp
+        dialogHeight = 210.dp
+    }
 
     /**
      * Creates the content of the dialog.

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -33,7 +33,7 @@ public class ConfirmationDialog : Dialog() {
          * Here's a usage example:
          * ```
          *     val confirmed = ConfirmationDialog.showConfirmation {
-         *         message = "Are you sure that you want to continue?"
+         *         message = "Are you sure you want to continue?"
          *         description = "This action is irreversible."
          *         yesButtonText = "Proceed"
          *         noButtonText = "Cancel"
@@ -44,7 +44,7 @@ public class ConfirmationDialog : Dialog() {
          * more concise, like this:
          * ```
          *     val confirmed = showConfirmation {
-         *         message = "Are you sure that you want to continue?"
+         *         message = "Are you sure you want to continue?"
          *     }
          * ```
          *

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -87,6 +87,24 @@ import kotlinx.coroutines.launch
 private val cancelShortcutKey = Escape.key
 private val submitShortcutKey = Ctrl(Enter.key)
 
+public abstract class OkCancelDialog : Dialog() {
+
+    /**
+     * The label for the dialog's Submit button.
+     *
+     * The default value is `OK`.
+     */
+    public override var submitButtonText: String = "OK"
+
+    /**
+     * The label for the dialog's Cancel button.
+     *
+     * The default value is `Cancel`.
+     */
+    public override var cancelButtonText: String = "Cancel"
+
+}
+
 /**
  * The base class for creating a modal dialog window, e.g. for editing and
  * submitting data.
@@ -159,14 +177,14 @@ public abstract class Dialog : Component() {
      *
      * The default value is `OK`.
      */
-    public var submitButtonText: String = "OK"
+    protected open var submitButtonText: String = "OK"
 
     /**
      * The label for the dialog's Cancel button.
      *
      * The default value is `Cancel`.
      */
-    public var cancelButtonText: String = "Cancel"
+    protected open var cancelButtonText: String = "Cancel"
 
     /**
      * The width of the dialog.

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -322,11 +322,6 @@ public abstract class Dialog : Component() {
         get() = cancelAvailable
         set(value) { cancelAvailable = value }
 
-    override fun initialize() {
-        super.initialize()
-        coroutineScope = rememberCoroutineScope()
-    }
-
     /**
      * Displays the modal dialog.
      *
@@ -383,6 +378,7 @@ public abstract class Dialog : Component() {
      */
     @Composable
     protected override fun content() {
+        coroutineScope = rememberCoroutineScope()
         displayMode.content(this) { formContent() }
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -87,24 +87,6 @@ import kotlinx.coroutines.launch
 private val cancelShortcutKey = Escape.key
 private val submitShortcutKey = Ctrl(Enter.key)
 
-public abstract class OkCancelDialog : Dialog() {
-
-    /**
-     * The label for the dialog's Submit button.
-     *
-     * The default value is `OK`.
-     */
-    public override var submitButtonText: String = "OK"
-
-    /**
-     * The label for the dialog's Cancel button.
-     *
-     * The default value is `Cancel`.
-     */
-    public override var cancelButtonText: String = "Cancel"
-
-}
-
 /**
  * The base class for creating a modal dialog window, e.g. for editing and
  * submitting data.
@@ -327,7 +309,7 @@ public abstract class Dialog : Component() {
     /**
      * Specifies whether the "Submit" button should be displayed.
      */
-    protected var submitAvailable: Boolean = true
+    protected var submitAvailable: Boolean = false
     internal var submitAvailableInternal: Boolean
         get() = submitAvailable
         set(value) { submitAvailable = value }
@@ -335,7 +317,7 @@ public abstract class Dialog : Component() {
     /**
      * Specifies whether the "Cancel" button should be displayed.
      */
-    protected var cancelAvailable: Boolean = true
+    protected var cancelAvailable: Boolean = false
     internal var cancelAvailableInternal: Boolean
         get() = cancelAvailable
         set(value) { cancelAvailable = value }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -482,7 +482,7 @@ public abstract class Dialog : Component() {
     }
 
     /**
-     * Exposes the [windowContent] with an `internal` visibility scope.
+     * Exposes the [windowContent] within an `internal` visibility scope.
      */
     context(ColumnScope)
     @Composable

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -110,7 +110,7 @@ public class MessageDialog : Dialog() {
         dialogClosure.await()
     }
 
-    override suspend fun submitForm(): Boolean {
+    override suspend fun submitContent(): Boolean {
         // No custom logic is required when the user acknowledges
         // the displayed message.
         return true

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -48,8 +48,21 @@ public class MessageDialog : Dialog() {
 
         /**
          * Displays the message dialog, and waits until the user dismissed it.
+         *
+         * Here's a usage example:
+         * ```
+         *     MessageDialog.showMessage("An error has occurred: ...")
+         * ```
+         *
+         * You can make its usage more concise if you import this function:
+         * ```
+         *     showMessage("An error has occurred: ...")
+         * ```
          */
-        public suspend fun showMessage(message: String, props: ComponentProps<MessageDialog>? = null) {
+        public suspend fun showMessage(
+            message: String,
+            props: ComponentProps<MessageDialog>? = null
+        ) {
             val dialog = create(config = props)
             dialog.message = message
             dialog.showMessage()

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -40,13 +40,14 @@ import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.future.await
 
 /**
- * A dialog that displays the specified message for the user.
+ * A dialog that displays the specified text message for the user.
  */
 public class MessageDialog : Dialog() {
     public companion object : AbstractComponentSetup({ MessageDialog() }) {
 
         /**
-         * Displays the message dialog, and waits until the user dismissed it.
+         * Displays the text message dialog, and waits until the user
+         * dismisses it.
          *
          * Here's a usage example:
          * ```
@@ -68,12 +69,8 @@ public class MessageDialog : Dialog() {
         }
     }
 
-    /**
-     * Initializes the `confirmButtonText` and the size of the dialog.
-     */
     init {
         submitAvailable = true
-        submitButtonText = "OK"
         dialogWidth = 430.dp
         dialogHeight = 210.dp
     }
@@ -84,16 +81,10 @@ public class MessageDialog : Dialog() {
     public override var title: String = "Message"
 
     /**
-     * The main message of the confirmation dialog, which is usually expected
+     * The main message of the dialog, which is usually expected
      * to contain the question presented to the user.
      */
     public var message: String = ""
-
-    /**
-     * An optional auxiliary text displayed below the message, which can provide
-     * an extra context about the question being asked.
-     */
-    public var description: String = ""
 
     init {
         cancelAvailable = false
@@ -129,12 +120,6 @@ public class MessageDialog : Dialog() {
             ) {
                 Text(
                     text = message,
-                    style = textStyle
-                )
-            }
-            Row {
-                Text(
-                    text = description,
                     style = textStyle
                 )
             }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.ComponentProps
-import io.spine.chords.core.layout.ConfirmationDialog.Companion.showConfirmation
 import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.future.await
 
@@ -95,17 +94,6 @@ public class MessageDialog : Dialog() {
      */
     public var description: String = ""
 
-    /**
-     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
-     * to prevent any potential "recursive" confirmations display, which might
-     * be the case when confirmations are set for all dialogs by setting
-     * `onBeforeSubmit` for all dialogs on an application-wide level.
-     *
-     * @see showConfirmation
-     * @see updateProps
-     */
-    private var onBeforeSubmitInternal: suspend () -> Boolean = { true }
-
     init {
         cancelAvailable = false
     }
@@ -113,7 +101,7 @@ public class MessageDialog : Dialog() {
     public suspend fun showMessage(): Boolean {
         var confirmed = false
         val dialogClosure = CompletableFuture<Unit>()
-        onBeforeSubmitInternal = {
+        onBeforeSubmit = {
             confirmed = true
             dialogClosure.complete(Unit)
             true
@@ -155,9 +143,4 @@ public class MessageDialog : Dialog() {
         }
     }
 
-    override fun updateProps() {
-        super.updateProps()
-
-        onBeforeSubmit = onBeforeSubmitInternal
-    }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -120,7 +120,7 @@ public class MessageDialog : Dialog() {
      * Creates the content of the dialog.
      */
     @Composable
-    protected override fun formContent() {
+    protected override fun contentSection() {
         val textStyle = typography.bodyLarge
 
         Column {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -72,6 +72,7 @@ public class MessageDialog : Dialog() {
      * Initializes the `confirmButtonText` and the size of the dialog.
      */
     init {
+        submitAvailable = true
         submitButtonText = "OK"
         dialogWidth = 430.dp
         dialogHeight = 210.dp
@@ -98,18 +99,15 @@ public class MessageDialog : Dialog() {
         cancelAvailable = false
     }
 
-    public suspend fun showMessage(): Boolean {
-        var confirmed = false
+    public suspend fun showMessage() {
         val dialogClosure = CompletableFuture<Unit>()
         onBeforeSubmit = {
-            confirmed = true
             dialogClosure.complete(Unit)
             true
         }
 
         open()
         dialogClosure.await()
-        return confirmed
     }
 
     override suspend fun submitForm(): Boolean {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -125,5 +125,4 @@ public class MessageDialog : Dialog() {
             }
         }
     }
-
 }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme.typography
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.spine.chords.core.AbstractComponentSetup
+import io.spine.chords.core.ComponentProps
+import io.spine.chords.core.layout.ConfirmationDialog.Companion.showConfirmation
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.future.await
+
+/**
+ * A dialog that displays the specified message for the user.
+ */
+public class MessageDialog : Dialog() {
+    public companion object : AbstractComponentSetup({ MessageDialog() }) {
+
+        /**
+         * Displays the message dialog, and waits until the user dismissed it.
+         */
+        public suspend fun showMessage(message: String, props: ComponentProps<MessageDialog>? = null) {
+            val dialog = create(config = props)
+            dialog.message = message
+            dialog.showMessage()
+        }
+    }
+
+    /**
+     * Initializes the `confirmButtonText` and the size of the dialog.
+     */
+    init {
+        submitButtonText = "OK"
+        dialogWidth = 430.dp
+        dialogHeight = 210.dp
+    }
+
+    /**
+     * The title of the dialog.
+     */
+    public override var title: String = "Message"
+
+    /**
+     * The main message of the confirmation dialog, which is usually expected
+     * to contain the question presented to the user.
+     */
+    public var message: String = ""
+
+    /**
+     * An optional auxiliary text displayed below the message, which can provide
+     * an extra context about the question being asked.
+     */
+    public var description: String = ""
+
+    /**
+     * These internal variants of `onBeforeSubmit`/`onBeforeCancel` are needed
+     * to prevent any potential "recursive" confirmations display, which might
+     * be the case when confirmations are set for all dialogs by setting
+     * `onBeforeSubmit` for all dialogs on an application-wide level.
+     *
+     * @see showConfirmation
+     * @see updateProps
+     */
+    private var onBeforeSubmitInternal: suspend () -> Boolean = { true }
+
+    init {
+        cancelAvailable = false
+    }
+
+    public suspend fun showMessage(): Boolean {
+        var confirmed = false
+        val dialogClosure = CompletableFuture<Unit>()
+        onBeforeSubmitInternal = {
+            confirmed = true
+            dialogClosure.complete(Unit)
+            true
+        }
+
+        open()
+        dialogClosure.await()
+        return confirmed
+    }
+
+    override suspend fun submitForm(): Boolean {
+        // No custom logic is required when the user acknowledges
+        // the displayed message.
+        return true
+    }
+
+    /**
+     * Creates the content of the dialog.
+     */
+    @Composable
+    protected override fun formContent() {
+        val textStyle = typography.bodyLarge
+
+        Column {
+            Row(
+                modifier = Modifier.padding(bottom = 6.dp)
+            ) {
+                Text(
+                    text = message,
+                    style = textStyle
+                )
+            }
+            Row {
+                Text(
+                    text = description,
+                    style = textStyle
+                )
+            }
+        }
+    }
+
+    override fun updateProps() {
+        super.updateProps()
+
+        onBeforeSubmit = onBeforeSubmitInternal
+    }
+}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/SubmitOrCancelDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/SubmitOrCancelDialog.kt
@@ -29,8 +29,10 @@ package io.spine.chords.core.layout
 /**
  * A modal dialog window, which has OK and Cancel buttons.
  *
- * It can be used in the same way as its base [Dialog] class, but it also
- * exposes
+ * It can be used in the same way as its base [Dialog] class. Compared to
+ * [Dialog], this component includes the Submit and Cancel buttons by default,
+ * and makes the respective button customization properties to be public ones:
+ * [submitButtonText], [cancelButtonText].
  *
  * @see Dialog
  */

--- a/core/src/main/kotlin/io/spine/chords/core/layout/SubmitOrCancelDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/SubmitOrCancelDialog.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+/**
+ * A modal dialog window, which has OK and Cancel buttons.
+ *
+ * It can be used in the same way as its base [Dialog] class, but it also
+ * exposes
+ *
+ * @see Dialog
+ */
+public abstract class SubmitOrCancelDialog : Dialog() {
+
+    /**
+     * The label for the dialog's Submit button.
+     *
+     * The default value is `OK`.
+     */
+    public override var submitButtonText: String = "OK"
+
+    /**
+     * The label for the dialog's Cancel button.
+     *
+     * The default value is `Cancel`.
+     */
+    public override var cancelButtonText: String = "Cancel"
+
+    init {
+        submitAvailable = true
+        cancelAvailable = true
+    }
+}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/SubmitOrCancelDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/SubmitOrCancelDialog.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.core.layout
 
 /**
- * A modal dialog window, which has OK and Cancel buttons.
+ * A modal dialog window, which has Submit and Cancel buttons.
  *
  * It can be used in the same way as its base [Dialog] class. Compared to
  * [Dialog], this component includes the Submit and Cancel buttons by default,

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.53`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.54`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -111,7 +111,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -230,7 +230,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -750,7 +750,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -992,7 +992,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1066,12 +1066,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 11 16:54:23 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 16:31:57 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.53`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.54`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1925,12 +1925,12 @@ This report was generated on **Wed Dec 11 16:54:23 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 11 16:54:26 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 16:32:02 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.53`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.54`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1992,7 +1992,7 @@ This report was generated on **Wed Dec 11 16:54:26 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2107,7 +2107,7 @@ This report was generated on **Wed Dec 11 16:54:26 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2596,7 +2596,7 @@ This report was generated on **Wed Dec 11 16:54:26 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2838,7 +2838,7 @@ This report was generated on **Wed Dec 11 16:54:26 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2912,12 +2912,12 @@ This report was generated on **Wed Dec 11 16:54:26 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 11 16:54:27 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 16:32:05 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.53`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.54`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2996,7 +2996,7 @@ This report was generated on **Wed Dec 11 16:54:27 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3111,7 +3111,7 @@ This report was generated on **Wed Dec 11 16:54:27 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3600,7 +3600,7 @@ This report was generated on **Wed Dec 11 16:54:27 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3842,7 +3842,7 @@ This report was generated on **Wed Dec 11 16:54:27 EET 2024** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3916,12 +3916,12 @@ This report was generated on **Wed Dec 11 16:54:27 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 11 16:54:29 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 16:32:08 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.53`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.54`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4715,12 +4715,12 @@ This report was generated on **Wed Dec 11 16:54:29 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 11 16:54:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 16:32:12 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.53`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.54`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5484,4 +5484,4 @@ This report was generated on **Wed Dec 11 16:54:30 EET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 11 16:54:31 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 16:32:14 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.53</version>
+<version>2.0.0-SNAPSHOT.54</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -73,7 +73,7 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.compose.desktop</groupId>
-    <artifactId>desktop-jvm-macos-x64</artifactId>
+    <artifactId>desktop-jvm-windows-x64</artifactId>
     <version>1.5.12</version>
     <scope>compile</scope>
   </dependency>

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/CustomMessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/CustomMessageForm.kt
@@ -26,6 +26,7 @@
 
 package io.spine.chords.proto.form
 
+import androidx.compose.runtime.Composable
 import com.google.protobuf.Message
 import io.spine.protobuf.ValidatingBuilder
 import io.spine.chords.core.Component
@@ -105,5 +106,19 @@ public open class CustomMessageForm<M : Message>
 protected constructor(builder: () -> ValidatingBuilder<M>) : MessageForm<M>() {
     init {
         this.builder = builder
+    }
+
+    /**
+     * This method is made final to prevent potential confusion for custom form
+     * implementers of whether it should be overridden to provide custom
+     * form's content.
+     *
+     * In order to specify custom form's content, make sure to override either
+     * [customContent] or [customMultipartContent] instead. See the
+     * documentation for the [CustomMessageForm] class.
+     */
+    @Composable
+    final override fun content() {
+        super.content()
     }
 }

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1234,8 +1234,6 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     public val dirty: Boolean get() = _dirty
     private var _dirty = false
 
-    @Composable
-    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         requireProperty(::builder.isInitialized, "builder")
@@ -1373,7 +1371,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      */
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
-    final override fun content() {
+    override fun content() {
         updateBeforeRendering()
 
         formScope.customMultipartContent()

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -49,6 +49,7 @@ import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.InputComponent
 import io.spine.chords.core.InputContext
 import io.spine.chords.core.ValidationErrorText
+import io.spine.chords.core.recompositionWorkaroundReadonly
 import io.spine.chords.proto.form.MessageForm.Companion.Multipart
 import io.spine.chords.proto.form.MessageForm.Companion.create
 import io.spine.chords.proto.form.MessageForm.Companion.invoke
@@ -1371,7 +1372,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      */
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
-    override fun content() {
+    override fun content(): Unit = recompositionWorkaroundReadonly {
         updateBeforeRendering()
 
         formScope.customMultipartContent()

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1234,6 +1234,8 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     public val dirty: Boolean get() = _dirty
     private var _dirty = false
 
+    @Composable
+    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         requireProperty(::builder.isInitialized, "builder")

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1344,24 +1344,6 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     }
 
     /**
-     * Renders the form's instance, which was created using
-     * the [create] function.
-     *
-     * In most cases forms (like class-based
-     * [Component][io.spine.chords.core.Component]s in general) would be
-     * declared using either of [invoke] functions, and thus won't need this
-     * function to be invoked explicitly though.
-     *
-     * If you're implementing a custom `MessageForm` subclass that needs its own
-     * built-in content to be specified, override the [customContent] or
-     * [customMultipartContent] method instead.
-     */
-    @Composable
-    final override fun Content() {
-        super.Content()
-    }
-
-    /**
      * The `MessageForm`'s rendering implementation.
      *
      * When defining custom `MessageForm` implementations (subclasses) that need

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
   * The version of all Chords libraries.
   */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.53")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.54")


### PR DESCRIPTION
This PR:
* Introduces a basic notion of `CommandOutcomeHandler`, which works together with `CommandMessageForm`, and for now is mainly responsible for handling the command posting outcome waiting timeout. The default implementation (`DefaultOutcomeHandler`) displays a message dialog in this situation.
* Introduces the `MessageDialog` component, which provides an easy way of displaying a simple dialog that presents the provided text message to the user.
* Makes the implementation of `Dialog` a bit more generic to support different number of buttons, and introduce a `SubmitOrCancel` dialog as a base class for Submit/Cancel type of dialogs.
* Extends KDocs a bit, including the component's lifecycle description in `Component`'s KDocs in particular.