### PR TITLE
Revise property names for input components

### DIFF
--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -80,7 +80,7 @@ import io.spine.protobuf.ValidatingBuilder
  *          // method is invoked when the form needs to be posted.
  *          Button(
  *              onClick = {
- *                  if (form.valueValid.value) {
+ *                  if (form.valid.value) {
  *                      form.postCommand()
  *                  }
  *              }
@@ -142,7 +142,7 @@ import io.spine.protobuf.ValidatingBuilder
  *
  *          Button(
  *              onClick = {
- *                  if (form.valueValid.value) {
+ *                  if (form.valid.value) {
  *                      form.postCommand()
  *                  }
  *              }
@@ -353,7 +353,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      * Posts the command based on all currently entered data.
      *
      * Note that this method can only be invoked when the data entered within
-     * the form is valid (when `valueValid.value == false`).
+     * the form is valid (when `valid.value == false`).
      *
      * Here's a typical usage example:
      * ```
@@ -362,14 +362,14 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      *     commandMessageForm.updateValidationDisplay(true)
      *
      *     // Submit the form if it is valid currently.
-     *     if (commandMessageForm.valueValid.value) {
+     *     if (commandMessageForm.valid.value) {
      *         commandMessageForm.postCommand()
      *     }
      * ```
      *
      * Note that the [updateValidationDisplay] invocation is technically not
      * required to check if the form is valid because the form is always
-     * validated on-the-fly automatically, and its [valueValid] property always
+     * validated on-the-fly automatically, and its [valid] property always
      * contains an up-to-date value. Nevertheless, it would typically be useful
      * to invoke it before [postCommand] to improve user's experience when the
      * form's [validationDisplayMode] property has a value of
@@ -378,13 +378,13 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
      * @return An object, which allows managing (e.g. cancelling) all
      *   subscriptions made by the [commandConsequences] callback.
      * @throws IllegalStateException If the form is not valid when this method
-     *   is invoked (e.g. when `valueValid.value == false`).
+     *   is invoked (e.g. when `valid.value == false`).
      * @see commandConsequences
      * @see cancelActiveSubscriptions
      */
     public fun postCommand(): EventSubscriptions {
         updateValidationDisplay(true)
-        check(valueValid.value) {
+        check(valid.value) {
             "`postCommand` cannot be invoked on an invalid form`"
         }
         val command = value.value

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -220,7 +220,7 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      */
     protected override suspend fun submitContent() {
         commandMessageForm.updateValidationDisplay(true)
-        if (!commandMessageForm.valueValid.value) {
+        if (!commandMessageForm.valid.value) {
             return
         }
         commandMessageForm.postCommand()

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -222,7 +222,7 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
      */
     override suspend fun submit() {
         commandMessageForm.updateValidationDisplay(true)
-        if (!commandMessageForm.valueValid.value) {
+        if (!commandMessageForm.valid.value) {
             return
         }
         commandMessageForm.postCommand()
@@ -309,6 +309,6 @@ public abstract class CommandWizardPage<M : Message, B : ValidatingBuilder<out M
 
     override fun validate(): Boolean {
         pageForm.updateValidationDisplay(true)
-        return pageForm.valueValid.value
+        return pageForm.valid.value
     }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -396,7 +396,7 @@ import kotlinx.coroutines.launch
  *   easily standardize the concepts common for all similar components
  *   (e.g. concepts reused in all input components) by extracting them into base
  *   class(es). For example, the input component's parameters such as its value,
- *   validity state ([valueValid][InputComponent.valueValid]), external
+ *   validity state ([valid][InputComponent.valid]), external
  *   validation message
  *   ([externalValidationMessage][InputComponent.externalValidationMessage]),
  *   etc. can be declared and documented as properties in the respective base

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -202,7 +202,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
         DropdownListBox<I> {
             items = getFilteredItems(searchString)
             selectedItem = this@DropdownSelector.selectedItem
-            noneItemEnabled = !valueRequired
+            noneItemEnabled = !required
             onSelectItem = ::onSelectItem
             expanded = this@DropdownSelector.expanded
             enabled = this@DropdownSelector.enabled
@@ -249,7 +249,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
                 .onPreviewKeyEvent { handleKeyEvent(it) },
             trailingIcon = {
                 TrailingIcons(
-                    valueRequired,
+                    required,
                     selectedItem != null,
                     expanded.value,
                     enabled
@@ -294,7 +294,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
         searchString = ""
         selectedItem = item
         selection = TextRange(if (item != null) itemText(item).length else 0)
-        valueValid.value = true
+        valid.value = true
         expanded.value = false
     }
 
@@ -355,7 +355,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
         if (searchString != newSearchString || selectedItem != null) {
             searchString = newSearchString
             selectedItem = null
-            valueValid.value = (newSearchString == "")
+            valid.value = (newSearchString == "")
             expanded.value = true
         }
     }

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -98,11 +98,11 @@ public interface InputContext {
  *
  * - Whenever the component contains a valid data entry at any given point in
  *   time, it provides a respective value of type [V] inside of [value] state,
- *   and reports a value of `true` in its [valueValid] state.
+ *   and reports a value of `true` in its [valid] state.
  *
  * - Whenever the component contains an invalid data entry at any given point in
  *   time, it provides `null` inside of [value], and `false` inside
- *   of [valueValid].
+ *   of [valid].
  *
  *   Besides, to ensure a good user's experience, and make the current state
  *   explicit to the user, a component is responsible for notifying the user of
@@ -117,7 +117,7 @@ public interface InputContext {
  * This is called an internal validation for convenience here. This kind of
  * validation is performed by the input component itself, before it comes up
  * with an actual value that it stores in the [value] property. The status of
- * this kind of validation is reflected in the [valueValid] state.
+ * this kind of validation is reflected in the [valid] state.
  *
  * It might also be needed for an application to validate field values after
  * they have been entered using `InputComponent`s. For example a form might need
@@ -130,7 +130,7 @@ public interface InputContext {
  * can enforce this input component to be displayed as an invalid one to
  * the user despite the input component itself didn't detect any validation
  * errors and has emitted the respective value of type [V], accompanied by its
- * `valueValid` having a value of `true`. In such cases the form that contains
+ * [valid] state having a value of `true`. In such cases the form that contains
  * such input component generates the respective "external" validation message
  * that it passes to the input component so that it can display it inside.
  *
@@ -142,7 +142,7 @@ public interface InputContext {
  * whenever it contains a non-`null` value. Note that
  * [externalValidationMessage] concerns only the external validation, and it is
  * not related to the component's own internal validation state, so it is
- * a normal situation that a component reports its [valueValid] state to contain
+ * a normal situation that a component reports its [valid] state to contain
  * `true`, but [externalValidationMessage] can contain a non-`null` value at
  * the same time.
  *
@@ -171,12 +171,12 @@ public interface InputContext {
  * Whenever the input component transitions from/to the dirty state, it has
  * to invoke the [onDirtyStateChange] callback.
  *
- * @param V
- *         a type of values that this input component allows to edit.
- * @constructor a constructor, which is used internally by the input component's
- *         implementation. Use [companion object's][ComponentCompanion]
- *         [invoke][ComponentCompanion.invoke] operators for instantiating
- *         and rendering any specific input component in any application code.
+ * @param V A type of values that this input component allows to edit.
+ *
+ * @constructor A constructor, which is used internally by the input component's
+ *   implementation. Use [companion object's][ComponentSetup]
+ *   [invoke][ComponentSetup.invoke] operators for instantiating and rendering
+ *   any specific input component in any application code.
  */
 @Stable
 public abstract class InputComponent<V> : FocusableComponent() {
@@ -189,7 +189,7 @@ public abstract class InputComponent<V> : FocusableComponent() {
      *
      * A value of `null` corresponds to a "not present" value if the input
      * component is in the respective state, or an invalid input. A value of
-     * [valueValid] at the same time describes whether the field has
+     * [valid] at the same time describes whether the field has
      * a valid value.
      */
     public open lateinit var value: MutableState<V?>
@@ -202,23 +202,23 @@ public abstract class InputComponent<V> : FocusableComponent() {
      * If an invalid value is entered, then the value in this [MutableState] is
      * set to `false`. Otherwise, it's set to `true`.
      */
-    public open lateinit var valueValid: MutableState<Boolean>
+    public open lateinit var valid: MutableState<Boolean>
 
     /**
      * Specifies whether the valid entry within the component can only result in
      * a non-`null` value.
      *
      * A value of `false` means that an input component can report its certain
-     * entry state as representing a `null` value, and still have `valueValid`
+     * entry state as representing a `null` value, and still have [valid]
      * to be `true`.
      *
      * A value of `true` means that the input component can only report a `null`
-     * value if its current entry is invalid (when it reports `valueValid` to
+     * value if its current entry is invalid (when it reports [valid] to
      * be `false`).
      * TODO:2024-03-17:dmitry.pikhulya: see how this property can be
      *     supported in all input components, not just in MessageForm
      */
-    public var valueRequired: Boolean by mutableStateOf(false)
+    public var required: Boolean by mutableStateOf(false)
 
     /**
      * This property is dedicated to be set by the form automatically for
@@ -272,8 +272,8 @@ public abstract class InputComponent<V> : FocusableComponent() {
         if (!this::value.isInitialized) {
             value = mutableStateOf(null)
         }
-        if (!this::valueValid.isInitialized) {
-            valueValid = mutableStateOf(true)
+        if (!this::valid.isInitialized) {
+            valid = mutableStateOf(true)
         }
     }
 

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -171,18 +171,18 @@ public typealias RawTextContent = TextFieldValue
  *    [ValueParseException] is displayed near the field, and [valid] state
  *    is set to a value of `false`.
  *
- *  - A value [V] is validated using [onValidateValue].
+ *  - A value [V] is validated using [onValidate].
  *
- *    After a value was successfully parsed, an optional [onValidateValue]
+ *    After a value was successfully parsed, an optional [onValidate]
  *    callback is invoked, which can be used to specify which values should be
  *    interpreted as valid, and which ones should cause a validation failure.
  *    If a callback is missing or if it returns `null`, then the value is
- *    considered valid. If [onValidateValue] returns a non-`null` validation
+ *    considered valid. If [onValidate] returns a non-`null` validation
  *    error message, then this message is displayed near the field and the
  *    [valid] state is set to `false`.
  *
  * If the entered value valid according to both [parseValue] and
- * [onValidateValue], the [valid] state gets a value of `true`.
+ * [onValidate], the [valid] state gets a value of `true`.
  *
  * #### Handling empty input
  *
@@ -274,7 +274,7 @@ public open class InputField<V> : InputComponent<V>() {
      * and makes the [valid] state to be `false`. Returning `null`
      * accepts the value as a valid one.
      */
-    public var onValidateValue: ((V) -> String?)? = null
+    public var onValidate: ((V) -> String?)? = null
 
     /**
      * A label for the component.
@@ -326,7 +326,7 @@ public open class InputField<V> : InputComponent<V>() {
      * correct it to a valid form.
      *
      * If the text field has a valid format (parsed successfully with
-     * [parseValue]), and is valid according to [onValidateValue] then this
+     * [parseValue]), and is valid according to [onValidate] then this
      * property is `null`.
      */
     private var invalidValueText by mutableStateOf<String?>(null)
@@ -622,17 +622,17 @@ public open class InputField<V> : InputComponent<V>() {
      * successfully, and identify whether it should be interpreted as a valid or
      * invalid value by the component.
      *
-     * The default implementation delegates this to the [onValidateValue]
+     * The default implementation delegates this to the [onValidate]
      * callback, but subclasses can introduce additional validation logic
      * if needed.
      *
      * @param value A value that needs to be validated.
      * @return A non-`null` validation error message string if a value [V]
      *   should be considered as an invalid one.
-     * @see onValidateValue
+     * @see onValidate
      */
     protected open fun whatsWrongWith(value: V): String? {
-        return onValidateValue?.invoke(value)
+        return onValidate?.invoke(value)
     }
 
     /**

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -168,8 +168,8 @@ public typealias RawTextContent = TextFieldValue
  *    When current text's parsing fails (with [parseValue] throwing
  *    [ValueParseException]), the validation error
  *    [message][ValueParseException.validationErrorMessage] from the respective
- *    [ValueParseException] is displayed near the field, and [valueValid]'s
- *    state is set to `false`.
+ *    [ValueParseException] is displayed near the field, and [valid] state
+ *    is set to a value of `false`.
  *
  *  - A value [V] is validated using [onValidate].
  *
@@ -179,10 +179,10 @@ public typealias RawTextContent = TextFieldValue
  *    If a callback is missing or if it returns `null`, then the value is
  *    considered valid. If [onValidateValue] returns a non-`null` validation
  *    error message, then this message is displayed near the field and the
- *    [valueValid] state is set to `false`.
+ *    [valid] state is set to `false`.
  *
  * If the entered value valid according to both [parseValue] and
- * [onValidate], the [valueValid] state gets a value of `true`.
+ * [onValidate], the [valid] state gets a value of `true`.
  *
  * #### Handling empty input
  *
@@ -236,7 +236,7 @@ public open class InputField<V> : InputComponent<V>() {
      *
      * A value of `null` corresponds to the empty input (when raw text is
      * an empty string), or an invalid input (when an input cannot be parsed as
-     * a valid value by [parseValue]). A value of [valueValid] describes whether
+     * a valid value by [parseValue]). A value of [valid] describes whether
      * the field has a valid value.
      */
     override var value: MutableState<V?>
@@ -253,17 +253,17 @@ public open class InputField<V> : InputComponent<V>() {
      * [ValueParseException]), then the value in this [MutableState] is set
      * to `false`. Otherwise, it's set to `true`.
      */
-    override var valueValid: MutableState<Boolean>
-        get() = super.valueValid
+    override var valid: MutableState<Boolean>
+        get() = super.valid
         set(value) {
-            super.valueValid = value
+            super.valid = value
         }
 
     /**
      * A callback, which is triggered after the value in the [MutableState] in
      * [value] has been updated with a newly edited value.
      */
-    public var onValueChange: ((V?) -> Unit)? = null
+    public var onChange: ((V?) -> Unit)? = null
 
     /**
      * An optional lambda, which acts as a custom validator for any value [V]
@@ -271,7 +271,7 @@ public open class InputField<V> : InputComponent<V>() {
      *
      * Returning a non-`null` string for a particular value [V] makes that
      * string to be displayed as an in-component's validation error message,
-     * and makes the [valueValid] state to be `false`. Returning `null`
+     * and makes the [valid] state to be `false`. Returning `null`
      * accepts the value as a valid one.
      */
     public var onValidate: ((V) -> String?)? = null
@@ -549,7 +549,7 @@ public open class InputField<V> : InputComponent<V>() {
         invalidValueText = newText.takeIf { !valid }
         selection = revisedTextContent.selection
 
-        valueValid.value = valid
+        this.valid.value = valid
         ownValidationMessage.value = validationErrorMessage
 
         val prevTextEmpty = currentRawTextContent.text.isEmpty()
@@ -558,7 +558,7 @@ public open class InputField<V> : InputComponent<V>() {
             onDirtyStateChange?.invoke(prevTextEmpty)
         }
         if (value.value != prevValue) {
-            onValueChange?.invoke(value.value)
+            onChange?.invoke(value.value)
         }
     }
 
@@ -680,7 +680,7 @@ public open class InputField<V> : InputComponent<V>() {
             selection = revisedRawTextContent.selection
             ownValidationMessage.value = null
         } else {
-            if (valueValid.value) {
+            if (valid.value) {
                 invalidValueText = null
                 selection = revisedRawTextContent.selection
                 ownValidationMessage.value = null

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1094,12 +1094,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:18 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:23 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1953,12 +1953,12 @@ This report was generated on **Thu Mar 27 20:08:18 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:26 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2991,12 +2991,12 @@ This report was generated on **Thu Mar 27 20:08:30 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:31 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:28 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4015,12 +4015,12 @@ This report was generated on **Thu Mar 27 20:08:31 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:30 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4814,12 +4814,12 @@ This report was generated on **Thu Mar 27 20:08:33 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:35 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:32 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5583,4 +5583,4 @@ This report was generated on **Thu Mar 27 20:08:35 EET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 27 20:08:37 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 28 16:50:33 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.74</version>
+<version>2.0.0-SNAPSHOT.75</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/InputComponentExt.kt
@@ -169,10 +169,10 @@ internal fun <
 ) {
     Field(field, defaultValue) {
         this@InputComponent.value = this@Field.fieldValue
-        this@InputComponent.valueValid = this@Field.fieldValueValid
+        this@InputComponent.valid = this@Field.fieldValueValid
         this@InputComponent.externalValidationMessage = this@Field.externalValidationMessage
         this@InputComponent.onDirtyStateChange = { this@Field.notifyDirtyStateChanged(it) }
-        this@InputComponent.valueRequired = this@Field.fieldRequired
+        this@InputComponent.required = this@Field.fieldRequired
         this@InputComponent.enabled = this@Field.fieldEnabled.value
         this@Field.focusRequestDispatcher.handleFocusRequest = { focus() }
         registerFieldValueEditor(this@InputComponent)

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -142,7 +142,7 @@ import io.spine.validate.ValidationException
  * Upon any change made in any declared field editor component, an attempt to
  * build a message [M] is made from all the currently entered field values. If
  * it succeeds, the respective validated value of type [M] is set into the
- * [value] state, and the value inside the [valueValid] state is set to `true`.
+ * [value] state, and the value inside the [valid] state is set to `true`.
  *
  * In case when any of the field editors report their own internal validation
  * errors (see [FormFieldScope.fieldValueValid]), or if any validation
@@ -150,7 +150,7 @@ import io.spine.validate.ValidationException
  * currently entered field values (when invoking the [builder]'s
  * [vBuild][ValidatingBuilder.vBuild] method), this prevents the form from a
  * successful creation of the resulting value [M], and results in `null` to be
- * stored in [value], and `false` to be stored in [valueValid].
+ * stored in [value], and `false` to be stored in [valid].
  *
  * ### Support for specifying a missing value
  *
@@ -162,13 +162,13 @@ import io.spine.validate.ValidationException
  * a value in the form might be useful for example when the form represents
  * an editor for an optional field of another message.
  *
- * To allow such an option for the user, set the form's [valueRequired] property
+ * To allow such an option for the user, set the form's [required] property
  * to `false`, and place the [OptionalMessageCheckbox] at the top-level scope of
  * the form ([MultipartFormScope], or [FormPartScope]), introduced by either of
  * `MessageForm` composable functions.
  *
  * If a checkbox is unchecked, a form would always report a [value]'s value of
- * `null`, and its [valueValid] state with a value of `true`.
+ * `null`, and its [valid] state with a value of `true`.
  *
  * ### Displaying per-field validation errors
  *
@@ -381,7 +381,7 @@ import io.spine.validate.ValidationException
  * ### Displaying validation errors manually
  *
  * The `MessageForm` component always provides an up-to-date input validation
- * state via its [valueValid] property. Nevertheless, it's possible to customize
+ * state via its [valid] property. Nevertheless, it's possible to customize
  * when validation error messages are displayed to the user.
  *
  * There are two aspects that can be utilized to gain more control of form's
@@ -887,9 +887,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * This has a non-`null` value only when a form-level validation has
          * indicated an error for this field, and is not affected by the field
          * editor's internal validation state, which is kept independently
-         * (see [valueValid]).
+         * (see [valid]).
          *
-         * @see [valueValid]
+         * @see [valid]
          */
         val externalValidationMessage: MutableState<String?> = mutableStateOf(null)
 
@@ -899,12 +899,12 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * state (not the validation state resulting in form the
          * form's validation).
          *
-         * Note that [valueValid] only reflects the field editor's own
+         * Note that [valid] only reflects the field editor's own
          * perspective on the field's validity state, which basically reflects
          * its ability to produce a value based on current user's input.
          * The form can perform additional validation over the values provided
          * by field editors, but the status of the form-level validation is
-         * independent from [valueValid].
+         * independent from [valid].
          *
          * @see [externalValidationMessage]
          */
@@ -1093,7 +1093,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     internal var onBeforeBuild: (ValidatingBuilder<out M>) -> Unit = {}
 
     init {
-        valueRequired = true
+        required = true
     }
 
     private val messageDef by lazy { builder().messageDef() }
@@ -1426,7 +1426,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     }
 
     private fun identifyInitialEnteringNonNullValue(): Boolean = when {
-        valueRequired || value.value != null ->
+        required || value.value != null ->
             true
 
         messageDef.fields.isEmpty() -> {
@@ -1518,9 +1518,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      *
      * If there are no validation failures while building the updated message's
      * value, then the value in the [value] state is updated with
-     * the newly built message, and the [valueValid] state is set to `true`.
+     * the newly built message, and the [valid] state is set to `true`.
      * Otherwise, the [value] state's value is set to a value of `null`, and
-     * the [valueValid] state's value is set to `false`.
+     * the [valid] state's value is set to `false`.
      *
      * The validation is performed using whatever rules are built in with
      * the standard Spine's `vBuild()` functionality of [ValidatingBuilder].
@@ -1533,7 +1533,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * invalid or incomplete entry in some of the fields). In this case, the
      * form's validation is also considered to fail.
      *
-     * This method states a validation error (sets [valueValid] to `true`, and
+     * This method states a validation error (sets [valid] to `true`, and
      * [value] to `null`),  if any of the validation constraints fail during
      * `vBuild()`, or if any fields have their internal validation errors.
      * The form's status is updated to reflect the validation failures before
@@ -1559,12 +1559,12 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         }
 
         if (!enteringNonNullValue.value) {
-            check(!valueRequired) {
+            check(!required) {
                 "enteringNonNullValue cannot be set to false " +
                         "on a form whose valueRequired is true."
             }
             value.value = null
-            valueValid.value = true
+            valid.value = true
             return
         }
 
@@ -1580,7 +1580,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
                 }
                 recoveringFromManualValidationErrors = true
             }
-            valueValid.value = false
+            valid.value = false
             value.value = null
             return
         }
@@ -1593,7 +1593,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         if (updateValidationErrors) {
             recoveringFromManualValidationErrors = nestedErrorsPresent
         }
-        valueValid.value = !nestedErrorsPresent
+        valid.value = !nestedErrorsPresent
         value.value = if (nestedErrorsPresent) {
             if (focusInvalidField) {
                 focus()
@@ -1620,7 +1620,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * Updates the displayed validation errors according to the currently
      * entered editor's data.
      *
-     * Note that the form's [valueValid] state is nevertheless always kept up to
+     * Note that the form's [valid] state is nevertheless always kept up to
      * date upon any updates in the form's fields, regardless of whether
      * [updateValidationDisplay] has been called or not. So this method just
      * ensures that the displayed messages are up-to-date as well, which makes

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/OptionalMessageCheckbox.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/OptionalMessageCheckbox.kt
@@ -65,7 +65,7 @@ public fun <M : Message> FormPartScope<M>.OptionalMessageCheckbox(
 public fun <M : Message> MultipartFormScope<M>.OptionalMessageCheckbox(
     text: String
 ) {
-    check(!form.valueRequired) {
+    check(!form.required) {
         "`OptionalMessageCheckbox` can only be used with forms whose `valueRequired` is false."
     }
     CheckboxWithText(

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -244,7 +244,7 @@ public class MoneyField : InputField<Money>() {
 
         selectedCurrency = item
 
-        if (value.value == null || !valueValid.value) {
+        if (value.value == null || !valid.value) {
             return
         }
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/PaymentMethodEditor.kt
@@ -67,7 +67,7 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
      * @param selectorsOffset A vertical distance between radio button selectors
      *   and their respective fields.
      * @param optionalCheckboxOffset A vertical distance between the checkbox,
-     *   which is displayed when [valueRequired] is `false`, and the rest of
+     *   which is displayed when [required] is `false`, and the rest of
      *   the controls within the component.
      */
     public data class Look(
@@ -79,7 +79,7 @@ public class PaymentMethodEditor : CustomMessageForm<PaymentMethod>(
     @Composable
     override fun FormPartScope<PaymentMethod>.customContent() {
         Column {
-            if (!valueRequired) {
+            if (!required) {
                 Row {
                     OptionalMessageCheckbox("Specify payment method")
                 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.74")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.75")


### PR DESCRIPTION
This PR revises the names of value-related properties in input components like this with the purpose of making the API more concise like this:
- `InputComponent.valueValid` -> `valid`
- `InputComponent.valueRequired` -> `required`
- `InputField.onValueChange` -> `onChange`
- `InputField.onValidateValue` -> `onValidate`

This PR addresses concerns raised in [this comment](https://github.com/SpineEventEngine/Chords/pull/107#discussion_r2017371965) of PR https://github.com/SpineEventEngine/Chords/pull/107.