### PR TITLE
Add `excludedEntityIds` property to the `EntityChooser` component

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ buildscript {
     standardSpineSdkRepositories()
 
     plugins {
-        id("io.spine.chords") version "1.9.20"
+        id("io.spine.chords") version "1.9.22"
     }
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -254,7 +254,7 @@ object Spine {
          */
         object GradlePlugin {
             private const val artifact = "${artifactPrefix}gradle-plugin"
-            private const val version = "1.9.20"
+            private const val version = "1.9.22"
 
             const val id = "io.spine.chords"
             const val lib = "$chordsGroup:$artifact:$version"

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -203,13 +203,12 @@ public abstract class EntityChooser<
     @ReadOnlyComposable
     override fun beforeComposeContent() {
         super.beforeComposeContent()
-        val includedEntityStates = entityStates.value.filter {
-            entityId(it) !in excludedEntities
-        }
         entityStatesByIds.clear()
-        includedEntityStates.forEach {
+        entityStates.value.forEach {
             entityStatesByIds[entityId(it)] = it
         }
-        items.value = includedEntityStates.map { entityId(it) }
+        items.value = entityStates.value.filter {
+            entityId(it) !in excludedEntities
+        }.map { entityId(it) }
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -96,6 +96,9 @@ public abstract class EntityChooser<
     /**
      * A set of entity IDs that should be excluded from the drop-down list,
      * and thus cannot be selected by the user.
+     *
+     * It's up to the subclasses of this component to expose this property
+     * with an appropriate name and visibility.
      */
     protected var excludedEntityIds: Set<I> by mutableStateOf(setOf())
 

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -30,7 +30,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import io.spine.chords.core.appshell.app
 import io.spine.base.EntityState
 import io.spine.chords.core.DropdownSelector
@@ -90,6 +92,12 @@ public abstract class EntityChooser<
     override val items: MutableState<Iterable<I>> = mutableStateOf(listOf())
     private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId)
     private val entityStatesByIds: HashMap<I, E> = hashMapOf()
+
+    /**
+     * A set of entity IDs that should be excluded from the drop-down list,
+     * and thus cannot be selected by the user.
+     */
+    protected var excludedEntities: Set<I> by mutableStateOf(setOf())
 
     /**
      * Identifies a type specified for the [E] type parameter by the
@@ -195,10 +203,13 @@ public abstract class EntityChooser<
     @ReadOnlyComposable
     override fun beforeComposeContent() {
         super.beforeComposeContent()
+        val includedEntityStates = entityStates.value.filter {
+            entityId(it) !in excludedEntities
+        }
         entityStatesByIds.clear()
-        entityStates.value.forEach {
+        includedEntityStates.forEach {
             entityStatesByIds[entityId(it)] = it
         }
-        items.value = entityStates.value.map { entityId(it) }
+        items.value = includedEntityStates.map { entityId(it) }
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -97,7 +97,7 @@ public abstract class EntityChooser<
      * A set of entity IDs that should be excluded from the drop-down list,
      * and thus cannot be selected by the user.
      */
-    protected var excludedEntities: Set<I> by mutableStateOf(setOf())
+    protected var excludedEntityIds: Set<I> by mutableStateOf(setOf())
 
     /**
      * Identifies a type specified for the [E] type parameter by the
@@ -111,7 +111,7 @@ public abstract class EntityChooser<
         val entityStateType =
             parameterizedEntityChooserType.arguments[TypeParameters.ENTITY_STATE.index].type
         checkNotNull(entityStateType) {
-            "The V type parameter (entity value type) cannot be a star <*> projection. "
+            "The E type parameter (entity state type) cannot be a star <*> projection. "
         }
 
         @Suppress(
@@ -208,7 +208,7 @@ public abstract class EntityChooser<
             entityStatesByIds[entityId(it)] = it
         }
         items.value = entityStates.value.filter {
-            entityId(it) !in excludedEntities
+            entityId(it) !in excludedEntityIds
         }.map { entityId(it) }
     }
 }

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/AnyExts.kt
@@ -33,6 +33,5 @@ package io.spine.chords.runtime
  * Helps avoid the `UNCHECKED_CAST` warning.
  */
 public inline fun <reified T : Any> Any.safeCast(): T {
-    return if (this is T) this
-    else error("Cannot cast `$this` to `${T::class}`.")
+    return this as? T ?: error("Cannot cast `$this` to `${T::class}`.")
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:00:02 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:41:02 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Tue Jul 14 14:00:02 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:00:04 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:41:03 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Tue Jul 14 14:00:04 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:00:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:41:05 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Tue Jul 14 14:00:06 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:00:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:41:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Tue Jul 14 14:00:07 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:00:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:41:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Tue Jul 14 14:00:08 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:00:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:41:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 24 15:33:54 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 29 13:45:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Fri Apr 24 15:33:54 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 24 15:33:55 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 29 13:45:11 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Fri Apr 24 15:33:55 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 24 15:33:56 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 29 13:45:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Fri Apr 24 15:33:56 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 24 15:33:57 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 29 13:45:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Fri Apr 24 15:33:57 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 24 15:33:59 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 29 13:45:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Fri Apr 24 15:33:59 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Apr 24 15:33:59 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 29 13:45:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 29 13:45:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:00:02 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Wed Apr 29 13:45:09 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 29 13:45:11 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:00:04 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Wed Apr 29 13:45:11 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 29 13:45:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:00:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Wed Apr 29 13:45:12 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 29 13:45:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:00:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Wed Apr 29 13:45:12 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 29 13:45:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:00:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Wed Apr 29 13:45:14 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 29 13:45:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 14:00:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.87</version>
+<version>2.0.0-SNAPSHOT.86</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.85</version>
+<version>2.0.0-SNAPSHOT.86</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.86</version>
+<version>2.0.0-SNAPSHOT.87</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -43,12 +43,12 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.text.TextStyle
 import com.google.protobuf.Message
 import io.spine.base.FieldPath
+import io.spine.chords.core.appshell.Props
 import io.spine.chords.core.FocusRequestDispatcher
 import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.InputComponent
 import io.spine.chords.core.InputContext
 import io.spine.chords.core.ValidationErrorText
-import io.spine.chords.core.appshell.Props
 import io.spine.chords.core.recompositionWorkaroundReadonly
 import io.spine.chords.proto.form.MessageForm.Companion.Multipart
 import io.spine.chords.proto.form.MessageForm.Companion.create
@@ -65,7 +65,6 @@ import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageFieldValue
 import io.spine.chords.runtime.MessageOneof
 import io.spine.chords.runtime.messageDef
-import io.spine.chords.runtime.safeCast
 import io.spine.protobuf.ValidatingBuilder
 import io.spine.validate.ConstraintViolation
 import io.spine.validate.ValidationException
@@ -459,6 +458,11 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          *   declaration site.
          */
         @Composable
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public operator fun <M : Message, B : ValidatingBuilder<out M>> invoke(
             value: MutableState<M?>,
             builder: () -> B,
@@ -466,13 +470,13 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
         ): MessageForm<M> = declareInstance(
-            value.safeCast(),
+            value as MutableState<Message?>,
             builder,
-            props.safeCast(),
+            props as Props<MessageForm<Message>>,
             onBeforeBuild
         ) {
-            content(this.safeCast())
-        }.safeCast()
+            content(this as FormPartScope<M>)
+        } as MessageForm<M>
 
         /**
          * Declares a `MessageForm` instance, which is automatically bound to
@@ -503,6 +507,11 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          */
         context(FormFieldsScope<PM>)
         @Composable
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public operator fun <
                 PM : Message,
                 M : Message,
@@ -515,14 +524,14 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
         ): MessageForm<M> = declareInstance(
-            field.safeCast() as MessageField<PM, Message>,
+            field as MessageField<PM, Message>,
             builder,
-            props.safeCast(),
+            props as Props<MessageForm<Message>>,
             defaultValue,
             onBeforeBuild
         ) {
-            content(this.safeCast())
-        }.safeCast()
+            content(this as FormPartScope<M>)
+        } as MessageForm<M>
 
         /**
          * Declares a multipart `MessageForm` instance, which edits a value
@@ -548,20 +557,25 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          *   declaration site.
          */
         @Composable
-        public fun <M : Message, B : ValidatingBuilder<out M>> Multipart(
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
+        public fun <M : Message, B: ValidatingBuilder<out M>> Multipart(
             value: MutableState<M?>,
             builder: () -> B,
             props: Props<MessageForm<M>> = Props {},
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
         ): MessageForm<M> = declareMultipartInstance(
-            value.safeCast(),
+            value as MutableState<Message?>,
             builder,
-            props.safeCast(),
+            props as Props<MessageForm<Message>>,
             onBeforeBuild
         ) {
-            content(this.safeCast())
-        }.safeCast()
+            content(this as MultipartFormScope<M>)
+        } as MessageForm<M>
 
         /**
          * Declares a multipart `MessageForm` instance, which is automatically
@@ -594,6 +608,11 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          */
         context(FormFieldsScope<PM>)
         @Composable
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
         public fun <
                 PM : Message,
                 M : Message,
@@ -606,14 +625,14 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
         ): MessageForm<M> = declareMultipartInstance(
-            field.safeCast() as MessageField<PM, Message>,
+            field as MessageField<PM, Message>,
             builder,
-            props.safeCast(),
+            props as Props<MessageForm<Message>>,
             defaultValue,
             onBeforeBuild
         ) {
-            content(this.safeCast())
-        }.safeCast()
+            content(this as MultipartFormScope<M>)
+        } as MessageForm<M>
 
         /**
          * Creates a [MessageForm] instance without rendering it in
@@ -646,17 +665,22 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @return A form's instance that has been created for this
          *   declaration site.
          */
-        public fun <M : Message, B : ValidatingBuilder<out M>> create(
+        @Suppress(
+            // Explicit casts are needed since we cannot parameterize
+            // `MessageFormCompanionBase` with the `M` type parameter.
+            "UNCHECKED_CAST"
+        )
+        public fun <M : Message, B: ValidatingBuilder<out M>> create(
             value: MutableState<M?>,
             builder: () -> B,
             onBeforeBuild: (B) -> Unit = {},
             props: Props<MessageForm<M>> = Props {}
         ): MessageForm<M> = createInstance(
-            value.safeCast(),
+            value as MutableState<Message?>,
             builder,
             onBeforeBuild,
-            props.safeCast()
-        ).safeCast()
+            props as Props<MessageForm<Message>>
+        ) as MessageForm<M>
     }
 
     /**
@@ -728,7 +752,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param fieldSelector A field selector component
          *   (such as [OneofRadioButton]).
          */
-        internal fun <F : MessageFieldValue> registerFieldSelector(
+        internal fun <F: MessageFieldValue> registerFieldSelector(
             field: MessageField<M, F>,
             fieldSelector: FocusableComponent
         ) {
@@ -1193,10 +1217,8 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * A [MultipartFormScope] instance, which is an outermost scope for
      * declarations within this form.
      */
-    @Suppress(
-        "LeakingThis" /* Leaking this shouldn't be a problem
-        since this field is designed for post-construction usage. */
-    )
+    @Suppress("LeakingThis" /* Leaking this shouldn't be a problem
+        since this field is designed for post-construction usage. */)
     private val formScope = MultipartFormScopeImpl(this)
 
     /**

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -43,12 +43,12 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.text.TextStyle
 import com.google.protobuf.Message
 import io.spine.base.FieldPath
-import io.spine.chords.core.appshell.Props
 import io.spine.chords.core.FocusRequestDispatcher
 import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.InputComponent
 import io.spine.chords.core.InputContext
 import io.spine.chords.core.ValidationErrorText
+import io.spine.chords.core.appshell.Props
 import io.spine.chords.core.recompositionWorkaroundReadonly
 import io.spine.chords.proto.form.MessageForm.Companion.Multipart
 import io.spine.chords.proto.form.MessageForm.Companion.create
@@ -65,6 +65,7 @@ import io.spine.chords.runtime.MessageField
 import io.spine.chords.runtime.MessageFieldValue
 import io.spine.chords.runtime.MessageOneof
 import io.spine.chords.runtime.messageDef
+import io.spine.chords.runtime.safeCast
 import io.spine.protobuf.ValidatingBuilder
 import io.spine.validate.ConstraintViolation
 import io.spine.validate.ValidationException
@@ -458,11 +459,6 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          *   declaration site.
          */
         @Composable
-        @Suppress(
-            // Explicit casts are needed since we cannot parameterize
-            // `MessageFormCompanionBase` with the `M` type parameter.
-            "UNCHECKED_CAST"
-        )
         public operator fun <M : Message, B : ValidatingBuilder<out M>> invoke(
             value: MutableState<M?>,
             builder: () -> B,
@@ -470,13 +466,13 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
         ): MessageForm<M> = declareInstance(
-            value as MutableState<Message?>,
+            value.safeCast(),
             builder,
-            props as Props<MessageForm<Message>>,
+            props.safeCast(),
             onBeforeBuild
         ) {
-            content(this as FormPartScope<M>)
-        } as MessageForm<M>
+            content(this.safeCast())
+        }.safeCast()
 
         /**
          * Declares a `MessageForm` instance, which is automatically bound to
@@ -507,16 +503,11 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          */
         context(FormFieldsScope<PM>)
         @Composable
-        @Suppress(
-            // Explicit casts are needed since we cannot parameterize
-            // `MessageFormCompanionBase` with the `M` type parameter.
-            "UNCHECKED_CAST"
-        )
         public operator fun <
                 PM : Message,
                 M : Message,
                 B : ValidatingBuilder<out M>
-        > invoke(
+                > invoke(
             field: MessageField<PM, M>,
             builder: () -> B,
             props: Props<MessageForm<M>> = Props {},
@@ -524,14 +515,14 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable FormPartScope<M>.() -> Unit
         ): MessageForm<M> = declareInstance(
-            field as MessageField<PM, Message>,
+            field.safeCast() as MessageField<PM, Message>,
             builder,
-            props as Props<MessageForm<Message>>,
+            props.safeCast(),
             defaultValue,
             onBeforeBuild
         ) {
-            content(this as FormPartScope<M>)
-        } as MessageForm<M>
+            content(this.safeCast())
+        }.safeCast()
 
         /**
          * Declares a multipart `MessageForm` instance, which edits a value
@@ -557,25 +548,20 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          *   declaration site.
          */
         @Composable
-        @Suppress(
-            // Explicit casts are needed since we cannot parameterize
-            // `MessageFormCompanionBase` with the `M` type parameter.
-            "UNCHECKED_CAST"
-        )
-        public fun <M : Message, B: ValidatingBuilder<out M>> Multipart(
+        public fun <M : Message, B : ValidatingBuilder<out M>> Multipart(
             value: MutableState<M?>,
             builder: () -> B,
             props: Props<MessageForm<M>> = Props {},
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
         ): MessageForm<M> = declareMultipartInstance(
-            value as MutableState<Message?>,
+            value.safeCast(),
             builder,
-            props as Props<MessageForm<Message>>,
+            props.safeCast(),
             onBeforeBuild
         ) {
-            content(this as MultipartFormScope<M>)
-        } as MessageForm<M>
+            content(this.safeCast())
+        }.safeCast()
 
         /**
          * Declares a multipart `MessageForm` instance, which is automatically
@@ -608,16 +594,11 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          */
         context(FormFieldsScope<PM>)
         @Composable
-        @Suppress(
-            // Explicit casts are needed since we cannot parameterize
-            // `MessageFormCompanionBase` with the `M` type parameter.
-            "UNCHECKED_CAST"
-        )
         public fun <
                 PM : Message,
                 M : Message,
                 B : ValidatingBuilder<out M>
-        > Multipart(
+                > Multipart(
             field: MessageField<PM, M>,
             builder: () -> B,
             props: Props<MessageForm<M>> = Props {},
@@ -625,14 +606,14 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             onBeforeBuild: (B) -> Unit = {},
             content: @Composable MultipartFormScope<M>.() -> Unit
         ): MessageForm<M> = declareMultipartInstance(
-            field as MessageField<PM, Message>,
+            field.safeCast() as MessageField<PM, Message>,
             builder,
-            props as Props<MessageForm<Message>>,
+            props.safeCast(),
             defaultValue,
             onBeforeBuild
         ) {
-            content(this as MultipartFormScope<M>)
-        } as MessageForm<M>
+            content(this.safeCast())
+        }.safeCast()
 
         /**
          * Creates a [MessageForm] instance without rendering it in
@@ -665,22 +646,17 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @return A form's instance that has been created for this
          *   declaration site.
          */
-        @Suppress(
-            // Explicit casts are needed since we cannot parameterize
-            // `MessageFormCompanionBase` with the `M` type parameter.
-            "UNCHECKED_CAST"
-        )
-        public fun <M : Message, B: ValidatingBuilder<out M>> create(
+        public fun <M : Message, B : ValidatingBuilder<out M>> create(
             value: MutableState<M?>,
             builder: () -> B,
             onBeforeBuild: (B) -> Unit = {},
             props: Props<MessageForm<M>> = Props {}
         ): MessageForm<M> = createInstance(
-            value as MutableState<Message?>,
+            value.safeCast(),
             builder,
             onBeforeBuild,
-            props as Props<MessageForm<Message>>
-        ) as MessageForm<M>
+            props.safeCast()
+        ).safeCast()
     }
 
     /**
@@ -752,7 +728,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param fieldSelector A field selector component
          *   (such as [OneofRadioButton]).
          */
-        internal fun <F: MessageFieldValue> registerFieldSelector(
+        internal fun <F : MessageFieldValue> registerFieldSelector(
             field: MessageField<M, F>,
             fieldSelector: FocusableComponent
         ) {
@@ -763,7 +739,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             )
             check(oneof.fields.contains(field as MessageField<M, MessageFieldValue>)) {
                 "The oneof field (${field.name}) being registered doesn't " +
-                "belong to this oneof (${oneof.name})"
+                        "belong to this oneof (${oneof.name})"
             }
             fieldSelectors[field] = fieldSelector
         }
@@ -1217,8 +1193,10 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * A [MultipartFormScope] instance, which is an outermost scope for
      * declarations within this form.
      */
-    @Suppress("LeakingThis" /* Leaking this shouldn't be a problem
-        since this field is designed for post-construction usage. */)
+    @Suppress(
+        "LeakingThis" /* Leaking this shouldn't be a problem
+        since this field is designed for post-construction usage. */
+    )
     private val formScope = MultipartFormScopeImpl(this)
 
     /**
@@ -1501,7 +1479,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     private fun updateDirty() {
         val dirty =
             fields.values.any { it.effectivelyDirty } ||
-            oneofs.values.any { it.selectedMessageField.value != null }
+                    oneofs.values.any { it.selectedMessageField.value != null }
         if (!_dirty && dirty) {
             enteringNonNullValue.value = true
         }
@@ -1725,10 +1703,10 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             } ?: run {
                 val formOneof = oneofs.values.firstOrNull {
                     it.validationMessage.value != null ||
-                    it.let {
-                        val selectedField = it.selectedFormField
-                        selectedField != null && selectedField.value.value == null
-                    }
+                            it.let {
+                                val selectedField = it.selectedFormField
+                                selectedField != null && selectedField.value.value == null
+                            }
                 }
                 formOneof?.selectedFormField
                     ?: formOneof?.fields?.values?.firstOrNull()

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetupBase.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetupBase.kt
@@ -274,4 +274,3 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
             props.run { configure() }
         }
 }
-

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.86")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.87")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.85")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.86")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.87")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.86")


### PR DESCRIPTION
## What

Adds an `excludedEntityIds` property to the abstract `EntityChooser` component,
allowing specific entities to be excluded from the drop-down list so they cannot
be selected by the user.

## Details

- New `protected var excludedEntityIds: Set<I>` backed by `mutableStateOf`, so
  updating the set reactively refilters the list.
- `beforeComposeContent()` now filters the excluded IDs out of `items` (the
  drop-down list). The internal `entityStatesByIds` map is still built from the
  full, unfiltered entity set, so an already-selected value remains resolvable
  and renders correctly even if it later becomes excluded.
- It's up to subclasses to expose this property with an appropriate name and
  visibility.

## Other changes

- Simplified `Any.safeCast()` using `as?`/`?:`.
- Minor KDoc typo fix and code clean-up/reformatting in `MessageForm`.
- Bumped the Chords Gradle plugin to `1.9.22` and the library version to
  `2.0.0-SNAPSHOT.86`.
