### PR TITLE
Improve table selection handling

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
@@ -239,7 +239,7 @@ public abstract class Table<E> : Component() {
                 // Make sure that selected entity value is always up to date
                 // with the `entities` list if it contains an updated
                 // entity value.
-                selectedEntity.value = entity
+                changeSelectedEntity(entity)
             }
             rowModifier(entity).background(selectedRowColor!!)
         } else {

--- a/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
@@ -102,6 +102,13 @@ public abstract class Table<E> : Component() {
     )
 
     /**
+     * A callback which is invoked whenever selected entity value is changed.
+     *
+     * The parameter of the lambda receives the new selected entity value.
+     */
+    public var onSelect: (E) -> Unit = { }
+
+    /**
      * A list of columns to be displayed in the table.
      */
     protected abstract val columns: List<TableColumn<E>>
@@ -169,8 +176,9 @@ public abstract class Table<E> : Component() {
      *
      * @param entity The entity associated with the clicked row.
      */
-    protected open fun changeSelectedEntity(entity: E) {
+    private fun changeSelectedEntity(entity: E) {
         selectedEntity.value = entity
+        onSelect(entity)
     }
 
     @Composable

--- a/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
@@ -106,7 +106,7 @@ public abstract class Table<E> : Component() {
      *
      * The parameter of the lambda receives the new selected entity value.
      */
-    public var onSelect: (E) -> Unit = { }
+    public var onSelect: ((E) -> Unit)? = null
 
     /**
      * A list of columns to be displayed in the table.
@@ -178,7 +178,7 @@ public abstract class Table<E> : Component() {
      */
     private fun changeSelectedEntity(entity: E) {
         selectedEntity.value = entity
-        onSelect(entity)
+        onSelect?.invoke(entity)
     }
 
     @Composable

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.66`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1086,12 +1086,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 11 22:40:39 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 13 09:16:56 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.66`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1945,12 +1945,12 @@ This report was generated on **Tue Mar 11 22:40:39 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 11 22:40:42 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 13 09:16:58 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.66`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2983,12 +2983,12 @@ This report was generated on **Tue Mar 11 22:40:42 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 11 22:40:44 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 13 09:17:01 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.66`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4007,12 +4007,12 @@ This report was generated on **Tue Mar 11 22:40:44 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 11 22:40:48 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 13 09:17:03 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.66`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4806,12 +4806,12 @@ This report was generated on **Tue Mar 11 22:40:48 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 11 22:40:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 13 09:17:05 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.66`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5575,4 +5575,4 @@ This report was generated on **Tue Mar 11 22:40:50 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 11 22:40:52 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 13 09:17:07 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.66</version>
+<version>2.0.0-SNAPSHOT.67</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.66")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.67")


### PR DESCRIPTION
This PR includes the following:
- The `selectedEntity` property of `Table` is now mutable, which is convenient when the app needs to maintain selection in its own `MutableState` instance.
- Since `Table` preserves its selection by entity's identifier, it's possible that an updated `entities` list will contain a new version of the selected entity. This PR ensures that the `selectedEntity` state gets an up-to-date value of the selected entity in such cases now.
- The `handleRowClick` method is no longer abstract. There's no need to force-implement it now because just specifying `selectedEntity` can be enough.