### PR TITLE
Fix some command consequences related issues

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -234,8 +234,8 @@ import kotlinx.coroutines.CoroutineScope
      *   the subscription has been made. In either of these cases, the returned
      *   `EventSubscription` is transitioned into an inactive state and stops
      *   receiving events.
-     * @param onEvent An optional callback, which will be invoked when the
-     *   specified event is emitted.
+     * @param onEvent A callback, which will be invoked when the specified event
+     *   is emitted.
      * @return An [EventSubscription] object, which represents the subscription
      *   that was made.
      */

--- a/client/src/main/kotlin/io/spine/chords/client/CommandConsequences.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/CommandConsequences.kt
@@ -249,7 +249,8 @@ public interface CommandConsequencesScope<out C: CommandMessage> {
      * is cancelled.
      *
      * @param timeout A maximum period of time that the event is waited for
-     *   since the moment of invoking this function.
+     *   since the moment of invoking this function. Defaults to
+     *   [defaultTimeout] property value.
      * @param timeoutHandler A callback, which should be invoked if an event
      *   is not emitted within the specified [timeout] period after invoking
      *   this method.

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 /**
  * Provides API to interact with the application server via gRPC.
@@ -300,7 +301,7 @@ public class DesktopClient(
  * @param spineClient A Spine Event Engine's [Client][io.spine.client.Client]
  *   instance where the subscription is being registered.
  */
-private class EventSubscriptionImpl(
+internal open class EventSubscriptionImpl(
     private val spineClient: io.spine.client.Client
 ) : EventSubscription {
     override val active: Boolean get() = subscription != null
@@ -329,6 +330,7 @@ private class EventSubscriptionImpl(
                 cancelSubscription()
 
                 onTimeout()
+                yield()
 
                 // Timeout job should be canceled AFTER invoking a callback
                 // to ensure that `onTimeout` callback's coroutine scope still

--- a/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
@@ -287,7 +287,7 @@ public open class ModalCommandConsequencesScope<C : CommandMessage>(
         return subscription
     }
 
-    private suspend fun triggerDefaultTimeoutHandlers() {
+    private fun triggerDefaultTimeoutHandlers() = callbacks {
         defaultTimeoutHandlers.forEach { it() }
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -36,8 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.appshell.Props
-import java.util.concurrent.CompletableFuture
-import kotlinx.coroutines.future.await
+import kotlinx.coroutines.CompletableDeferred
 
 /**
  * A dialog that prompts the user either to make a boolean decision
@@ -165,7 +164,7 @@ public class ConfirmationDialog : Dialog() {
      */
     public suspend fun showConfirmation(): Boolean {
         var confirmed = false
-        val dialogClosure = CompletableFuture<Unit>()
+        val dialogClosure = CompletableDeferred<Unit>()
         onBeforeSubmit = {
             confirmed = true
             dialogClosure.complete(Unit)

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -36,8 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.appshell.Props
-import java.util.concurrent.CompletableFuture
-import kotlinx.coroutines.future.await
+import kotlinx.coroutines.CompletableDeferred
 
 /**
  * A dialog that displays the specified text message for the user.
@@ -91,7 +90,7 @@ public class MessageDialog : Dialog() {
     }
 
     public suspend fun showMessage() {
-        val dialogClosure = CompletableFuture<Unit>()
+        val dialogClosure = CompletableDeferred<Unit>()
         onBeforeSubmit = {
             dialogClosure.complete(Unit)
             true

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.63`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.64`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1086,12 +1086,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:41:34 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 01:10:55 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.63`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.64`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1945,12 +1945,12 @@ This report was generated on **Thu Feb 20 17:41:34 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:41:37 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 01:10:58 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.63`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.64`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2983,12 +2983,12 @@ This report was generated on **Thu Feb 20 17:41:37 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:41:43 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 01:11:02 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.63`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.64`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4007,12 +4007,12 @@ This report was generated on **Thu Feb 20 17:41:43 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:41:46 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 01:11:08 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.63`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.64`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4806,12 +4806,12 @@ This report was generated on **Thu Feb 20 17:41:46 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:41:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 01:11:12 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.63`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.64`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5575,4 +5575,4 @@ This report was generated on **Thu Feb 20 17:41:50 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 17:41:53 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 22 01:11:15 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.63</version>
+<version>2.0.0-SNAPSHOT.64</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.63")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.64")


### PR DESCRIPTION
This PR includes the following:
- Correct the capability to customize `CommandConsequences.defaultTimeout` property.
- Fix the timeout callback's coroutine scope to be active when the callback is invoked (which fixes complex scenarios within a callback, such as closing a dialog after showing a message).
- Move making event subscriptions (which are relatively time-consuming) after `onBeforePost` callbacks to improve the UX of posting progress display.
- Offload the server communication operations (making subscriptions, posting of a command) to the IO coroutine dispatcher to ensure timely UI updates within consequence callbacks (especially actual for `onBeforePost`).
- Minor KDoc and code style corrections.