### PR TITLE
Fix dropdown filtering, improve `Client` API, other improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ allprojects {
                 KotlinX.Coroutines.core,
                 KotlinX.Coroutines.bom,
                 KotlinX.Coroutines.jdk8,
+                KotlinX.Coroutines.swing,
                 KotlinX.Coroutines.test,
                 KotlinX.Coroutines.testJvm,
                 KotlinX.Coroutines.debug,

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
@@ -38,7 +38,7 @@ object KotlinX {
         const val core = "$group:kotlinx-coroutines-core:$version"
         const val jdk8 = "$group:kotlinx-coroutines-jdk8:$version"
 
-        // TODO:2024-08-30:dmitry.pikhulya: the following five libs were added
+        // TODO:2024-08-30:dmitry.pikhulya: the following libs were added
         //    relative to the `config` module's content. Consider updating
         //    the `config` module accordingly.
         //   See https://github.com/SpineEventEngine/Chords/issues/3

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
@@ -38,7 +38,7 @@ object KotlinX {
         const val core = "$group:kotlinx-coroutines-core:$version"
         const val jdk8 = "$group:kotlinx-coroutines-jdk8:$version"
 
-        // TODO:2024-08-30:dmitry.pikhulya: the following four libs were added
+        // TODO:2024-08-30:dmitry.pikhulya: the following five libs were added
         //    relative to the `config` module's content. Consider updating
         //    the `config` module accordingly.
         //   See https://github.com/SpineEventEngine/Chords/issues/3
@@ -46,6 +46,7 @@ object KotlinX {
         const val test = "$group:kotlinx-coroutines-test:$version"
         const val testJvm = "$group:kotlinx-coroutines-test-jvm:$version"
         const val debug = "$group:kotlinx-coroutines-debug:$version"
+        const val swing = "$group:kotlinx-coroutines-swing:$version"
     }
 
     // TODO:2024-08-30:dmitry.pikhulya: This AtomicFu library was added relative

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import io.spine.internal.dependency.Kotlin
+import io.spine.internal.dependency.KotlinX
 import io.spine.internal.dependency.Material3
 import io.spine.internal.dependency.Spine
 
@@ -35,6 +36,7 @@ plugins {
 
 dependencies {
     implementation(Kotlin.reflect)
+    implementation(KotlinX.Coroutines.swing)
     implementation(compose.desktop.currentOs)
     implementation(Material3.Desktop.lib)
     implementation(Spine.CoreJava.server)

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -87,7 +87,7 @@ public interface Client {
      * @param queryFilter A filter to apply when querying the initial list
      *   of entities.
      * @param observeFilter A filter to apply when observing updates to
-     *   the entities, whose criteria should match the ones of [queryFilter].
+     *   the entities, whose criteria should match the ones in [queryFilter].
      * @param onNext A callback function that is called with the list of
      *   entities after the initial query completes, and each time any of the
      *   observed entities is updated.
@@ -104,11 +104,14 @@ public interface Client {
      * Returns a [State], which maintains an up-to-date entity value according
      * to the given filter parameters.
      *
-     * If more than one entity matches the criteria specified by [queryFilter]
+     * Note the following specifics of how special cases are handled:
+     * - If more than one entity matches the criteria specified by [queryFilter]
      * or [observeFilter] parameters, then the returned [State] gets the first
-     * matching value. If no entries match the specified criteria, then the
-     * state gets a non-`null` value of the [defaultValue] parameter. If
-     * [defaultValue] is `null`, [NoMatchingDataException] is thrown.
+     * matching value.
+     * - If no entries match the specified criteria, then the
+     * state gets the value of the [defaultValue] parameter, provided that it
+     * contains non-`null` value.
+     * - If [defaultValue] is `null`, then [NoMatchingDataException] is thrown.
      *
      * @param E A type of entity being read and observed.
      *
@@ -116,7 +119,7 @@ public interface Client {
      *   read and observed.
      * @param queryFilter A filter to use for querying the initial entity value.
      * @param observeFilter A filter to use for observing entity updates, whose
-     *   criteria should match the ones of [queryFilter].
+     *   criteria should match the ones in [queryFilter].
      * @param defaultValue Specifying a non-`null` value prevents this function
      *   from thrown an exception if no matching records were found by using
      *   this value as a result.

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -106,7 +106,8 @@ public interface Client {
      *
      * If more than one entity matches the criteria specified by [queryFilter]
      * or [observeFilter] parameters, then the returned [State] gets the first
-     * matching value.
+     * matching value. If no entries match the specified criteria, then the
+     * respective value is `null`.
      *
      * @param E A type of entity being read and observed.
      *

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -123,7 +123,7 @@ public interface Client {
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter
-    ): State<E?>
+    ): State<E>
 
     /**
      * Retrieves an entity of the specified class with the given ID.

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -61,16 +61,16 @@ import kotlin.time.Duration
      * Reads the list of entities with the [entityClass] class and returns the
      * respective [State], which is maintained to contain an up-to-date list.
      *
-     * By default, this method just launches an asynchronous reading and returns
-     * immediately. Setting [awaitInitialList] to `true` will make the
-     * method to wait for reading the list to complete before returning.
+     * By default, this method waits until the list is read for the first time
+     * before returning. Setting [awaitInitialList] to `false` will start
+     * loading the list in the background and return immediately.
      *
      * @param E A type of entities being read and observed.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of
      *   the entity's ID.
-     * @param awaitInitialList Setting to `true` makes the method to wait for
+     * @param awaitInitialList Setting to `false` makes the method to wait for
      *   reading the current entity list before returning.
      * @return A [State] that contains a list whose content should be populated
      *   and kept up to date by this function.
@@ -78,7 +78,7 @@ import kotlin.time.Duration
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
-        awaitInitialList: Boolean = false
+        awaitInitialList: Boolean = true
     ): State<List<E>>
 
     /**
@@ -89,6 +89,11 @@ import kotlin.time.Duration
      * [observeFilters]. Each time any entity that matches the [observeFilters]
      * changes, the [onNext] callback will be invoked again with the updated
      * list of entities.
+     *
+     * By default, this method waits until the list is read for the first time
+     * and invokes [onNext] with the current list's content before returning.
+     * Setting [awaitInitialList] to `false` will start loading the list in the
+     * background and return immediately.
      *
      * By default, this method just launches an asynchronous reading and returns
      * immediately. Setting [awaitInitialList] to `true` will make the
@@ -112,13 +117,17 @@ import kotlin.time.Duration
         extractId: (E) -> Any,
         queryFilters: CompositeQueryFilter,
         observeFilters: CompositeEntityStateFilter,
-        awaitInitialList: Boolean,
+        awaitInitialList: Boolean = true,
         onNext: (List<E>) -> Unit
     )
 
     /**
      * Returns a [State], which maintains an up-to-date entity value according
      * to the given filter parameters.
+     *
+     * By default, this method waits until the entity value is read for the
+     * first time before returning. Setting [awaitInitialValue] to `false` will
+     * start loading the value in the background and return immediately.
      *
      * @param E A type of entity being read and observed.
      *
@@ -135,7 +144,7 @@ import kotlin.time.Duration
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter,
-        awaitInitialValue: Boolean = false
+        awaitInitialValue: Boolean = true
     ): State<E?>
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -82,28 +82,6 @@ import kotlin.time.Duration
     ): State<List<E>>
 
     /**
-     * Returns a [State], which contains an up-to-date entity value according to
-     * the given filter parameters.
-     *
-     * @param E A type of entity being read and observed.
-     *
-     * @param entityClass A class of entity value that should be
-     *   read and observed.
-     * @param queryFilter Filter to use for querying the initial entity value.
-     * @param observeFilter Filter to use for observing entity updates.
-     * @param awaitInitialValue Setting to `true` makes the method to wait for
-     *   reading the current entity value before returning.
-     * @return A [State] that contains an up-to-date entity value according to
-     *   the given [observeFilter].
-     */
-    public fun <E : EntityState> readAndObserveFirst(
-        entityClass: Class<E>,
-        queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter,
-        awaitInitialValue: Boolean = false
-    ): State<E?>
-
-    /**
      * Reads all entities of type [entityClass] that match the given
      * [queryFilters] and invokes the [onNext] callback with the initial list of
      * entities. Then sets up observation to receive future updates to the
@@ -137,6 +115,28 @@ import kotlin.time.Duration
         awaitInitialList: Boolean,
         onNext: (List<E>) -> Unit
     )
+
+    /**
+     * Returns a [State], which contains an up-to-date entity value according to
+     * the given filter parameters.
+     *
+     * @param E A type of entity being read and observed.
+     *
+     * @param entityClass A class of entity value that should be
+     *   read and observed.
+     * @param queryFilter Filter to use for querying the initial entity value.
+     * @param observeFilter Filter to use for observing entity updates.
+     * @param awaitInitialValue Setting to `true` makes the method to wait for
+     *   reading the current entity value before returning.
+     * @return A [State] that contains an up-to-date entity value according to
+     *   the given [observeFilter].
+     */
+    public fun <E : EntityState> readAndObserveFirst(
+        entityClass: Class<E>,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter,
+        awaitInitialValue: Boolean = false
+    ): State<E?>
 
     /**
      * Retrieves an entity of the specified class with the given ID.

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -107,7 +107,8 @@ public interface Client {
      * If more than one entity matches the criteria specified by [queryFilter]
      * or [observeFilter] parameters, then the returned [State] gets the first
      * matching value. If no entries match the specified criteria, then the
-     * respective value is `null`.
+     * state gets a non-`null` value of the [defaultValue] parameter. If
+     * [defaultValue] is `null`, [NoMatchingDataException] is thrown.
      *
      * @param E A type of entity being read and observed.
      *
@@ -116,14 +117,20 @@ public interface Client {
      * @param queryFilter A filter to use for querying the initial entity value.
      * @param observeFilter A filter to use for observing entity updates, whose
      *   criteria should match the ones of [queryFilter].
+     * @param defaultValue Specifying a non-`null` value prevents this function
+     *   from thrown an exception if no matching records were found by using
+     *   this value as a result.
      * @return A [State] that contains an up-to-date entity value according to
      *   the given criteria.
+     * @throws NoMatchingDataException If there is no entity that matches the
+     *   given criteria and there's no non-`null` [defaultValue] provided.
      */
     public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter
-    ): State<E?>
+        observeFilter: CompositeEntityStateFilter,
+        defaultValue: E? = null
+    ): State<E>
 
     /**
      * Retrieves an entity of the specified class with the given ID.
@@ -363,5 +370,14 @@ public class ServerCommunicationException(cause: Throwable) : RuntimeException(c
 public class ServerError(public val error: Error) : RuntimeException(error.message) {
     public companion object {
         private const val serialVersionUID: Long = -5438430153458733051L
+    }
+}
+
+/**
+ * Signifies a failure to obtain data matching the requested criteria.
+ */
+public class NoMatchingDataException(message: String) : RuntimeException(message) {
+    public companion object {
+        private const val serialVersionUID: Long = 2459671723206505789L
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -166,6 +166,9 @@ import kotlin.time.Duration
      *   when posting a command.
      * @throws ServerError If the command couldn't be acknowledged due to an
      *   error on the server.
+     * @throws ServerCommunicationException In case of a network communication
+     *   failure that has occurred during posting of the command. It is unknown
+     *   whether the command has been acknowledged or no in this case.
      */
     public fun <C: CommandMessage> postCommand(command: C)
 

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -106,8 +106,7 @@ public interface Client {
      *
      * If more than one entity matches the criteria specified by [queryFilter]
      * or [observeFilter] parameters, then the returned [State] gets the first
-     * value from the resulting list. If no entries match the specified
-     * criteria, then the respective value is `null`.
+     * matching value.
      *
      * @param E A type of entity being read and observed.
      *
@@ -117,6 +116,8 @@ public interface Client {
      * @param observeFilter Filter to use for observing entity updates.
      * @return A [State] that contains an up-to-date entity value according to
      *   the given [observeFilter].
+     * @throws NoMatchingDataException If there is no entity that matches the
+     *   given criteria.
      */
     public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
@@ -362,5 +363,14 @@ public class ServerCommunicationException(cause: Throwable) : RuntimeException(c
 public class ServerError(public val error: Error) : RuntimeException(error.message) {
     public companion object {
         private const val serialVersionUID: Long = -5438430153458733051L
+    }
+}
+
+/**
+ * Signifies a failure to obtain data matching the requested criteria.
+ */
+public class NoMatchingDataException(message: String) : RuntimeException(message) {
+    public companion object {
+        private const val serialVersionUID: Long = 2459671723206505789L
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -116,14 +116,12 @@ public interface Client {
      * @param observeFilter Filter to use for observing entity updates.
      * @return A [State] that contains an up-to-date entity value according to
      *   the given [observeFilter].
-     * @throws NoMatchingDataException If there is no entity that matches the
-     *   given criteria.
      */
     public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter
-    ): State<E>
+    ): State<E?>
 
     /**
      * Retrieves an entity of the specified class with the given ID.
@@ -363,14 +361,5 @@ public class ServerCommunicationException(cause: Throwable) : RuntimeException(c
 public class ServerError(public val error: Error) : RuntimeException(error.message) {
     public companion object {
         private const val serialVersionUID: Long = -5438430153458733051L
-    }
-}
-
-/**
- * Signifies a failure to obtain data matching the requested criteria.
- */
-public class NoMatchingDataException(message: String) : RuntimeException(message) {
-    public companion object {
-        private const val serialVersionUID: Long = 2459671723206505789L
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -140,7 +140,7 @@ import kotlin.time.Duration
      * @return A [State] that contains an up-to-date entity value according to
      *   the given [observeFilter].
      */
-    public fun <E : EntityState> readAndObserveFirst(
+    public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter,

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -75,19 +75,19 @@ public interface Client {
 
     /**
      * Reads all entities of type [entityClass] that match the given
-     * [queryFilters] and invokes the [onNext] callback with the initial list of
+     * [queryFilter] and invokes the [onNext] callback with the initial list of
      * entities. Then sets up observation to receive future updates to the
      * entities, filtering the observed updates using the provided
-     * [observeFilters]. Each time any entity that matches the [observeFilters]
+     * [observeFilter]. Each time any entity that matches the [observeFilter]
      * changes, the [onNext] callback will be invoked again with the updated
      * list of entities.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of the entity's ID.
-     * @param queryFilters Filters to apply when querying the initial list
+     * @param queryFilter A filter to apply when querying the initial list
      *   of entities.
-     * @param observeFilters Filters to apply when observing updates to
-     *   the entities.
+     * @param observeFilter A filter to apply when observing updates to
+     *   the entities, whose criteria should match the ones of [queryFilter].
      * @param onNext A callback function that is called with the list of
      *   entities after the initial query completes, and each time any of the
      *   observed entities is updated.
@@ -95,8 +95,8 @@ public interface Client {
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
-        queryFilters: CompositeQueryFilter,
-        observeFilters: CompositeEntityStateFilter,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter,
         onNext: (List<E>) -> Unit
     )
 
@@ -113,10 +113,11 @@ public interface Client {
      *
      * @param entityClass A class of entity value that should be
      *   read and observed.
-     * @param queryFilter Filter to use for querying the initial entity value.
-     * @param observeFilter Filter to use for observing entity updates.
+     * @param queryFilter A filter to use for querying the initial entity value.
+     * @param observeFilter A filter to use for observing entity updates, whose
+     *   criteria should match the ones of [queryFilter].
      * @return A [State] that contains an up-to-date entity value according to
-     *   the given [observeFilter].
+     *   the given criteria.
      */
     public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -26,7 +26,7 @@
 
 package io.spine.chords.client
 
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import com.google.protobuf.Message
 import io.spine.base.CommandMessage
 import io.spine.base.EntityState
@@ -56,22 +56,22 @@ import kotlin.time.Duration
      */
     public val userId: UserId?
 
+
     /**
-     * Reads the list of entities with the [entityClass] class into [targetList]
-     * and ensures that future updates to the list are reflected in [targetList]
+     * Reads the list of entities with the [entityClass] class into a new
+     * [State] and ensures that future updates to the list are reflected in it
      * as well.
      *
      * @param entityClass A class of entities that should be read and observed.
-     * @param targetList A [MutableState] that contains a list whose content
-     *   should be populated and kept up to date by this function.
-     * @param extractId  A callback that should read the value of
+     * @param extractId A callback that should read the value of
      *   the entity's ID.
+     * @return A [State] that contains a list whose content should be populated
+     *   and kept up to date by this function.
      */
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
-        targetList: MutableState<List<E>>,
         extractId: (E) -> Any
-    )
+    ): State<List<E>>
 
     /**
      * Reads all entities of type [entityClass] that match the given

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -95,11 +95,6 @@ import kotlin.time.Duration
      * Setting [awaitInitialList] to `false` will start loading the list in the
      * background and return immediately.
      *
-     * By default, this method just launches an asynchronous reading and returns
-     * immediately. Setting [awaitInitialList] to `true` will make the
-     * method to wait for reading the list to complete, and invoking the
-     * [onNext] callback for the first time before returning.
-     *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of the entity's ID.
      * @param queryFilters Filters to apply when querying the initial list
@@ -124,6 +119,11 @@ import kotlin.time.Duration
     /**
      * Returns a [State], which maintains an up-to-date entity value according
      * to the given filter parameters.
+     *
+     * If more than one entity matches the criteria specified by [queryFilter]
+     * or [observeFilter] parameters, then the returned [State] gets the first
+     * value from the resulting list. If no entries match the specified
+     * criteria, then the respective value is `null`.
      *
      * By default, this method waits until the entity value is read for the
      * first time before returning. Setting [awaitInitialValue] to `false` will

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -74,6 +74,25 @@ import kotlin.time.Duration
     ): State<List<E>>
 
     /**
+     * Returns a [State], which contains an up-to-date entity value according to
+     * the given filter parameters.
+     *
+     * @param E A type of entity being read and observed.
+     *
+     * @param entityClass A class of entity value that should be
+     *   read and observed.
+     * @param queryFilter Filter to use for querying the initial entity value.
+     * @param observeFilter Filter to use for observing entity updates.
+     * @return A [State] that contains an up-to-date entity value according to
+     *   the given [observeFilter].
+     */
+    public fun <E : EntityState> readAndObserveFirst(
+        entityClass: Class<E>,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter
+    ): State<E?>
+
+    /**
      * Reads all entities of type [entityClass] that match the given
      * [queryFilters] and invokes the [onNext] callback with the initial list of
      * entities. Then sets up observation to receive future updates to the

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -58,19 +58,27 @@ import kotlin.time.Duration
 
 
     /**
-     * Reads the list of entities with the [entityClass] class into a new
-     * [State] and ensures that future updates to the list are reflected in it
-     * as well.
+     * Reads the list of entities with the [entityClass] class and returns the
+     * respective [State], which is maintained to contain an up-to-date list.
+     *
+     * By default, this method just launches an asynchronous reading and returns
+     * immediately. Setting [awaitInitialList] to `true` will make the
+     * method to wait for reading the list to complete before returning.
+     *
+     * @param E A type of entities being read and observed.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of
      *   the entity's ID.
+     * @param awaitInitialList Setting to `true` makes the method to wait for
+     *   reading the current entity list before returning.
      * @return A [State] that contains a list whose content should be populated
      *   and kept up to date by this function.
      */
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
-        extractId: (E) -> Any
+        extractId: (E) -> Any,
+        awaitInitialList: Boolean = false
     ): State<List<E>>
 
     /**
@@ -83,13 +91,16 @@ import kotlin.time.Duration
      *   read and observed.
      * @param queryFilter Filter to use for querying the initial entity value.
      * @param observeFilter Filter to use for observing entity updates.
+     * @param awaitInitialValue Setting to `true` makes the method to wait for
+     *   reading the current entity value before returning.
      * @return A [State] that contains an up-to-date entity value according to
      *   the given [observeFilter].
      */
     public fun <E : EntityState> readAndObserveFirst(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter
+        observeFilter: CompositeEntityStateFilter,
+        awaitInitialValue: Boolean = false
     ): State<E?>
 
     /**
@@ -101,12 +112,19 @@ import kotlin.time.Duration
      * changes, the [onNext] callback will be invoked again with the updated
      * list of entities.
      *
+     * By default, this method just launches an asynchronous reading and returns
+     * immediately. Setting [awaitInitialList] to `true` will make the
+     * method to wait for reading the list to complete, and invoking the
+     * [onNext] callback for the first time before returning.
+     *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of the entity's ID.
      * @param queryFilters Filters to apply when querying the initial list
      *   of entities.
      * @param observeFilters Filters to apply when observing updates to
      *   the entities.
+     * @param awaitInitialList Setting to `true` makes the method to wait for
+     *   reading the current entity list before returning.
      * @param onNext A callback function that is called with the list of
      *   entities after the initial query completes, and each time any of the
      *   observed entities is updated.
@@ -116,6 +134,7 @@ import kotlin.time.Duration
         extractId: (E) -> Any,
         queryFilters: CompositeQueryFilter,
         observeFilters: CompositeEntityStateFilter,
+        awaitInitialList: Boolean,
         onNext: (List<E>) -> Unit
     )
 

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -117,8 +117,8 @@ import kotlin.time.Duration
     )
 
     /**
-     * Returns a [State], which contains an up-to-date entity value according to
-     * the given filter parameters.
+     * Returns a [State], which maintains an up-to-date entity value according
+     * to the given filter parameters.
      *
      * @param E A type of entity being read and observed.
      *

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -41,7 +41,7 @@ import kotlin.time.Duration
 /**
  * Provides an API for interacting with the application server.
  */
- public interface Client {
+public interface Client {
 
     /**
      * Signifies whether the connection with the server is open.
@@ -56,29 +56,21 @@ import kotlin.time.Duration
      */
     public val userId: UserId?
 
-
     /**
      * Reads the list of entities with the [entityClass] class and returns the
      * respective [State], which is maintained to contain an up-to-date list.
-     *
-     * By default, this method waits until the list is read for the first time
-     * before returning. Setting [awaitInitialList] to `false` will start
-     * loading the list in the background and return immediately.
      *
      * @param E A type of entities being read and observed.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of
      *   the entity's ID.
-     * @param awaitInitialList Setting to `false` makes the method to wait for
-     *   reading the current entity list before returning.
      * @return A [State] that contains a list whose content should be populated
      *   and kept up to date by this function.
      */
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
-        extractId: (E) -> Any,
-        awaitInitialList: Boolean = true
+        extractId: (E) -> Any
     ): State<List<E>>
 
     /**
@@ -90,19 +82,12 @@ import kotlin.time.Duration
      * changes, the [onNext] callback will be invoked again with the updated
      * list of entities.
      *
-     * By default, this method waits until the list is read for the first time
-     * and invokes [onNext] with the current list's content before returning.
-     * Setting [awaitInitialList] to `false` will start loading the list in the
-     * background and return immediately.
-     *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of the entity's ID.
      * @param queryFilters Filters to apply when querying the initial list
      *   of entities.
      * @param observeFilters Filters to apply when observing updates to
      *   the entities.
-     * @param awaitInitialList Setting to `true` makes the method to wait for
-     *   reading the current entity list before returning.
      * @param onNext A callback function that is called with the list of
      *   entities after the initial query completes, and each time any of the
      *   observed entities is updated.
@@ -112,7 +97,6 @@ import kotlin.time.Duration
         extractId: (E) -> Any,
         queryFilters: CompositeQueryFilter,
         observeFilters: CompositeEntityStateFilter,
-        awaitInitialList: Boolean = true,
         onNext: (List<E>) -> Unit
     )
 
@@ -125,26 +109,19 @@ import kotlin.time.Duration
      * value from the resulting list. If no entries match the specified
      * criteria, then the respective value is `null`.
      *
-     * By default, this method waits until the entity value is read for the
-     * first time before returning. Setting [awaitInitialValue] to `false` will
-     * start loading the value in the background and return immediately.
-     *
      * @param E A type of entity being read and observed.
      *
      * @param entityClass A class of entity value that should be
      *   read and observed.
      * @param queryFilter Filter to use for querying the initial entity value.
      * @param observeFilter Filter to use for observing entity updates.
-     * @param awaitInitialValue Setting to `true` makes the method to wait for
-     *   reading the current entity value before returning.
      * @return A [State] that contains an up-to-date entity value according to
      *   the given [observeFilter].
      */
     public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter,
-        awaitInitialValue: Boolean = true
+        observeFilter: CompositeEntityStateFilter
     ): State<E?>
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -91,7 +91,7 @@ public class DesktopClient(
      */
     override val isOpen: Boolean get() = spineClient.isOpen
 
-    public override val userId: UserId?
+    override val userId: UserId?
         get() = user()
 
 
@@ -102,30 +102,12 @@ public class DesktopClient(
         spineClient.close()
     }
 
-    /**
-     * Reads the list of entities with the [entityClass] class and returns the
-     * respective [State], which is maintained to contain an up-to-date list.
-     *
-     * By default, this method waits until the list is read for the first time
-     * before returning. Setting [awaitInitialList] to `false` will start
-     * loading the list in the background and return immediately.
-     *
-     * @param E A type of entities being read and observed.
-     *
-     * @param entityClass A class of entities that should be read and observed.
-     * @param extractId A callback that should read the value of
-     *   the entity's ID.
-     * @param awaitInitialList Setting to `false` makes the method to wait for
-     *   reading the current entity list before returning.
-     * @return A [State] that contains a list whose content should be populated
-     *   and kept up to date by this function.
-     */
     @OptIn(
         // The observation setup coroutine is short-lived and doesn't need to be
         // limited to a particular scope.
         DelicateCoroutinesApi::class
     )
-    public override fun <E : EntityState> readAndObserve(
+    override fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
         awaitInitialList: Boolean
@@ -155,38 +137,12 @@ public class DesktopClient(
         return listState
     }
 
-    /**
-     * Reads all entities of type [entityClass] that match the given
-     * [queryFilters] and invokes the [onNext] callback with the initial list of
-     * entities. Then sets up observation to receive future updates to the
-     * entities, filtering the observed updates using the provided
-     * [observeFilters]. Each time any entity that matches the [observeFilters]
-     * changes, the [onNext] callback will be invoked again with the updated
-     * list of entities.
-     *
-     * By default, this method waits until the list is read for the first time
-     * and invokes [onNext] with the current list's content before returning.
-     * Setting [awaitInitialList] to `false` will start loading the list in the
-     * background and return immediately.
-     *
-     * @param entityClass A class of entities that should be read and observed.
-     * @param extractId A callback that should read the value of the entity's ID.
-     * @param queryFilters Filters to apply when querying the initial list
-     *   of entities.
-     * @param observeFilters Filters to apply when observing updates to
-     *   the entities.
-     * @param awaitInitialList Setting to `true` makes the method to wait for
-     *   reading the current entity list before returning.
-     * @param onNext A callback function that is called with the list of
-     *   entities after the initial query completes, and each time any of the
-     *   observed entities is updated.
-     */
     @OptIn(
         // The observation setup coroutine is short-lived and doesn't need to be
         // limited to a particular scope.
         DelicateCoroutinesApi::class
     )
-    public override fun <E : EntityState> readAndObserve(
+    override fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
         queryFilters: CompositeQueryFilter,
@@ -225,30 +181,6 @@ public class DesktopClient(
         }
     }
 
-    /**
-     * Returns a [State], which maintains an up-to-date entity value according
-     * to the given filter parameters.
-     *
-     * If more than one entity matches the criteria specified by [queryFilter]
-     * or [observeFilter] parameters, then the returned [State] gets the first
-     * value from the resulting list. If no entries match the specified
-     * criteria, then the respective value is `null`.
-     *
-     * By default, this method waits until the entity value is read for the
-     * first time before returning. Setting [awaitInitialValue] to `false` will
-     * start loading the value in the background and return immediately.
-     *
-     * @param E A type of entity being read and observed.
-     *
-     * @param entityClass A class of entity value that should be
-     *   read and observed.
-     * @param queryFilter Filter to use for querying the initial entity value.
-     * @param observeFilter Filter to use for observing entity updates.
-     * @param awaitInitialValue Setting to `true` makes the method to wait for
-     *   reading the current entity value before returning.
-     * @return A [State] that contains an up-to-date entity value according to
-     *   the given [observeFilter].
-     */
     override fun <E : EntityState> readAndObserveFirst(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
@@ -262,13 +194,7 @@ public class DesktopClient(
         return entityState
     }
 
-    /**
-     * Retrieves an entity of the specified class with the given ID.
-     *
-     * @param entityClass The class of the entity to retrieve.
-     * @param id The ID of the entity to retrieve.
-     */
-    public override fun <E : EntityState, M : Message> read(
+    override fun <E : EntityState, M : Message> read(
         entityClass: Class<E>,
         id: M
     ): E? {
@@ -279,16 +205,6 @@ public class DesktopClient(
         return entities.firstOrNull()
     }
 
-    /**
-     * Posts the given [command] to the server.
-     *
-     * @param command A command that has to be posted.
-     * @throws ServerError If the command could not be acknowledged due to an
-     *   error on the server.
-     * @throws ServerCommunicationException In case of a network communication
-     *   failure that has occurred during posting of the command. It is unknown
-     *   whether the command has been acknowledged or no in this case.
-     */
     override fun <C : CommandMessage> postCommand(command: C) {
         var error: Throwable? = null
         try {
@@ -313,22 +229,11 @@ public class DesktopClient(
         }
     }
 
-    /**
-     * Posts the specified [command] and handles the respective [consequences].
-     *
-     * See the [Client.postCommand] documentation for details.
-     */
-    public override fun <C : CommandMessage> postCommand(
+    override fun <C : CommandMessage> postCommand(
         command: C,
         consequences: CommandConsequences<C>
     ): EventSubscriptions = consequences.postAndProcessConsequences(command)
 
-    /**
-     * Subscribes to an event of type [E] whose given [field]
-     * equals [fieldValue].
-     *
-     * See the [Client.onEvent] documentation for details.
-     */
     override fun <E : EventMessage> onEvent(
         event: Class<E>,
         field: EventMessageField,

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -103,20 +103,19 @@ public class DesktopClient(
     }
 
     /**
-     * Reads the list of entities with the [entityClass] class into a new
-     * [State] and ensures that future updates to the list are reflected in it
-     * as well.
+     * Reads the list of entities with the [entityClass] class and returns the
+     * respective [State], which is maintained to contain an up-to-date list.
      *
-     * By default, this method just launches an asynchronous reading and returns
-     * immediately. Setting [awaitInitialList] to `true` will make the
-     * method to wait for reading the list to complete before returning.
+     * By default, this method waits until the list is read for the first time
+     * before returning. Setting [awaitInitialList] to `false` will start
+     * loading the list in the background and return immediately.
      *
      * @param E A type of entities being read and observed.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of
      *   the entity's ID.
-     * @param awaitInitialList Setting to `true` makes the method to wait for
+     * @param awaitInitialList Setting to `false` makes the method to wait for
      *   reading the current entity list before returning.
      * @return A [State] that contains a list whose content should be populated
      *   and kept up to date by this function.
@@ -165,14 +164,13 @@ public class DesktopClient(
      * changes, the [onNext] callback will be invoked again with the updated
      * list of entities.
      *
-     * By default, this method just launches an asynchronous reading and returns
-     * immediately. Setting [awaitInitialList] to `true` will make the
-     * method to wait for reading the list to complete, and invoking the
-     * [onNext] callback for the first time before returning.
+     * By default, this method waits until the list is read for the first time
+     * and invokes [onNext] with the current list's content before returning.
+     * Setting [awaitInitialList] to `false` will start loading the list in the
+     * background and return immediately.
      *
      * @param entityClass A class of entities that should be read and observed.
-     * @param extractId A callback that should read the value of the
-     *   entity's ID.
+     * @param extractId A callback that should read the value of the entity's ID.
      * @param queryFilters Filters to apply when querying the initial list
      *   of entities.
      * @param observeFilters Filters to apply when observing updates to
@@ -236,13 +234,16 @@ public class DesktopClient(
      * value from the resulting list. If no entries match the specified
      * criteria, then the respective value is `null`.
      *
+     * By default, this method waits until the entity value is read for the
+     * first time before returning. Setting [awaitInitialValue] to `false` will
+     * start loading the value in the background and return immediately.
+     *
      * @param E A type of entity being read and observed.
      *
      * @param entityClass A class of entity value that should be
      *   read and observed.
-     * @param queryFilter A filter for querying the initial entity value.
-     * @param observeFilter A filter for observing entity updates, whose
-     *   criteria are expected to match the ones in [queryFilter].
+     * @param queryFilter Filter to use for querying the initial entity value.
+     * @param observeFilter Filter to use for observing entity updates.
      * @param awaitInitialValue Setting to `true` makes the method to wait for
      *   reading the current entity value before returning.
      * @return A [State] that contains an up-to-date entity value according to

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -125,11 +125,11 @@ public class DesktopClient(
         observeFilters: CompositeEntityStateFilter,
         onNext: (List<E>) -> Unit
     ) {
-        val initialResult: List<E>? = clientRequest()
+        val initialResult: List<E> = clientRequest()
             .select(entityClass)
             .where(queryFilters)
             .run()
-        onNext(initialResult!!)
+        onNext(initialResult)
         val observedEntities = mutableStateOf(initialResult)
         clientRequest()
             .subscribeTo(entityClass)

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -121,13 +121,13 @@ public class DesktopClient(
     override fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
-        queryFilters: CompositeQueryFilter,
-        observeFilters: CompositeEntityStateFilter,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter,
         onNext: (List<E>) -> Unit
     ) {
         val initialResult: List<E> = clientRequest()
             .select(entityClass)
-            .where(queryFilters)
+            .where(queryFilter)
             .run()
         onNext(initialResult)
         val observedEntities = mutableStateOf(initialResult)
@@ -139,7 +139,7 @@ public class DesktopClient(
                     onNext(observedEntities.value)
                 }
             }
-            .where(observeFilters)
+            .where(observeFilter)
             .post()
     }
 

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -132,12 +132,18 @@ public class DesktopClient(
      * Returns a [State], which contains an up-to-date entity value according to
      * the given filter parameters.
      *
+     * If more than one entity matches the criteria specified by [queryFilter]
+     * or [observeFilter] parameters, then the returned [State] gets the first
+     * value from the resulting list. If no entries match the specified
+     * criteria, then the respective value is `null`.
+     *
      * @param E A type of entity being read and observed.
      *
      * @param entityClass A class of entity value that should be
      *   read and observed.
-     * @param queryFilter Filter to use for querying the initial entity value.
-     * @param observeFilter Filter to use for observing entity updates.
+     * @param queryFilter A filter for querying the initial entity value.
+     * @param observeFilter A filter for observing entity updates, whose
+     *   criteria are expected to match the ones in [queryFilter].
      * @return A [State] that contains an up-to-date entity value according to
      *   the given [observeFilter].
      */

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -181,7 +181,7 @@ public class DesktopClient(
         }
     }
 
-    override fun <E : EntityState> readAndObserveFirst(
+    override fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter,

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -144,40 +144,6 @@ public class DesktopClient(
     }
 
     /**
-     * Returns a [State], which contains an up-to-date entity value according to
-     * the given filter parameters.
-     *
-     * If more than one entity matches the criteria specified by [queryFilter]
-     * or [observeFilter] parameters, then the returned [State] gets the first
-     * value from the resulting list. If no entries match the specified
-     * criteria, then the respective value is `null`.
-     *
-     * @param E A type of entity being read and observed.
-     *
-     * @param entityClass A class of entity value that should be
-     *   read and observed.
-     * @param queryFilter A filter for querying the initial entity value.
-     * @param observeFilter A filter for observing entity updates, whose
-     *   criteria are expected to match the ones in [queryFilter].
-     * @param awaitInitialValue Setting to `true` makes the method to wait for
-     *   reading the current entity value before returning.
-     * @return A [State] that contains an up-to-date entity value according to
-     *   the given [observeFilter].
-     */
-    override fun <E : EntityState> readAndObserveFirst(
-        entityClass: Class<E>,
-        queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter,
-        awaitInitialValue: Boolean
-    ): State<E?> {
-        val entityState = mutableStateOf<E?>(null)
-        readAndObserve(entityClass, { it }, queryFilter, observeFilter, awaitInitialValue) {
-            entityState.value = if (it.size > 0) it.first() else null
-        }
-        return entityState
-    }
-
-    /**
      * Reads all entities of type [entityClass] that match the given
      * [queryFilters] and invokes the [onNext] callback with the initial list of
      * entities. Then sets up observation to receive future updates to the
@@ -234,6 +200,40 @@ public class DesktopClient(
         if (awaitInitialList) {
             initialRead.get()
         }
+    }
+
+    /**
+     * Returns a [State], which contains an up-to-date entity value according to
+     * the given filter parameters.
+     *
+     * If more than one entity matches the criteria specified by [queryFilter]
+     * or [observeFilter] parameters, then the returned [State] gets the first
+     * value from the resulting list. If no entries match the specified
+     * criteria, then the respective value is `null`.
+     *
+     * @param E A type of entity being read and observed.
+     *
+     * @param entityClass A class of entity value that should be
+     *   read and observed.
+     * @param queryFilter A filter for querying the initial entity value.
+     * @param observeFilter A filter for observing entity updates, whose
+     *   criteria are expected to match the ones in [queryFilter].
+     * @param awaitInitialValue Setting to `true` makes the method to wait for
+     *   reading the current entity value before returning.
+     * @return A [State] that contains an up-to-date entity value according to
+     *   the given [observeFilter].
+     */
+    override fun <E : EntityState> readAndObserveFirst(
+        entityClass: Class<E>,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter,
+        awaitInitialValue: Boolean
+    ): State<E?> {
+        val entityState = mutableStateOf<E?>(null)
+        readAndObserve(entityClass, { it }, queryFilter, observeFilter, awaitInitialValue) {
+            entityState.value = if (it.size > 0) it.first() else null
+        }
+        return entityState
     }
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -200,7 +200,7 @@ public class DesktopClient(
                 .select(entityClass)
                 .where(queryFilters)
                 .run()
-            onNext(initialResult!!)
+             onNext(initialResult!!)
         }
         if (awaitInitialList) {
             readInitialList()

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -147,9 +147,8 @@ public class DesktopClient(
         val initialValue = initialList.getOrNull(0) ?: defaultValue
         if (initialValue == null) {
             throw NoMatchingDataException(
-                "No entity could be found that matches the specified criteria:\n" +
-                "    entityClass = ${entityClass.name}\n" +
-                "    queryFilter = $queryFilter\n"
+                "No entity could be found that matches the specified criteria, and no " +
+                        "`defaultValue` has been provided. Entity class: ${entityClass.name}"
             )
         }
         val state = mutableStateOf(initialValue)

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -203,8 +203,8 @@ public class DesktopClient(
     }
 
     /**
-     * Returns a [State], which contains an up-to-date entity value according to
-     * the given filter parameters.
+     * Returns a [State], which maintains an up-to-date entity value according
+     * to the given filter parameters.
      *
      * If more than one entity matches the criteria specified by [queryFilter]
      * or [observeFilter] parameters, then the returned [State] gets the first

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -147,19 +147,13 @@ public class DesktopClient(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter
-    ): State<E> {
+    ): State<E?> {
         val initialResult: List<E> = clientRequest()
             .select(entityClass)
             .where(queryFilter)
             .limit(1)
             .run()
-        if (initialResult.size == 0) {
-            throw NoMatchingDataException(
-                "No entity could be found that matches the specified criteria"
-            )
-        }
-
-        val state = mutableStateOf(initialResult.get(0))
+        val state = mutableStateOf(initialResult.getOrNull(0))
 
         clientRequest()
             .subscribeTo(entityClass)

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -60,13 +60,13 @@ import kotlin.reflect.javaType
  * to specify the type of items to be searched for by implementing the
  * [entityStateClass] method, and implement [entityId] and [itemText] methods.
  *
- * @param I a type of entity ID.
- * @param E a type of entity state.
+ * @param E A type of entity state.
+ * @param I A type of entity ID.
  */
 @Stable
 public abstract class EntityChooser<
-        I : MessageFieldValue,
-        E : EntityState // Keep in sync with the `TypeParameters` enum!
+        E : EntityState, // Keep in sync with the `TypeParameters` enum!
+        I : MessageFieldValue
         > : DropdownSelector<I>() {
 
     /**
@@ -77,24 +77,18 @@ public abstract class EntityChooser<
     private enum class TypeParameters(val index: Int) {
 
         /**
-         * The entity ID type parameter (`I` class's parameter).
-         */
-        ID(0),
-
-        /**
          * The entity state type parameter (`E` class's parameter).
          */
-        ENTITY_STATE(1)
+        ENTITY_STATE(0),
+
+        /**
+         * The entity ID type parameter (`I` class's parameter).
+         */
+        ID(1)
     }
 
     override val items: MutableState<Iterable<I>> = mutableStateOf(listOf())
-
-    private val entityStates = run {
-        val entityStates = mutableStateOf(listOf<E>())
-        app.client.readAndObserve(entityStateClass, entityStates, ::entityId)
-        entityStates
-    }
-
+    private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId)
     private val entityStatesByIds: HashMap<I, E> = hashMapOf()
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -88,7 +88,7 @@ public abstract class EntityChooser<
     }
 
     override val items: MutableState<Iterable<I>> = mutableStateOf(listOf())
-    private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId)
+    private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId, false)
     private val entityStatesByIds: HashMap<I, E> = hashMapOf()
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -88,7 +88,7 @@ public abstract class EntityChooser<
     }
 
     override val items: MutableState<Iterable<I>> = mutableStateOf(listOf())
-    private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId, false)
+    private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId)
     private val entityStatesByIds: HashMap<I, E> = hashMapOf()
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
@@ -140,7 +140,7 @@ import kotlin.time.Duration
 public open class ModalCommandConsequences<C : CommandMessage>(
     private val postingState: MutableState<Boolean>,
     public val close: () -> Unit,
-    consequences: ModalCommandConsequencesScope<C>.() -> Unit,
+    consequences: ModalCommandConsequencesScope<C>.() -> Unit
 ) : CommandConsequences<C>(
     consequences as CommandConsequencesScope<C>.() -> Unit
 ) {

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -150,8 +150,7 @@ import kotlinx.coroutines.launch
  * - Mouse clicks have to be handled on the invoker with calling the
  *   [DropdownListBoxScope.handleClick] function.
  *
- * @param I
- *         a type of items displayed in the drop-down list.
+ * @param I A type of items displayed in the drop-down list.
  */
 // All class's functions are better to have in this class.
 @Suppress("TooManyFunctions", "LargeClass")
@@ -190,7 +189,7 @@ public class DropdownListBox<I> : Component() {
     /**
      * A list of items to display in the drop-down list.
      */
-    public var items: Iterable<I> = emptyList()
+    public var items: Iterable<I> by mutableStateOf(emptyList())
 
     /**
      * Specifies whether clicking the invoker triggers displaying of the
@@ -202,7 +201,7 @@ public class DropdownListBox<I> : Component() {
      * Currently selected item in the drop-down list,
      * or `null` if none is selected.
      */
-    public var selectedItem: I? = null
+    public var selectedItem: I? by mutableStateOf(null)
 
     /**
      * A function to be called when an item in the drop-down list is selected.

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -154,12 +154,13 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
      * is selected or not.
      */
     private val fieldTextStyle: TextStyle @Composable get() {
-        val defaultTextStyle = LocalTextStyle.current
+        val currentTextStyle = LocalTextStyle.current
         return if (selectedItem != null) {
-            defaultTextStyle
+            currentTextStyle
         } else {
-            val defaultTextColor = defaultTextStyle.color
-            defaultTextStyle.copy(color = defaultTextColor.copy(alpha = 0.5f))
+            currentTextStyle.copy(
+                currentTextStyle.color.copy(0.5f)
+            )
         }
     }
 
@@ -191,7 +192,6 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
     }
 
     @Composable
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun content() {
         val fieldText = getFieldText(searchString)
 

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -28,7 +28,10 @@ package io.spine.chords.core.appshell
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.window.application
 import io.spine.chords.core.layout.ConfirmationDialog
@@ -197,13 +200,19 @@ public open class Application(
         }
 
         application(exitProcessOnExit = exitProcessOnClose) {
+            var mainWindowVisible by mutableStateOf(true)
             val appWindow = remember {
-                val appWindow = createAppWindow(::exitApplication)
+                val appWindow = createAppWindow({
+                    mainWindowVisible = false
+                    exitApplication()
+                })
                 _ui = ApplicationUI(appWindow)
                 appWindow.mainScreen.topBar.actions = { topBarActions() }
                 appWindow
             }
-            appWindowContent(appWindow)
+            if (mainWindowVisible) {
+                appWindowContent(appWindow)
+            }
         }
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -41,6 +41,24 @@ import kotlinx.coroutines.CompletableDeferred
 /**
  * A dialog that prompts the user either to make a boolean decision
  * (e.g. approve or deny some action).
+ *
+ * Use the [ConfirmationDialog.showConfirmation] function to display the
+ * confirmation dialog and wait for the user's decision:
+ *
+ * ```
+ *     val confirmed = ConfirmationDialog.showConfirmation {
+ *         message = "Are you sure you want to continue?"
+ *         description = "This action is irreversible."
+ *     }
+ * ```
+ *
+ * You can also import this function specifically and make its usages
+ * more concise, like this:
+ * ```
+ *     val confirmed = showConfirmation {
+ *         message = "Are you sure you want to continue?"
+ *     }
+ * ```
  */
 public class ConfirmationDialog : Dialog() {
     public companion object : AbstractComponentSetup({ ConfirmationDialog() }) {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.CompletableDeferred
  * A dialog that prompts the user either to make a boolean decision
  * (e.g. approve or deny some action).
  *
- * Use the [ConfirmationDialog.showConfirmation] function to display the
+ * Use the `ConfirmationDialog.showConfirmation` function to display the
  * confirmation dialog and wait for the user's decision:
  *
  * ```

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -40,6 +40,17 @@ import kotlinx.coroutines.CompletableDeferred
 
 /**
  * A dialog that displays the specified text message for the user.
+ *
+ * Use the `MessageDialog.showMessage` method to show the dialog.
+ * Here's an example:
+ * ```
+ *     MessageDialog.showMessage("An error has occurred: ...")
+ * ```
+ *
+ * You can make the usage more concise by importing this function:
+ * ```
+ *     showMessage("An error has occurred: ...")
+ * ```
  */
 public class MessageDialog : Dialog() {
     public companion object : AbstractComponentSetup({ MessageDialog() }) {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1094,7 +1094,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 12:57:19 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 17:59:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1953,7 +1953,7 @@ This report was generated on **Fri Mar 21 12:57:19 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 12:57:21 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 17:59:52 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2991,7 +2991,7 @@ This report was generated on **Fri Mar 21 12:57:21 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 12:57:23 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 17:59:55 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4015,7 +4015,7 @@ This report was generated on **Fri Mar 21 12:57:23 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 12:57:26 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 17:59:57 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4814,7 +4814,7 @@ This report was generated on **Fri Mar 21 12:57:26 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 12:57:28 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 17:59:59 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5583,4 +5583,4 @@ This report was generated on **Fri Mar 21 12:57:28 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 12:57:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 18:00:01 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -230,6 +230,10 @@
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-swing. **Version** : 1.7.3.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.4.0.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.4.0.
      * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
@@ -979,6 +983,10 @@
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-swing. **Version** : 1.7.3.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-test. **Version** : 1.7.3.**No license information found**
 1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-test-jvm. **Version** : 1.7.3.
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
@@ -1086,7 +1094,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 20 16:30:47 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 12:57:19 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1945,7 +1953,7 @@ This report was generated on **Thu Mar 20 16:30:47 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 20 16:30:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 12:57:21 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2983,7 +2991,7 @@ This report was generated on **Thu Mar 20 16:30:50 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 20 16:30:55 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 12:57:23 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4007,7 +4015,7 @@ This report was generated on **Thu Mar 20 16:30:55 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 20 16:30:57 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 12:57:26 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4806,7 +4814,7 @@ This report was generated on **Thu Mar 20 16:30:57 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 20 16:31:00 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 12:57:28 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5575,4 +5583,4 @@ This report was generated on **Thu Mar 20 16:31:00 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 20 16:31:02 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 12:57:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.68`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.69`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -121,7 +121,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -240,7 +240,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -770,7 +770,7 @@
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -1012,7 +1012,7 @@
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1086,12 +1086,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 20:41:53 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 20 16:30:47 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.68`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.69`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1945,12 +1945,12 @@ This report was generated on **Mon Mar 17 20:41:53 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 20:41:55 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 20 16:30:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.68`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.69`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2041,7 +2041,7 @@ This report was generated on **Mon Mar 17 20:41:55 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2159,7 +2159,7 @@ This report was generated on **Mon Mar 17 20:41:55 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2664,7 +2664,7 @@ This report was generated on **Mon Mar 17 20:41:55 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -2909,7 +2909,7 @@ This report was generated on **Mon Mar 17 20:41:55 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2983,12 +2983,12 @@ This report was generated on **Mon Mar 17 20:41:55 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 20:41:57 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 20 16:30:55 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.68`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.69`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3077,7 +3077,7 @@ This report was generated on **Mon Mar 17 20:41:57 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3192,7 +3192,7 @@ This report was generated on **Mon Mar 17 20:41:57 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3691,7 +3691,7 @@ This report was generated on **Mon Mar 17 20:41:57 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-macos-x64. **Version** : 1.5.12.**No license information found**
+1.  **Group** : org.jetbrains.compose.desktop. **Name** : desktop-jvm-windows-x64. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation. **Version** : 1.5.12.**No license information found**
 1.  **Group** : org.jetbrains.compose.foundation. **Name** : foundation-desktop. **Version** : 1.5.12.
      * **Project URL:** [https://github.com/JetBrains/compose-jb](https://github.com/JetBrains/compose-jb)
@@ -3933,7 +3933,7 @@ This report was generated on **Mon Mar 17 20:41:57 EET 2025** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-macos-x64. **Version** : 0.7.85.4.
+1.  **Group** : org.jetbrains.skiko. **Name** : skiko-awt-runtime-windows-x64. **Version** : 0.7.85.4.
      * **Project URL:** [https://www.github.com/JetBrains/skiko](https://www.github.com/JetBrains/skiko)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4007,12 +4007,12 @@ This report was generated on **Mon Mar 17 20:41:57 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 20:41:58 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 20 16:30:57 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.68`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.69`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4806,12 +4806,12 @@ This report was generated on **Mon Mar 17 20:41:58 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 20:41:59 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 20 16:31:00 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.68`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.69`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5575,4 +5575,4 @@ This report was generated on **Mon Mar 17 20:41:59 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 20:42:01 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 20 16:31:02 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.68</version>
+<version>2.0.0-SNAPSHOT.69</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -79,7 +79,7 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.compose.desktop</groupId>
-    <artifactId>desktop-jvm-macos-x64</artifactId>
+    <artifactId>desktop-jvm-windows-x64</artifactId>
     <version>1.5.12</version>
     <scope>compile</scope>
   </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
+    <groupId>org.jetbrains.kotlinx</groupId>
+    <artifactId>kotlinx-coroutines-swing</artifactId>
+    <version>1.7.3</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-testlib</artifactId>
     <version>31.1-jre</version>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.68")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.69")


### PR DESCRIPTION
This PR contains the following:
- A fix for the `DropdownListBox`'s item filtering behavior (a regression where items were not filtered automatically until changing the selected item).
- An improvement of the `Client's` API for reading and observing entities:
  - The `Client.readAndObserve` method was changed from accepting `MutableState` to creating and returning it automatically, which simplifies its usages.
  - Added `Client.readOneAndObserve` to address a common scenario when just one entity state needs to be obtained.
- Speed up closing of main window when existing.
- Added `kotlinx-coroutines-swing` dependency, which is required for `Dispatchers.Main` to be usable.