### PR TITLE
Decrease dialog's height if the description field is empty

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -203,6 +203,9 @@ public class ConfirmationDialog : Dialog() {
      * makes a decision.
      */
     public suspend fun showConfirmation(): Boolean {
+        // TODO:2025-04-18:oleg.melnik: Remove the code below after automatic
+        //  size detection is implemented for dialogs.
+        //  https://github.com/SpineEventEngine/Chords/issues/118
         if (description.isBlank() && height == DefaultDialogHeight) {
             height -= ReservedDescriptionHeight
         }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -39,6 +39,22 @@ import io.spine.chords.core.appshell.Props
 import kotlinx.coroutines.CompletableDeferred
 
 /**
+ * Default width of the [ConfirmationDialog].
+ */
+private val DefaultDialogWidth = 450.dp
+
+/**
+ * Default height of the [ConfirmationDialog].
+ */
+private val DefaultDialogHeight = 220.dp
+
+/**
+ * The value used to reduce the dialog's height
+ * when the description field is empty.
+ */
+private val ReservedDescriptionHeight = 32.dp
+
+/**
  * A dialog that prompts the user either to make a boolean decision
  * (e.g. approve or deny some action).
  *
@@ -123,7 +139,9 @@ public class ConfirmationDialog : Dialog() {
      */
     public var yesButtonText: String
         get() = submitButtonText
-        set(value) { submitButtonText = value }
+        set(value) {
+            submitButtonText = value
+        }
 
     /**
      * The label for the dialog's No button.
@@ -132,7 +150,9 @@ public class ConfirmationDialog : Dialog() {
      */
     public var noButtonText: String
         get() = cancelButtonText
-        set(value) { cancelButtonText = value }
+        set(value) {
+            cancelButtonText = value
+        }
 
     init {
         submitAvailable = true
@@ -140,8 +160,8 @@ public class ConfirmationDialog : Dialog() {
 
         yesButtonText = "Yes"
         noButtonText = "No"
-        width = 430.dp
-        height = 210.dp
+        width = DefaultDialogWidth
+        height = DefaultDialogHeight
     }
 
     /**
@@ -152,19 +172,21 @@ public class ConfirmationDialog : Dialog() {
         val textStyle = typography.bodyLarge
 
         Column {
-            Row(
-                modifier = Modifier.padding(bottom = 6.dp)
-            ) {
+            Row {
                 Text(
                     text = message,
                     style = textStyle
                 )
             }
-            Row {
-                Text(
-                    text = description,
-                    style = textStyle
-                )
+            if (description.isNotBlank()) {
+                Row(
+                    modifier = Modifier.padding(top = 8.dp)
+                ) {
+                    Text(
+                        text = description,
+                        style = textStyle
+                    )
+                }
             }
         }
     }
@@ -181,6 +203,9 @@ public class ConfirmationDialog : Dialog() {
      * makes a decision.
      */
     public suspend fun showConfirmation(): Boolean {
+        if (description.isBlank() && height == DefaultDialogHeight) {
+            height -= ReservedDescriptionHeight
+        }
         var confirmed = false
         val dialogClosure = CompletableDeferred<Unit>()
         onBeforeSubmit = {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
@@ -48,6 +48,22 @@ import kotlinx.coroutines.CompletableDeferred
 private const val InputComponentNoOfLines = 3
 
 /**
+ * Default width of the [InputTextDialog].
+ */
+private val DefaultDialogWidth = 450.dp
+
+/**
+ * Default height of the [InputTextDialog].
+ */
+private val DefaultDialogHeight = 300.dp
+
+/**
+ * The value used to reduce the dialog's height
+ * when the description field is empty.
+ */
+private val ReservedDescriptionHeight = 24.dp
+
+/**
  * A dialog that allows input of a text value.
  *
  * By default, the dialog is configured to allow multiline text input. However,
@@ -182,8 +198,8 @@ public class InputTextDialog : Dialog() {
     init {
         submitAvailable = true
         cancelAvailable = true
-        width = 430.dp
-        height = 300.dp
+        width = DefaultDialogWidth
+        height = DefaultDialogHeight
     }
 
     /**
@@ -193,23 +209,25 @@ public class InputTextDialog : Dialog() {
     protected override fun contentSection() {
         val textStyle = typography.bodyLarge
         Column {
-            Row(
-                modifier = Modifier.padding(bottom = 8.dp)
-            ) {
+            Row {
                 Text(
                     text = message,
                     style = textStyle
                 )
             }
-            Row(
-                modifier = Modifier.padding(bottom = 16.dp)
-            ) {
-                Text(
-                    text = description,
-                    style = textStyle
-                )
+            if (description.isNotBlank()) {
+                Row(
+                    modifier = Modifier.padding(top = 8.dp)
+                ) {
+                    Text(
+                        text = description,
+                        style = textStyle
+                    )
+                }
             }
-            Row {
+            Row(
+                modifier = Modifier.padding(top = 16.dp)
+            ) {
                 text.value = defaultText
                 StringField {
                     label = textFieldLabel
@@ -238,6 +256,9 @@ public class InputTextDialog : Dialog() {
      * pressing the submit button, or `null`, if the user cancels the input.
      */
     private suspend fun show(): String? {
+        if (description.isBlank() && height == DefaultDialogHeight) {
+            height -= ReservedDescriptionHeight
+        }
         var dialogCancelled = false
         val dialogClosure = CompletableDeferred<Unit>()
         onBeforeSubmit = {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
@@ -256,6 +256,9 @@ public class InputTextDialog : Dialog() {
      * pressing the submit button, or `null`, if the user cancels the input.
      */
     private suspend fun show(): String? {
+        // TODO:2025-04-18:oleg.melnik: Remove the code below after automatic
+        //  size detection is implemented for dialogs.
+        //  https://github.com/SpineEventEngine/Chords/issues/118
         if (description.isBlank() && height == DefaultDialogHeight) {
             height -= ReservedDescriptionHeight
         }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1094,12 +1094,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 08 11:56:54 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 18 13:36:25 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1953,12 +1953,12 @@ This report was generated on **Tue Apr 08 11:56:54 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 08 11:57:03 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 18 13:36:27 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2991,12 +2991,12 @@ This report was generated on **Tue Apr 08 11:57:03 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 08 11:57:05 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 18 13:36:28 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -4015,12 +4015,12 @@ This report was generated on **Tue Apr 08 11:57:05 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 08 11:57:06 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 18 13:36:29 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4814,12 +4814,12 @@ This report was generated on **Tue Apr 08 11:57:06 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 08 11:57:07 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 18 13:36:30 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5583,4 +5583,4 @@ This report was generated on **Tue Apr 08 11:57:07 EEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 08 11:57:07 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 18 13:36:31 EEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.79</version>
+<version>2.0.0-SNAPSHOT.80</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.79")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.80")


### PR DESCRIPTION
This PR reduces the height of the `ConfirmationDialog` and `InputTextDialog` components when the description field is not provided by the user and the dialog height remains at its default value.