### PR TITLE
Implement `StringField` component

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -29,7 +29,6 @@ package io.spine.chords.client.form
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import io.spine.base.CommandMessage
 import io.spine.chords.client.CommandConsequences
 import io.spine.chords.client.CommandConsequencesScope
@@ -42,7 +41,6 @@ import io.spine.chords.proto.form.MessageForm
 import io.spine.chords.proto.form.MessageFormSetupBase
 import io.spine.chords.proto.form.MultipartFormScope
 import io.spine.protobuf.ValidatingBuilder
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * A form that allows entering a value of a command message and posting
@@ -341,12 +339,6 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
         { CommandConsequences(it) }
 
     /**
-     * [CoroutineScope] owned by this form's composition used for running
-     * form-related suspending calls.
-     */
-    private lateinit var coroutineScope: CoroutineScope
-
-    /**
      * Event subscriptions, which were made by [commandConsequences] as a result
      * of command posted during dialog form's submission.
      */
@@ -355,12 +347,6 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
     override fun initialize() {
         super.initialize()
         requireProperty(this::commandConsequences.isInitialized, "commandConsequences")
-    }
-
-    @Composable
-    override fun content() {
-        coroutineScope = rememberCoroutineScope()
-        super.content()
     }
 
     /**
@@ -396,7 +382,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      * @see commandConsequences
      * @see cancelActiveSubscriptions
      */
-    public suspend fun postCommand(): EventSubscriptions {
+    public fun postCommand(): EventSubscriptions {
         updateValidationDisplay(true)
         check(valueValid.value) {
             "`postCommand` cannot be invoked on an invalid form`"

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -28,6 +28,7 @@ package io.spine.chords.client.form
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.mutableStateOf
 import io.spine.base.CommandMessage
 import io.spine.chords.client.CommandConsequences
@@ -344,6 +345,8 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      */
     private var activeSubscriptions: MutableList<EventSubscriptions> = ArrayList()
 
+    @Composable
+    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         requireProperty(this::commandConsequences.isInitialized, "commandConsequences")

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -28,7 +28,6 @@ package io.spine.chords.client.form
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.mutableStateOf
 import io.spine.base.CommandMessage
 import io.spine.chords.client.CommandConsequences
@@ -345,8 +344,6 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      */
     private var activeSubscriptions: MutableList<EventSubscriptions> = ArrayList()
 
-    @Composable
-    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         requireProperty(this::commandConsequences.isInitialized, "commandConsequences")

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -650,15 +650,7 @@ public abstract class Component : DefaultPropsOwnerBase() {
      * [props] callback (which is passed along with component instance's
      * declaration) has been invoked for the first time, and before
      * the component's composable content is rendered for the first time.
-     *
-     * This function is declared as being a read-only composable one for
-     * the implementations to be able to access the composition-related data,
-     * such as various [MaterialTheme][androidx.compose.material3.MaterialTheme]
-     * properties and other
-     * [CompositionLocal][androidx.compose.runtime.CompositionLocal] values.
      */
-    @Composable
-    @ReadOnlyComposable
     protected open fun initialize() {
         check(!initialized.value) {
             "Component.initialize() shouldn't be invoked more than once."

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -650,7 +650,15 @@ public abstract class Component : DefaultPropsOwnerBase() {
      * [props] callback (which is passed along with component instance's
      * declaration) has been invoked for the first time, and before
      * the component's composable content is rendered for the first time.
+     *
+     * This function is declared as being a read-only composable one for
+     * the implementations to be able to access the composition-related data,
+     * such as various [MaterialTheme][androidx.compose.material3.MaterialTheme]
+     * properties and other
+     * [CompositionLocal][androidx.compose.runtime.CompositionLocal] values.
      */
+    @Composable
+    @ReadOnlyComposable
     protected open fun initialize() {
         check(!initialized.value) {
             "Component.initialize() shouldn't be invoked more than once."

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -63,7 +63,6 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.BottomEnd
 import androidx.compose.ui.Alignment.Companion.CenterEnd
@@ -118,8 +117,6 @@ import java.awt.event.KeyEvent.CHAR_UNDEFINED
 import java.lang.Character.UnicodeBlock
 import java.lang.Character.UnicodeBlock.SPECIALS
 import java.lang.Character.isISOControl
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * A component that displays a customizable composable [invoker] content, and
@@ -420,7 +417,7 @@ public class DropdownListBox<I> : Component() {
     private val firstItemIndex: Int get() = if (noneItemEnabled) -1 else 0
 
     private var scrollState: ScrollState by writeOnce()
-    private var coroutineScope: CoroutineScope by writeOnce()
+    protected override var enableLaunch: Boolean = true
 
     @Composable
     @ReadOnlyComposable
@@ -432,7 +429,6 @@ public class DropdownListBox<I> : Component() {
     @Composable
     override fun content() {
         scrollState = rememberScrollState(0)
-        coroutineScope = rememberCoroutineScope()
 
         LaunchedEffect(enabled) {
             if (!enabled) {
@@ -975,7 +971,7 @@ public class DropdownListBox<I> : Component() {
                         .height(visibleListHeight)
                 ) {
                     if (scrollPositionRequested != null) {
-                        coroutineScope.launch {
+                        launch {
                             scrollState.scrollTo(scrollPositionRequested!!)
                             scrollPositionRequested = null
                         }
@@ -1007,7 +1003,7 @@ public class DropdownListBox<I> : Component() {
             )
         }
 
-        coroutineScope.launch {
+        launch {
             focusRequester.requestFocus()
         }
 

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -26,9 +26,7 @@
 
 package io.spine.chords.core
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -269,8 +267,6 @@ public abstract class InputComponent<V> : FocusableComponent() {
      */
     public var enabled: Boolean by mutableStateOf(true)
 
-    @Composable
-    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         if (!this::value.isInitialized) {

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -26,7 +26,9 @@
 
 package io.spine.chords.core
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -267,6 +269,8 @@ public abstract class InputComponent<V> : FocusableComponent() {
      */
     public var enabled: Boolean by mutableStateOf(true)
 
+    @Composable
+    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         if (!this::value.isInitialized) {

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -201,12 +200,12 @@ public typealias RawTextContent = TextFieldValue
  * When both `placeholder` and `promptText` properties are specified, then only
  * the `placeholder` is used.
  *
- * @param V
- *         a type of values that an input field allows to edit.
- * @constructor a constructor, which is used internally by the input component's
- *         implementation. Use [companion object's][ComponentCompanion]
- *         [invoke][ComponentCompanion.invoke] operators for instantiating
- *         and rendering any specific input component in any application code.
+ * @param V A type of values that an input field allows to edit.
+ *
+ * @constructor A constructor, which is used internally by the input component's
+ *   implementation. Use [companion object's][ComponentSetup]
+ *   [invoke][ComponentSetup.invoke] operators for instantiating and
+ *   rendering any specific input component in any application code.
  */
 @Stable
 public open class InputField<V> : InputComponent<V>() {
@@ -281,17 +280,14 @@ public open class InputField<V> : InputComponent<V>() {
      * An [InputReviser] that can be specified to modify the user's input before
      * it is applied to the input field.
      */
-    protected var inputReviser: InputReviser? by mutableStateOf(null)
+    protected open var inputReviser: InputReviser? by mutableStateOf(null)
 
     /**
      * Transforms the raw text typed in by the user to form a text displayed in
      * the field (without affecting how the text is stored in raw text, or
      * parsed and formatted with).
      */
-    protected open val visualTransformation: VisualTransformation
-        @Composable
-        @ReadOnlyComposable
-        get() = None
+    protected open var visualTransformation: VisualTransformation by mutableStateOf(None)
 
     /**
      * An intermediate text field's text, which is a text that cannot be
@@ -330,6 +326,12 @@ public open class InputField<V> : InputComponent<V>() {
      * is to be displayed.
      */
     protected open var supportingText: (@Composable (String) -> Unit) = { Text(it) }
+
+    /**
+     * Specifies whether this should be a single-line text entry field (if
+     * `false`, by default), or a multiline text entry one (if set to `true`).
+     */
+    protected open var multiline: Boolean = false
 
     /**
      * A function that should validate the given input field's raw text, and, if
@@ -376,13 +378,12 @@ public open class InputField<V> : InputComponent<V>() {
      *         }
      *   ```
      *
-     * @param rawText
-     *         an input field's raw text that needs to be parsed for creating
-     *         a value of type [V].
-     * @return a valid value of type [V] that is the result of
-     *         parsing [rawText].
-     * @throws ValueParseException if [rawText] cannot be parsed as
-     *         a valid value.
+     * @param rawText An input field's raw text that needs to be parsed for
+     *   creating a value of type [V].
+     * @return A valid value of type [V] that is the result of
+     *   parsing [rawText].
+     * @throws ValueParseException If [rawText] cannot be parsed as
+     *   a valid value.
      * @see exceptionBasedParser
      */
     @Throws(ValueParseException::class)
@@ -406,7 +407,7 @@ public open class InputField<V> : InputComponent<V>() {
         val validationErrorText = ownValidationMessage.value ?: externalValidationMessage?.value
 
         TextField(
-            singleLine = true,
+            singleLine = !multiline,
             value = rawTextContent,
             label = label?.let { { Text(text = it) } },
             isError = validationErrorText != null,

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -332,19 +332,19 @@ public open class InputField<V> : InputComponent<V>() {
      * Specifies whether this should be a single-line text entry field (if
      * `false`, by default), or a multiline text entry one (if set to `true`).
      */
-    protected open var multiline: Boolean = false
+    protected open var multiline: Boolean by mutableStateOf(false)
 
     /**
      * Minimum number of visible lines
      * (applicable only if [multiline] == `true`).
      */
-    protected open var minLines: Int = 1
+    protected open var minLines: Int by mutableStateOf(1)
 
     /**
      * Maximum number of visible lines
      * (applicable only if [multiline] == `true`).
      */
-    protected open var maxLines: Int = MAX_VALUE
+    protected open var maxLines: Int by mutableStateOf(MAX_VALUE)
 
     /**
      * A function that should validate the given input field's raw text, and, if

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -54,6 +54,7 @@ import io.spine.chords.core.keyboard.KeyRange.Companion.Digit
 import io.spine.chords.core.keyboard.KeyRange.Companion.Whitespace
 import io.spine.chords.core.keyboard.matches
 import io.spine.chords.core.primitive.preventWidthAutogrowing
+import kotlin.Int.Companion.MAX_VALUE
 import kotlin.math.min
 import kotlin.reflect.KClass
 
@@ -334,6 +335,18 @@ public open class InputField<V> : InputComponent<V>() {
     protected open var multiline: Boolean = false
 
     /**
+     * Minimum number of visible lines
+     * (applicable only if [multiline] == `true`).
+     */
+    protected open var minLines: Int = 1
+
+    /**
+     * Maximum number of visible lines
+     * (applicable only if [multiline] == `true`).
+     */
+    protected open var maxLines: Int = MAX_VALUE
+
+    /**
      * A function that should validate the given input field's raw text, and, if
      * it has a valid format for parsing a value of type [V], and satisfies all
      * constraints that might have been defined for the target value, then it
@@ -407,7 +420,6 @@ public open class InputField<V> : InputComponent<V>() {
         val validationErrorText = ownValidationMessage.value ?: externalValidationMessage?.value
 
         TextField(
-            singleLine = !multiline,
             value = rawTextContent,
             label = label?.let { { Text(text = it) } },
             isError = validationErrorText != null,
@@ -436,6 +448,9 @@ public open class InputField<V> : InputComponent<V>() {
             prefix = prefix,
             suffix = suffix,
             interactionSource = interactionSource,
+            singleLine = !multiline,
+            minLines = if (multiline) minLines else 1,
+            maxLines = if (multiline) maxLines else 1,
             enabled = enabled,
             textStyle = textStyle,
             modifier = modifier(modifier)

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.Bottom
 import androidx.compose.ui.Alignment.Companion.CenterVertically
@@ -55,10 +54,6 @@ import io.spine.chords.core.appshell.app
 import io.spine.chords.core.keyboard.KeyModifiers.Companion.Ctrl
 import io.spine.chords.core.keyboard.key
 import io.spine.chords.core.layout.WindowType.DesktopWindow
-import io.spine.chords.core.writeOnce
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 
 /**
  * A shortcut (key combination), which invokes dialog submission.
@@ -389,11 +384,7 @@ public abstract class Dialog : Component() {
      */
     internal var nestedDialog by mutableStateOf<Dialog?>(null)
 
-    /**
-     * Coroutine scope for launching asynchronous execution of actions initiated
-     * by the dialog's controls.
-     */
-    private var coroutineScope: CoroutineScope by writeOnce()
+    protected override val enableLaunch: Boolean = true
 
     /**
      * Specifies whether the "Submit" button should be displayed.
@@ -452,12 +443,9 @@ public abstract class Dialog : Component() {
      * controls and doesn't close the dialog. Any such effects should be a part
      * of the actual dialog's implementation in its [submitContent] method.
      */
-    public fun submit() {
-        check(coroutineScope.isActive) { "Coroutine is not active" }
-        coroutineScope.launch {
-            if (onBeforeSubmit()) {
-                submitContent()
-            }
+    public fun submit(): Unit = launch {
+        if (onBeforeSubmit()) {
+            submitContent()
         }
     }
 
@@ -480,12 +468,9 @@ public abstract class Dialog : Component() {
      * This means invoking the [onBeforeCancel] callback, and closing the dialog
      * if the callback didn't prevent closing.
      */
-    public fun cancel() {
-        check(coroutineScope.isActive) { "Coroutine is not active" }
-        coroutineScope.launch {
-            if (onBeforeCancel()) {
-                close()
-            }
+    public fun cancel(): Unit = launch {
+        if (onBeforeCancel()) {
+            close()
         }
     }
 
@@ -498,7 +483,6 @@ public abstract class Dialog : Component() {
      */
     @Composable
     protected final override fun content() {
-        coroutineScope = rememberCoroutineScope()
         windowType.dialogWindow(this)
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/primitive/StringField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/primitive/StringField.kt
@@ -46,6 +46,18 @@ public class StringField : InputField<String>() {
         get() = super.visualTransformation
         set(value) { super.visualTransformation = value }
 
+    public override var multiline: Boolean
+        get() = super.multiline
+        set(value) { super.multiline = value }
+
+    public override var minLines: Int
+        get() = super.minLines
+        set(value) { super.minLines = value }
+
+    public override var maxLines: Int
+        get() = super.maxLines
+        set(value) { super.maxLines = value }
+
     public override var prefix: (@Composable () -> Unit)?
         get() = super.prefix
         set(value) { super.prefix = value }
@@ -53,8 +65,4 @@ public class StringField : InputField<String>() {
     public override var suffix: (@Composable () -> Unit)?
         get() = super.suffix
         set(value) { super.suffix = value }
-
-    public override var multiline: Boolean
-        get() = super.multiline
-        set(value) { super.multiline = value }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/primitive/StringField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/primitive/StringField.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.primitive
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.input.VisualTransformation
+import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.InputField
+import io.spine.chords.core.InputReviser
+
+/**
+ * An [InputField] implementation that allows entering `String` values.
+ */
+public class StringField : InputField<String>() {
+    public companion object : ComponentSetup<StringField>({ StringField() })
+
+    public override var inputReviser: InputReviser?
+        get() = super.inputReviser
+        set(value) { super.inputReviser = value }
+
+    public override var visualTransformation: VisualTransformation
+        get() = super.visualTransformation
+        set(value) { super.visualTransformation = value }
+
+    public override var prefix: (@Composable () -> Unit)?
+        get() = super.prefix
+        set(value) { super.prefix = value }
+
+    public override var suffix: (@Composable () -> Unit)?
+        get() = super.suffix
+        set(value) { super.suffix = value }
+
+    public override var multiline: Boolean
+        get() = super.multiline
+        set(value) { super.multiline = value }
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.69`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.70`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1094,12 +1094,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 17:59:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 18:02:05 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.69`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.70`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1953,12 +1953,12 @@ This report was generated on **Fri Mar 21 17:59:50 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 17:59:52 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 18:02:09 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.69`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.70`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2991,12 +2991,12 @@ This report was generated on **Fri Mar 21 17:59:52 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 17:59:55 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 18:02:12 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.69`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.70`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4015,12 +4015,12 @@ This report was generated on **Fri Mar 21 17:59:55 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 17:59:57 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 18:02:16 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.69`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.70`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4814,12 +4814,12 @@ This report was generated on **Fri Mar 21 17:59:57 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 17:59:59 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 18:02:18 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.69`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.70`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5583,4 +5583,4 @@ This report was generated on **Fri Mar 21 17:59:59 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 18:00:01 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 18:02:21 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.69</version>
+<version>2.0.0-SNAPSHOT.70</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1096,7 +1096,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         valueRequired = true
     }
 
-    private val messageDef get() = builder().messageDef()
+    private val messageDef by lazy { builder().messageDef() }
 
     /**
      * Message's fields that are a part of this form.
@@ -1235,8 +1235,6 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     public val dirty: Boolean get() = _dirty
     private var _dirty = false
 
-    @Composable
-    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         requireProperty(::builder.isInitialized, "builder")
@@ -1639,6 +1637,14 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         }
 
         updateMessage(true, focusInvalidPart)
+    }
+
+    /**
+     * A developer-friendly string representation of this form instance.
+     */
+    override fun toString(): String {
+        return "${javaClass.simpleName} for ${builder().descriptorForType.name} " +
+                "(${super.toString()})"
     }
 
     private fun clearValidationDisplay() {

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1235,6 +1235,8 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     public val dirty: Boolean get() = _dirty
     private var _dirty = false
 
+    @Composable
+    @ReadOnlyComposable
     override fun initialize() {
         super.initialize()
         requireProperty(::builder.isInitialized, "builder")

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -89,8 +89,9 @@ public class DateTimeField : InputField<Timestamp>() {
 
     @Composable
     @ReadOnlyComposable
-    override fun initialize() {
+    override fun beforeComposeContent() {
         super.beforeComposeContent()
+        inputReviser = DateTimeFieldReviser(dateTimePattern)
         textStyle = LocalTextStyle.current.copy(fontFamily = Monospace)
         val secondaryColor = colorScheme.secondary
         visualTransformation = VisualTransformation {
@@ -98,11 +99,6 @@ public class DateTimeField : InputField<Timestamp>() {
                 it.text, dateTimePattern
             ).toTransformedString(secondaryColor)
         }
-    }
-
-    override fun updateProps() {
-        super.updateProps()
-        inputReviser = DateTimeFieldReviser(dateTimePattern)
     }
 
     override fun formatValue(value: Timestamp): String {

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -95,10 +95,9 @@ public class DateTimeField : InputField<Timestamp>() {
         textStyle = LocalTextStyle.current.copy(fontFamily = Monospace)
         val secondaryColor = colorScheme.secondary
         visualTransformation = VisualTransformation {
-            val transformedString = complementWithPattern(
+            complementWithPattern(
                 it.text, dateTimePattern
             ).toTransformedString(secondaryColor)
-            transformedString
         }
     }
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -27,7 +27,7 @@
 package io.spine.chords.proto.time
 
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
@@ -88,27 +88,23 @@ public class DateTimeField : InputField<Timestamp>() {
         inputReviser = DateTimeFieldReviser(dateTimePattern)
     }
 
-    override val visualTransformation: VisualTransformation
-        @Composable
-        @ReadOnlyComposable
-        get() {
-            val maskTextColor: Color = MaterialTheme.colorScheme.secondary
-            return VisualTransformation {
-                val transformedString = complementWithPattern(
-                    it.text,
-                    dateTimePattern
-                )
-                    .toTransformedString(maskTextColor)
-                transformedString
-            }
-        }
-
     @Composable
     @ReadOnlyComposable
-    override fun beforeComposeContent() {
+    override fun initialize() {
         super.beforeComposeContent()
-        inputReviser = DateTimeFieldReviser(dateTimePattern)
         textStyle = LocalTextStyle.current.copy(fontFamily = Monospace)
+        val secondaryColor = colorScheme.secondary
+        visualTransformation = VisualTransformation {
+            val transformedString = complementWithPattern(
+                it.text, dateTimePattern
+            ).toTransformedString(secondaryColor)
+            transformedString
+        }
+    }
+
+    override fun updateProps() {
+        super.updateProps()
+        inputReviser = DateTimeFieldReviser(dateTimePattern)
     }
 
     override fun formatValue(value: Timestamp): String {

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -85,7 +85,6 @@ public class DateTimeField : InputField<Timestamp>() {
 
     init {
         label = "Date/time"
-        inputReviser = DateTimeFieldReviser(dateTimePattern)
     }
 
     @Composable

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.69")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.70")


### PR DESCRIPTION
This PR includes the following:
- Implemented `StringField` component (an implementation of `InputField` for editing string-typed fields).
- Added `Component.launch()` method, which simplifies a common need of launching coroutines from components (no explicit invocation of `rememberCoroutineScope()` is required now).
- Cleaned up the code a bit — `CommandMessage.postCommand` doesn't need to be a `suspend` function now.