### PR TITLE
Simplify `InputReviser`-related code

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -782,15 +782,15 @@ public interface InputReviser {
      * See the "Revising the entered text" section in
      * [InputField]'s description.
      *
-     * @param currentRawTextContent A [RawTextContent], which represents the
+     * @param current A [RawTextContent], which represents the
      *   current value of text that field has, before user modification.
-     * @param rawTextContentCandidate A [RawTextContent] which holds raw text
+     * @param candidate A [RawTextContent] which holds raw text
      *   content that was just modified by the user.
      * @return [RawTextContent] which holds revised user input text.
      */
     public fun reviseRawTextContent(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
+        current: RawTextContent,
+        candidate: RawTextContent
     ): RawTextContent
 
     /**
@@ -817,17 +817,14 @@ public interface InputReviser {
          */
         public val DigitsOnly: InputReviser = object : InputReviser {
             override fun reviseRawTextContent(
-                currentRawTextContent: RawTextContent,
-                rawTextContentCandidate: RawTextContent
-            ): RawTextContent {
-                return rawTextContentCandidate.copy(
-                    rawTextContentCandidate.text.filter { it.isDigit() }
-                )
-            }
+                current: RawTextContent,
+                candidate: RawTextContent
+            ): RawTextContent = candidate.copy(
+                candidate.text.filter { it.isDigit() }
+            )
 
-            override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {
-                return keyEvent matches (!Digit).typed
-            }
+            override fun filterKeyEvent(keyEvent: KeyEvent): Boolean =
+                keyEvent matches (!Digit).typed
         }
 
         /**
@@ -835,17 +832,14 @@ public interface InputReviser {
          */
         public val NonWhitespaces: InputReviser = object : InputReviser {
             override fun reviseRawTextContent(
-                currentRawTextContent: RawTextContent,
-                rawTextContentCandidate: RawTextContent
-            ): RawTextContent {
-                return rawTextContentCandidate.copy(
-                    rawTextContentCandidate.text.filter { !it.isWhitespace() }
-                )
-            }
+                current: RawTextContent,
+                candidate: RawTextContent
+            ): RawTextContent = candidate.copy(
+                candidate.text.filter { !it.isWhitespace() }
+            )
 
-            override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {
-                return keyEvent matches Whitespace.typed
-            }
+            override fun filterKeyEvent(keyEvent: KeyEvent): Boolean =
+                keyEvent matches Whitespace.typed
         }
 
         /**
@@ -854,13 +848,11 @@ public interface InputReviser {
          */
         public val ToLowerCase: InputReviser = object : InputReviser {
             override fun reviseRawTextContent(
-                currentRawTextContent: RawTextContent,
-                rawTextContentCandidate: RawTextContent
-            ): RawTextContent {
-                return rawTextContentCandidate.copy(
-                    rawTextContentCandidate.text.lowercase()
-                )
-            }
+                current: RawTextContent,
+                candidate: RawTextContent
+            ): RawTextContent = candidate.copy(
+                candidate.text.lowercase()
+            )
 
             override fun filterKeyEvent(keyEvent: KeyEvent): Boolean = false
         }
@@ -875,16 +867,14 @@ public interface InputReviser {
          */
         public fun maxLength(maxLength: Int): InputReviser = object : InputReviser {
             override fun reviseRawTextContent(
-                currentRawTextContent: RawTextContent,
-                rawTextContentCandidate: RawTextContent
-            ): RawTextContent {
-                return rawTextContentCandidate.copy(
-                    rawTextContentCandidate.text.substring(
-                        0,
-                        min(maxLength, rawTextContentCandidate.text.length)
-                    )
+                current: RawTextContent,
+                candidate: RawTextContent
+            ): RawTextContent = candidate.copy(
+                candidate.text.substring(
+                    0,
+                    min(maxLength, candidate.text.length)
                 )
-            }
+            )
 
             override fun filterKeyEvent(keyEvent: KeyEvent): Boolean = false
         }
@@ -900,7 +890,7 @@ public interface InputReviser {
          * then it gets determined by [additionalReviser].
          *
          * @receiver The first reviser that should process the raw text
-         *           content candidate and key event.
+         *   content candidate and key event.
          * @param additionalReviser The second reviser that should process the
          *   raw text content candidate and key event.
          * @return A new `InputReviser`, which combines the action of two
@@ -910,17 +900,11 @@ public interface InputReviser {
             additionalReviser: InputReviser
         ): InputReviser = object : InputReviser {
             override fun reviseRawTextContent(
-                currentRawTextContent: RawTextContent,
-                rawTextContentCandidate: RawTextContent
+                current: RawTextContent,
+                candidate: RawTextContent
             ): RawTextContent {
-                val intermediateRevision = this@then.reviseRawTextContent(
-                    currentRawTextContent,
-                    rawTextContentCandidate
-                )
-                return additionalReviser.reviseRawTextContent(
-                    currentRawTextContent,
-                    intermediateRevision
-                )
+                val intermediateRevision = this@then.reviseRawTextContent(current, candidate)
+                return additionalReviser.reviseRawTextContent(current, intermediateRevision)
             }
 
             override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1094,12 +1094,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:18 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:23 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1953,12 +1953,12 @@ This report was generated on **Thu Mar 27 20:08:18 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:26 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2991,12 +2991,12 @@ This report was generated on **Thu Mar 27 20:08:30 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:31 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:28 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4015,12 +4015,12 @@ This report was generated on **Thu Mar 27 20:08:31 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4814,12 +4814,12 @@ This report was generated on **Thu Mar 27 20:08:33 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:35 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:32 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5583,4 +5583,4 @@ This report was generated on **Thu Mar 27 20:08:35 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:37 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1094,7 +1094,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 16:50:23 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 18:46:19 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1953,7 +1953,7 @@ This report was generated on **Fri Mar 28 16:50:23 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 16:50:26 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 18:46:22 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2991,7 +2991,7 @@ This report was generated on **Fri Mar 28 16:50:26 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 16:50:28 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 18:46:25 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4015,7 +4015,7 @@ This report was generated on **Fri Mar 28 16:50:28 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 16:50:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 18:46:28 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4814,7 +4814,7 @@ This report was generated on **Fri Mar 28 16:50:30 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 16:50:32 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 18:46:31 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5583,4 +5583,4 @@ This report was generated on **Fri Mar 28 16:50:32 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 28 16:50:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 18:46:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1094,12 +1094,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 19:33:38 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 27 20:08:18 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1953,12 +1953,12 @@ This report was generated on **Thu Mar 27 19:33:38 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 19:33:46 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 27 20:08:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2991,12 +2991,12 @@ This report was generated on **Thu Mar 27 19:33:46 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 19:33:48 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 27 20:08:31 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4015,12 +4015,12 @@ This report was generated on **Thu Mar 27 19:33:48 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 19:33:50 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 27 20:08:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4814,12 +4814,12 @@ This report was generated on **Thu Mar 27 19:33:50 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 19:33:52 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 27 20:08:35 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5583,4 +5583,4 @@ This report was generated on **Thu Mar 27 19:33:52 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 19:33:54 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 27 20:08:37 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.75</version>
+<version>2.0.0-SNAPSHOT.76</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.74</version>
+<version>2.0.0-SNAPSHOT.75</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -78,7 +78,7 @@ import io.spine.validate.ValidationException
  * to build a message of type [M]). The simplest way to specify field editors is
  * to use respective suitable types of class-based input components (the ones,
  * which extend [InputComponent]), and associate them with respective message's
- * message's fields as shown below.
+ * fields as shown below.
  *
  * Note that unlike other input components, `MessageForm` doesn't introduce any
  * visual output or layout capabilities by itself. Instead, it displays whatever

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -288,32 +288,23 @@ internal class MoneyFieldReviser(
 ) : InputReviser {
 
     override fun reviseRawTextContent(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
+        current: RawTextContent,
+        candidate: RawTextContent
     ): RawTextContent {
-        var updatedRawTextContentCandidate = rawTextContentCandidate.copy(
-            text = rawTextContentCandidate.text.replace(
-                '.',
-                decimalSeparator
-            )
+        var updatedCandidate = candidate.copy(
+            candidate.text.replace('.', decimalSeparator)
         )
-        if (currentRawTextContent.text != updatedRawTextContentCandidate.text &&
-            currentRawTextContent.text.isNotEmpty()
+        if (current.text != updatedCandidate.text &&
+            current.text.isNotEmpty()
         ) {
-            updatedRawTextContentCandidate =
-                if (currentRawTextContent.selection.collapsed) {
-                    updateRawTextContentCandidateWhenTextIsNotSelected(
-                        currentRawTextContent,
-                        updatedRawTextContentCandidate
-                    )
+            updatedCandidate =
+                if (current.selection.collapsed) {
+                    updateCandidateWhenTextIsNotSelected(current, updatedCandidate)
                 } else {
-                    updateRawTextContentCandidateWhenTextIsSelected(
-                        currentRawTextContent,
-                        updatedRawTextContentCandidate
-                    )
+                    updateCandidateWhenTextIsSelected(current, updatedCandidate)
                 }
         }
-        return sanitizeMoneyField(currentRawTextContent, updatedRawTextContentCandidate, currency)
+        return sanitizeMoneyField(current, updatedCandidate)
     }
 
     override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {
@@ -328,52 +319,47 @@ internal class MoneyFieldReviser(
      * contain decimal separator, input value is modified to preserve decimal
      * separator in it.
      *
-     * @param currentRawTextContent
-     *         a [RawTextContent] that encapsulates current text input value
-     *         and cursor position.
-     * @param rawTextContentCandidate
-     *         a [RawTextContent] that encapsulates updated text input value
-     *         and updated cursor position.
-     * @return [RawTextContent] which contains updated text input and
-     *         updated cursor input position.
+     * @param current A [RawTextContent] that encapsulates current
+     *   text input value and cursor position.
+     * @param candidate A [RawTextContent] that encapsulates
+     *   updated text input value and updated cursor position.
+     * @return [RawTextContent] which contains updated text input and updated
+     *   cursor input position.
      */
-    private fun updateRawTextContentCandidateWhenTextIsSelected(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
+    private fun updateCandidateWhenTextIsSelected(
+        current: RawTextContent,
+        candidate: RawTextContent
     ): RawTextContent {
-        if (currentRawTextContent.selection.length != currentRawTextContent.text.length) {
-            val selectedText = currentRawTextContent.getSelectedText()
-            val replaceWithText = rawTextContentCandidate.text.substring(
-                currentRawTextContent.selection.min,
-                rawTextContentCandidate.selection.start
-            )
-            val decimalSeparatorIndex =
-                currentRawTextContent.text.indexOfFirst { it == decimalSeparator }
-            val updatedRawTextContentCandidate: RawTextContent
-            if (!replaceWithText.contains(decimalSeparator) &&
-                selectedText.contains(decimalSeparator)
-            ) {
-                val startIndex = rawTextContentCandidate.selection.start
-                val updatedRawText = rawTextContentCandidate.text.substring(0, startIndex) +
-                        decimalSeparator +
-                        rawTextContentCandidate.text.substring(startIndex)
-
-                updatedRawTextContentCandidate =
-                    RawTextContent(
-                        updatedRawText,
-                        TextRange(startIndex)
-                    )
-            } else if (decimalSeparatorIndex < currentRawTextContent.selection.min) {
-                updatedRawTextContentCandidate =
-                    updateRawTextContentDecimalPart(currentRawTextContent, rawTextContentCandidate)
-            } else {
-                updatedRawTextContentCandidate = rawTextContentCandidate
-            }
-
-            return updatedRawTextContentCandidate
+        if (current.selection.length == current.text.length) {
+             return candidate
         }
 
-        return rawTextContentCandidate
+        val selectedText = current.getSelectedText()
+        val replaceWithText = candidate.text.substring(
+            current.selection.min,
+            candidate.selection.start
+        )
+        val decimalSeparatorIndex = current.text.indexOfFirst { it == decimalSeparator }
+        return when {
+            (!replaceWithText.contains(decimalSeparator) &&
+                selectedText.contains(decimalSeparator)
+            ) -> {
+                val startIndex = candidate.selection.start
+                val updatedRawText = candidate.text.substring(0, startIndex) +
+                        decimalSeparator +
+                        candidate.text.substring(startIndex)
+
+                RawTextContent(updatedRawText, TextRange(startIndex))
+            }
+
+            decimalSeparatorIndex < current.selection.min -> {
+                updateDecimalPart(current, candidate)
+            }
+
+            else -> {
+                candidate
+            }
+        }
     }
 
     /**
@@ -384,97 +370,92 @@ internal class MoneyFieldReviser(
      * if that character is decimal separator resulting input value will
      * preserve separator, it will just update cursor position.
      *
-     * @param currentRawTextContent
-     *         a [RawTextContent] that encapsulates current text input value
-     *         and cursor position.
-     * @param rawTextContentCandidate
-     *         a [RawTextContent] that encapsulates updated text input value
-     *         and updated cursor position.
+     * @param current A [RawTextContent] that encapsulates current text input
+     *   value and cursor position.
+     * @param candidate A [RawTextContent] that encapsulates updated text input
+     *   value and updated cursor position.
      * @return [RawTextContent] which contains updated text input and
-     *         updated cursor input position.
+     *   updated cursor input position.
      */
-    private fun updateRawTextContentCandidateWhenTextIsNotSelected(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
+    private fun updateCandidateWhenTextIsNotSelected(
+        current: RawTextContent,
+        candidate: RawTextContent
     ): RawTextContent {
         val decimalSeparatorIndex =
-            currentRawTextContent.text.indexOfFirst { it == decimalSeparator }
-        val updatedRawTextContentCandidate: RawTextContent
-        if (rawTextContentCandidate.selection.start <= currentRawTextContent.selection.start) {
-            val deletedChar = currentRawTextContent.text[rawTextContentCandidate.selection.start]
-            if (deletedChar == decimalSeparator) {
-                val textRange = TextRange(rawTextContentCandidate.selection.start)
+            current.text.indexOfFirst { it == decimalSeparator }
+        return when {
+            candidate.selection.start <= current.selection.start -> {
+                val deletedChar = current.text[candidate.selection.start]
+                when {
+                    deletedChar == decimalSeparator -> {
+                        val textRange = TextRange(candidate.selection.start)
+                        RawTextContent(current.text, textRange)
+                    }
 
-                updatedRawTextContentCandidate =
-                    RawTextContent(currentRawTextContent.text, textRange)
-            } else if (rawTextContentCandidate.selection.start > decimalSeparatorIndex) {
-                val remainingDecimalPartIndex = if (currentRawTextContent.selection.collapsed &&
-                    rawTextContentCandidate.selection.collapsed &&
-                    currentRawTextContent.selection.start == rawTextContentCandidate.selection.start
-                ) {
-                    currentRawTextContent.selection.min + 1
-                } else {
-                    currentRawTextContent.selection.min
+                    candidate.selection.start > decimalSeparatorIndex -> {
+                        val remainingDecimalPartIndex =
+                            current.selection.min + (1.takeIf {
+                                current.selection.collapsed &&
+                                        candidate.selection.collapsed &&
+                                        current.selection.start == candidate.selection.start
+                            } ?: 0)
+
+                        val updatedRawText =
+                            current.text.substring(0, candidate.selection.min) +
+                                    "0" + current.text.substring(remainingDecimalPartIndex)
+
+                        candidate.copy(updatedRawText)
+                    }
+
+                    else -> {
+                        candidate
+                    }
                 }
-                val updatedRawText =
-                    currentRawTextContent.text.substring(0, rawTextContentCandidate.selection.min) +
-                            "0" + currentRawTextContent.text.substring(remainingDecimalPartIndex)
-
-                updatedRawTextContentCandidate = rawTextContentCandidate.copy(text = updatedRawText)
-            } else {
-                updatedRawTextContentCandidate = rawTextContentCandidate
             }
-        } else if (decimalSeparatorIndex < currentRawTextContent.selection.min) {
-            updatedRawTextContentCandidate =
-                updateRawTextContentDecimalPart(currentRawTextContent, rawTextContentCandidate)
-        } else {
-            updatedRawTextContentCandidate = rawTextContentCandidate
-        }
 
-        return updatedRawTextContentCandidate
+            decimalSeparatorIndex < current.selection.min -> {
+                updateDecimalPart(current, candidate)
+            }
+
+            else -> {
+                candidate
+            }
+        }
     }
 
     /**
      * Revise user's input when user modifies decimal part of money value.
      *
-     * @param currentRawTextContent
-     *         a [RawTextContent] that encapsulates current text input value
-     *         and cursor position.
-     * @param rawTextContentCandidate
-     *         a [RawTextContent] that encapsulates updated text input value
-     *         and updated cursor position.
+     * @param current A [RawTextContent] that encapsulates current text input
+     *   value and cursor position.
+     * @param rawCandidate A [RawTextContent] that encapsulates updated text
+     *   input value and updated cursor position.
      * @return [RawTextContent] which contains revised text input and
-     *         updated cursor input position.
+     *   updated cursor input position.
      */
-    private fun updateRawTextContentDecimalPart(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
+    private fun updateDecimalPart(
+        current: RawTextContent,
+        rawCandidate: RawTextContent
     ): RawTextContent {
         val updatedRawText =
-            currentRawTextContent.text.substring(0, currentRawTextContent.selection.min) +
-                    rawTextContentCandidate.text.substring(
-                        currentRawTextContent.selection.min,
-                        rawTextContentCandidate.selection.max
-                    ) +
-                    if (currentRawTextContent.text.length <
-                        rawTextContentCandidate.selection.max
-                    ) {
-                        ""
-                    } else {
-                        currentRawTextContent.text.substring(
-                            rawTextContentCandidate.selection.max,
-                            currentRawTextContent.text.length
-                        )
-                    }
+            current.text.substring(0, current.selection.min) +
+                    rawCandidate.text.substring(
+                        current.selection.min,
+                        rawCandidate.selection.max
+                    ) + (
+                    current.text.substring(
+                        rawCandidate.selection.max,
+                        current.text.length
+                    ).takeIf { current.text.length >= rawCandidate.selection.max } ?: "")
 
-        return rawTextContentCandidate.copy(text = updatedRawText)
+        return rawCandidate.copy(updatedRawText)
     }
 
     /**
      * Corrects the human-readable string representation of [Money] according to
      * some basic limitations of how the money string should be formatted.
      *
-     * Note that depending on the value of [rawTextContentCandidate] input
+     * Note that depending on the value of [candidate] input
      * string, this function doesn't necessarily return [RawTextContent] with
      * valid money string, e.g. when the input string doesn't
      * include a currency symbol or an amount value.
@@ -503,7 +484,7 @@ internal class MoneyFieldReviser(
      *   something else).
      *
      * Having mentioned the above, it should generally be noted that, depending
-     * on the [rawTextContentCandidate] input text, this method doesn't
+     * on the [candidate] input text, this method doesn't
      * necessarily result in a [RawTextContent] with a string value,
      * which can be interpreted as a valid money string.
      *
@@ -511,23 +492,18 @@ internal class MoneyFieldReviser(
      * considered as a valid value, and thus results in returning a
      * [RawTextContent] with empty string value as well.
      *
-     * @param currentRawTextContent
-     *         a [RawTextContent] that encapsulates current text input value
-     *         and cursor position.
-     * @param rawTextContentCandidate
-     *         a [RawTextContent] that encapsulates updated text input value
-     *         and cursor position that should be sanitized.
-     * @param currency
-     *         a money amount currency.
+     * @param current A [RawTextContent] that encapsulates current text input
+     *   value and cursor position.
+     * @param candidate A [RawTextContent] that encapsulates updated text input
+     *   value and cursor position that should be sanitized.
      * @return [RawTextContent] which holds updated cursor position and
      *         sanitized modification of [rawTextCandidate] text value.
      */
     private fun sanitizeMoneyField(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent,
-        currency: Currency
+        current: RawTextContent,
+        candidate: RawTextContent
     ): RawTextContent {
-        val trimmedStr = rawTextContentCandidate.text.trim()
+        val trimmedStr = candidate.text.trim()
         if (trimmedStr.isEmpty()) {
             return RawTextContent("")
         }
@@ -535,8 +511,8 @@ internal class MoneyFieldReviser(
         val exponentDigits = currency.options.exponentDigits
 
         val (sanitizedAmount, inputCursorOffset) = sanitizeAmount(
-            currentRawTextContent,
-            rawTextContentCandidate,
+            current,
+            candidate,
             trimmedStr,
             exponentDigits
         )
@@ -550,8 +526,8 @@ internal class MoneyFieldReviser(
 
         return RawTextContent(
             sanitizedText, TextRange(
-                start = rawTextContentCandidate.selection.start - inputCursorOffset,
-                end = rawTextContentCandidate.selection.end - inputCursorOffset
+                candidate.selection.start - inputCursorOffset,
+                candidate.selection.end - inputCursorOffset
             )
         )
     }

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -437,18 +437,20 @@ internal class MoneyFieldReviser(
         current: RawTextContent,
         rawCandidate: RawTextContent
     ): RawTextContent {
-        val updatedRawText =
-            current.text.substring(0, current.selection.min) +
-                    rawCandidate.text.substring(
-                        current.selection.min,
-                        rawCandidate.selection.max
-                    ) + (
-                    current.text.substring(
-                        rawCandidate.selection.max,
-                        current.text.length
-                    ).takeIf { current.text.length >= rawCandidate.selection.max } ?: "")
+        val beforeSelection = current.text.substring(0, current.selection.min)
 
-        return rawCandidate.copy(updatedRawText)
+        val atSelection = rawCandidate.text.substring(
+            current.selection.min,
+            rawCandidate.selection.max
+        )
+
+        val afterSelection = if (current.text.length >= rawCandidate.selection.max)
+            current.text.substring(
+                rawCandidate.selection.max,
+                current.text.length
+            ) else ""
+
+        return rawCandidate.copy(beforeSelection + atSelection + afterSelection)
     }
 
     /**

--- a/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/net/IpAddressField.kt
@@ -66,15 +66,12 @@ public class IpAddressField : InputField<IpAddress>() {
  */
 private val DigitsAndDotsOnly: InputReviser = object : InputReviser {
     override fun reviseRawTextContent(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
-    ): RawTextContent {
-        return rawTextContentCandidate.copy(
-            rawTextContentCandidate.text.filter { it.isDigit() || it == '.' }
-        )
-    }
+        current: RawTextContent,
+        candidate: RawTextContent
+    ): RawTextContent = candidate.copy(
+        candidate.text.filter { it.isDigit() || it == '.' }
+    )
 
-    override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {
-        return keyEvent matches (!Digit and !'.'.key).typed
-    }
+    override fun filterKeyEvent(keyEvent: KeyEvent): Boolean =
+        keyEvent matches (!Digit and !'.'.key).typed
 }

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -273,31 +273,31 @@ internal class DateTimeFieldReviser(
 ) : InputReviser {
 
     override fun reviseRawTextContent(
-        currentRawTextContent: RawTextContent,
-        rawTextContentCandidate: RawTextContent
+        current: RawTextContent,
+        candidate: RawTextContent
     ): RawTextContent {
-        var updatedRawTextContentCandidate = rawTextContentCandidate
+        var updatedRawTextContentCandidate = candidate
 
-        if (currentRawTextContent.text != rawTextContentCandidate.text) {
+        if (current.text != candidate.text) {
             updatedRawTextContentCandidate =
-                if (currentRawTextContent.selection.collapsed) {
+                if (current.selection.collapsed) {
                     updateRawTextContentCandidateWhenTextIsNotSelected(
-                        currentRawTextContent,
-                        rawTextContentCandidate
+                        current,
+                        candidate
                     )
                 } else {
                     updateRawTextContentCandidateWhenTextIsSelected(
-                        currentRawTextContent,
-                        rawTextContentCandidate
+                        current,
+                        candidate
                     )
                 }
         }
 
         updatedRawTextContentCandidate =
-            DigitsOnly.reviseRawTextContent(currentRawTextContent, updatedRawTextContentCandidate)
+            DigitsOnly.reviseRawTextContent(current, updatedRawTextContentCandidate)
 
         return maxLength(dateTimePattern.filter { it.isLetter() }.length).reviseRawTextContent(
-            currentRawTextContent,
+            current,
             updatedRawTextContentCandidate
         )
     }

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -276,30 +276,21 @@ internal class DateTimeFieldReviser(
         current: RawTextContent,
         candidate: RawTextContent
     ): RawTextContent {
-        var updatedRawTextContentCandidate = candidate
+        var updatedCandidate = candidate
 
         if (current.text != candidate.text) {
-            updatedRawTextContentCandidate =
+            updatedCandidate =
                 if (current.selection.collapsed) {
-                    updateRawTextContentCandidateWhenTextIsNotSelected(
-                        current,
-                        candidate
-                    )
+                    updateCandidateWhenTextIsNotSelected(current, candidate)
                 } else {
-                    updateRawTextContentCandidateWhenTextIsSelected(
-                        current,
-                        candidate
-                    )
+                    updateCandidateWhenTextIsSelected(current, candidate)
                 }
         }
 
-        updatedRawTextContentCandidate =
-            DigitsOnly.reviseRawTextContent(current, updatedRawTextContentCandidate)
+        updatedCandidate = DigitsOnly.reviseRawTextContent(current, updatedCandidate)
 
-        return maxLength(dateTimePattern.filter { it.isLetter() }.length).reviseRawTextContent(
-            current,
-            updatedRawTextContentCandidate
-        )
+        val rawPatternLength = dateTimePattern.filter { it.isLetter() }.length
+        return maxLength(rawPatternLength).reviseRawTextContent(current, updatedCandidate)
     }
 
     override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {
@@ -309,16 +300,14 @@ internal class DateTimeFieldReviser(
     /**
      * Updates user's input when entered text replaces the one selected by user.
      *
-     * @param currentRawTextContent
-     *         a [RawTextContent] that encapsulates current text input value
-     *         and cursor position.
-     * @param rawTextContentCandidate
-     *         a [RawTextContent] that encapsulates updated text input value
-     *         and updated cursor position.
+     * @param currentRawTextContent A [RawTextContent] that encapsulates current
+     *   text input value and cursor position.
+     * @param rawTextContentCandidate A [RawTextContent] that encapsulates
+     *   updated text input value and updated cursor position.
      * @return [RawTextContent] which contains updated text input and
-     *         updated cursor input position.
+     *   updated cursor input position.
      */
-    private fun updateRawTextContentCandidateWhenTextIsSelected(
+    private fun updateCandidateWhenTextIsSelected(
         currentRawTextContent: RawTextContent,
         rawTextContentCandidate: RawTextContent
     ): RawTextContent {
@@ -374,16 +363,14 @@ internal class DateTimeFieldReviser(
      * Updates user's input when user doesn't select any input text
      * and just enters new one.
      *
-     * @param currentRawTextContent
-     *         a [RawTextContent] that encapsulates current text input value
-     *         and cursor position.
-     * @param rawTextContentCandidate
-     *         a [RawTextContent] that encapsulates updated text input value
-     *         and updated cursor position.
+     * @param currentRawTextContent A [RawTextContent] that encapsulates current
+     *   text input value and cursor position.
+     * @param rawTextContentCandidate A [RawTextContent] that encapsulates
+     *   updated text input value and updated cursor position.
      * @return [RawTextContent] which contains updated text input and
-     *         updated cursor input position.
+     *   updated cursor input position.
      */
-    private fun updateRawTextContentCandidateWhenTextIsNotSelected(
+    private fun updateCandidateWhenTextIsNotSelected(
         currentRawTextContent: RawTextContent,
         rawTextContentCandidate: RawTextContent
     ): RawTextContent {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.75")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.76")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.74")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.75")


### PR DESCRIPTION
This PR just performs some basic refactoring to simplify the code of `InputReviser` declarations. It covers only basic code simplifications without making substantial revisions, and it does not change the functionality.
