### PR TITLE
Auto-select table record on row actions menu clicked

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
@@ -265,7 +265,7 @@ public abstract class Table<E> : Component() {
         val sortedEntities = sortedEntities()
         val tableColumns = columns.toMutableList()
         if (rowActions != null) {
-            tableColumns.add(rowActionsColumn(rowActions!!))
+            tableColumns.add(rowActionsColumn(rowActions!!, ::changeSelectedEntity))
         }
         Column(
             modifier = Modifier.fillMaxSize()
@@ -773,10 +773,13 @@ private fun <E> TableRow(
  * Clicking the button opens the row actions menu.
  *
  * @param rowActionsConfig The configuration for row actions.
+ * @param onRowActionsClicked A callback invoked with the row's entity when its
+ *   actions menu is opened.
  * @return A `TableColumn` with a "More" button for triggering row actions.
  */
 private fun <E> rowActionsColumn(
-    rowActionsConfig: RowActionsConfig<E>
+    rowActionsConfig: RowActionsConfig<E>,
+    onRowActionsClicked: (E) -> Unit
 ): TableColumn<E> {
     return TableColumn(
         name = "",
@@ -789,7 +792,8 @@ private fun <E> rowActionsColumn(
             RowActionsButton(
                 entity,
                 rowActionsConfig,
-                rowActionsVisible
+                rowActionsVisible,
+                onRowActionsClicked
             )
         }
     }
@@ -807,16 +811,20 @@ private fun <E> rowActionsColumn(
  *   and their appearance.
  * @param visibility A state that controls the visibility
  *   of the dropdown menu.
+ * @param onRowActionsClicked A callback invoked with the [entity] when the menu
+ *   is opened.
  */
 @Composable
 private fun <E> RowActionsButton(
     entity: E,
     config: RowActionsConfig<E>,
     visibility: MutableState<Boolean>,
+    onRowActionsClicked: (E) -> Unit,
 ) {
     IconButton(
         modifier = Modifier.size(48.dp),
         onClick = {
+            onRowActionsClicked(entity)
             visibility.value = true
         }
     ) {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:41:02 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 18:38:48 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Tue Jul 14 14:41:02 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:41:03 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 18:38:49 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Tue Jul 14 14:41:03 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:41:05 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 18:38:51 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Tue Jul 14 14:41:05 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:41:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 18:38:52 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Tue Jul 14 14:41:06 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:41:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 18:38:53 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Tue Jul 14 14:41:07 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 14:41:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 14 18:38:54 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.86</version>
+<version>2.0.0-SNAPSHOT.87</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.86")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.87")


### PR DESCRIPTION
## What

Makes the `Table` component select the corresponding record when the user
opens a row's actions menu. Previously, clicking the "More" button only opened
the dropdown menu, leaving the selection (and row highlight) on whatever row
was selected before.

## Details

- `rowActionsColumn` and `RowActionsButton` accept a new
  `onRowActionsClicked: (E) -> Unit` callback, invoked with the row's entity
  right before the dropdown menu is shown.
- `Table.content()` passes `::changeSelectedEntity` as that callback, so
  invoking the menu reuses the regular row-selection flow: `selectedEntity` is
  updated, the `onSelect` callback fires, and the row receives the
  selected-row highlight — exactly as if the row itself was clicked.
- The wiring is internal (private functions); there is no public API change.

## Other changes

- Bumped the version to `2.0.0-SNAPSHOT.87` and regenerated `pom.xml` and
  `dependencies.md`.
