### PR TITLE
Update the codegen plugins to use the newer version of ProtoData `0.92.11`

### DIFF
--- a/codegen/plugins/build.gradle.kts
+++ b/codegen/plugins/build.gradle.kts
@@ -55,7 +55,7 @@ plugins {
     id("net.ltgt.errorprone")
     id("detekt-code-analysis")
     id("com.google.protobuf")
-    id("io.spine.protodata") version "0.70.3"
+    id("io.spine.protodata") version "0.92.11"
     idea
 }
 

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.234"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.234"
+    const val version = "2.0.0-SNAPSHOT.242"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.242"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.182"
+        const val version = "2.0.0-SNAPSHOT.206"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-        const val version = "2.0.0-SNAPSHOT.206"
+    const val version = "2.0.0-SNAPSHOT.206"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.259"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.266"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.259"
+    const val version = "2.0.0-SNAPSHOT.266"
 
     /**
      * The ID of the Gradle plugin.

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -44,7 +44,7 @@ object ProtoData {
     /**
      * The version of ProtoData dependencies.
      */
-    const val version = "0.70.3"
+    const val version = "0.92.11"
 
     /**
      * Identifies ProtoData as a `classpath` dependency under `buildScript` block.

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.234"
+    const val version = "2.0.0-SNAPSHOT.246"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.188"
+    const val version = "2.0.0-SNAPSHOT.197"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldsRenderer.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageFieldsRenderer.kt
@@ -26,12 +26,12 @@
 
 package io.spine.chords.codegen.plugins
 
-import io.spine.chords.runtime.MessageDef
-import io.spine.chords.runtime.MessageField
-import io.spine.chords.runtime.MessageOneof
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
+import io.spine.chords.runtime.MessageDef
 import io.spine.chords.runtime.MessageDef.Companion.MESSAGE_DEF_CLASS_SUFFIX
+import io.spine.chords.runtime.MessageField
+import io.spine.chords.runtime.MessageOneof
 import io.spine.protodata.ast.Field
 import io.spine.protodata.ast.TypeName
 import io.spine.protodata.java.javaPackage
@@ -65,9 +65,6 @@ public class MessageFieldsRenderer : Renderer<Kotlin>(Kotlin.lang()) {
         if (!sources.outputRoot.endsWith(KOTLIN_SOURCE_ROOT)) {
             return
         }
-        checkNotNull(typeSystem) {
-            "`TypeSystem` is not initialized."
-        }
 
         select(MessageTypeView::class.java).all()
             .filter {
@@ -75,7 +72,7 @@ public class MessageFieldsRenderer : Renderer<Kotlin>(Kotlin.lang()) {
                 !it.id.file.path.endsWith(REJECTIONS_PROTO_FILE_NAME)
             }.forEach { messageTypeView ->
                 val typeName = messageTypeView.id.typeName
-                val messageToHeader = typeSystem!!.findMessage(typeName)
+                val messageToHeader = typeSystem.findMessage(typeName)
                 checkNotNull(messageToHeader) {
                     "Message not found for type `$typeName`."
                 }
@@ -93,10 +90,10 @@ public class MessageFieldsRenderer : Renderer<Kotlin>(Kotlin.lang()) {
      * for the [fields] provided.
      */
     private fun TypeName.generateFileContent(fields: Iterable<Field>) =
-        FileSpec.builder(fullClassName(typeSystem!!))
+        FileSpec.builder(fullClassName(typeSystem))
             .indent(Indent.defaultJavaIndent.toString())
             .also { fileBuilder ->
-                MessageDefFileGenerator(this, fields, typeSystem!!)
+                MessageDefFileGenerator(this, fields, typeSystem)
                     .generateCode(fileBuilder)
             }
             .build()
@@ -107,7 +104,7 @@ public class MessageFieldsRenderer : Renderer<Kotlin>(Kotlin.lang()) {
      */
     private fun TypeName.generateFilePath(): Path {
         return Path.of(
-            javaPackage(typeSystem!!).replace('.', '/'),
+            javaPackage(typeSystem).replace('.', '/'),
             generateFileName()
         )
     }

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageViewRepository.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageViewRepository.kt
@@ -27,7 +27,6 @@ package io.spine.chords.codegen.plugins
 
 import io.spine.core.EventContext
 import io.spine.protodata.ast.event.TypeDiscovered
-import io.spine.protodata.ast.typeName
 import io.spine.protodata.plugin.ViewRepository
 import io.spine.server.route.EventRoute
 import io.spine.server.route.EventRouting

--- a/codegen/plugins/codegen-plugins/src/main/resources/codegen-workspace/build.gradle.kts
+++ b/codegen/plugins/codegen-plugins/src/main/resources/codegen-workspace/build.gradle.kts
@@ -47,7 +47,7 @@ buildscript {
 plugins {
     kotlin("jvm")
     id("com.google.protobuf")
-    id("io.spine.protodata") version "0.70.3"
+    id("io.spine.protodata") version "0.92.11"
     idea
 }
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1094,12 +1094,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 03 11:58:36 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 07 18:36:33 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1953,12 +1953,12 @@ This report was generated on **Thu Apr 03 11:58:36 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 03 11:58:38 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 07 18:36:34 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2991,12 +2991,12 @@ This report was generated on **Thu Apr 03 11:58:38 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 03 11:58:40 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 07 18:36:35 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4015,12 +4015,12 @@ This report was generated on **Thu Apr 03 11:58:40 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 03 11:58:42 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 07 18:36:35 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4814,12 +4814,12 @@ This report was generated on **Thu Apr 03 11:58:42 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 03 11:58:43 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 07 18:36:36 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5583,4 +5583,4 @@ This report was generated on **Thu Apr 03 11:58:43 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 03 11:58:44 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 07 18:36:37 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1094,7 +1094,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 07 18:36:33 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 11:56:54 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1953,7 +1953,7 @@ This report was generated on **Mon Apr 07 18:36:33 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 07 18:36:34 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 11:57:03 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2991,7 +2991,7 @@ This report was generated on **Mon Apr 07 18:36:34 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 07 18:36:35 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 11:57:05 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4015,7 +4015,7 @@ This report was generated on **Mon Apr 07 18:36:35 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 07 18:36:35 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 11:57:06 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4814,7 +4814,7 @@ This report was generated on **Mon Apr 07 18:36:35 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 07 18:36:36 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 11:57:07 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5583,4 +5583,4 @@ This report was generated on **Mon Apr 07 18:36:36 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Apr 07 18:36:37 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 11:57:07 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.78</version>
+<version>2.0.0-SNAPSHOT.79</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.78")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.79")


### PR DESCRIPTION
This PR updates the code generation plugins to use the newer version of ProtoData `0.92.11`, while continuing to use Java 11 and Gradle 7.6.