### PR TITLE
Add column values to Table

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
@@ -129,19 +129,15 @@ import io.spine.chords.core.table.TableSortingDirection.DESCENDING
  *         columns = listOf(
  *             TableColumn(
  *                 name = "Name",
- *                 sorting = TableColumnSorting(compareBy(User::name))
- *             ) { user ->
- *                 Text(user.name)
- *             },
+ *                 value = User::name
+ *             ),
  *             TableColumn(
  *                 name = "Created",
+ *                 value = User::createdAt,
  *                 sorting = TableColumnSorting(
- *                     comparator = compareBy(User::createdAt),
  *                     initialDirection = DESCENDING
  *                 )
- *             ) { user ->
- *                 Text(user.createdAt.toString())
- *             }
+ *             )
  *         )
  *     }
  *
@@ -378,7 +374,10 @@ public abstract class Table<E> : Component() {
  * @param columnKey A stable identifier of the column used to keep track of the sorting state.
  *   By default, the column [name] is used.
  * @param sorting Optional sorting configuration for this column.
- *   If `null`, the header is rendered without interactive sorting support.
+ *   If omitted for a column with a [value], natural ascending sorting is used.
+ * @param value An optional function that extracts this column's value from an entity.
+ *   Values returned for different entities must be mutually comparable. When specified,
+ *   it supplies the default sorting comparator and allows [cellContent] to be omitted.
  * @param cellContent A callback that specifies what element to display
  *   inside each cell of this column.
  */
@@ -389,8 +388,72 @@ public data class TableColumn<E>(
     val padding: PaddingValues = PaddingValues(),
     val columnKey: Any = name,
     val sorting: TableColumnSorting<E>? = null,
+    val value: ((E) -> Comparable<*>?)?,
     val cellContent: @Composable (E) -> Unit
-)
+) {
+
+    /**
+     * Creates a column with explicitly defined cell content and no column value.
+     *
+     * This constructor preserves the original, value-less column declaration API.
+     */
+    public constructor(
+        name: String,
+        horizontalArrangement: Horizontal = Center,
+        weight: Float = 1F,
+        padding: PaddingValues = PaddingValues(),
+        columnKey: Any = name,
+        sorting: TableColumnSorting<E>? = null,
+        cellContent: @Composable (E) -> Unit
+    ) : this(
+        name,
+        horizontalArrangement,
+        weight,
+        padding,
+        columnKey,
+        sorting,
+        null,
+        cellContent
+    )
+
+    /**
+     * Creates a valued column with a default text-based cell renderer.
+     *
+     * @param name The name of the column to be displayed in a header.
+     * @param value A function that extracts this column's value from an entity.
+     * @param horizontalArrangement The horizontal arrangement of the column's content.
+     * @param weight The proportional width to allocate to this column.
+     * @param padding The padding values of each cell's content in this column.
+     * @param columnKey A stable identifier used to keep track of the sorting state.
+     * @param sorting Optional sorting configuration. Natural ascending sorting is used
+     *   when this parameter is omitted.
+     */
+    public constructor(
+        name: String,
+        value: (E) -> Comparable<*>?,
+        horizontalArrangement: Horizontal = Center,
+        weight: Float = 1F,
+        padding: PaddingValues = PaddingValues(),
+        columnKey: Any = name,
+        sorting: TableColumnSorting<E>? = null
+    ) : this(
+        name,
+        horizontalArrangement,
+        weight,
+        padding,
+        columnKey,
+        sorting,
+        value,
+        { entity -> Text(value(entity)?.toString().orEmpty()) }
+    )
+
+    internal val effectiveSorting: TableColumnSorting<E>? =
+        sorting?.resolvedFor(value) ?: value?.let {
+            TableColumnSorting<E>().resolvedFor(it)
+        }
+
+    internal val sortable: Boolean = effectiveSorting != null
+}
 
 /**
  * Defines sorting rules for a table column.
@@ -401,7 +464,62 @@ public data class TableColumn<E>(
 public data class TableColumnSorting<E>(
     val comparator: Comparator<E>,
     val initialDirection: TableSortingDirection = ASCENDING
-)
+) {
+
+    /**
+     * Creates sorting configuration that compares values extracted by the column.
+     *
+     * This constructor can only be used for a [TableColumn] that defines a value.
+     *
+     * @param initialDirection The direction applied the first time the column is activated.
+     */
+    public constructor(
+        initialDirection: TableSortingDirection = ASCENDING
+    ) : this(columnValueComparatorMarker(), initialDirection)
+
+    internal val usesColumnValue: Boolean
+        get() = comparator === columnValueComparatorMarker
+
+    internal fun resolvedFor(
+        columnValue: ((E) -> Comparable<*>?)?
+    ): TableColumnSorting<E> {
+        if (!usesColumnValue) {
+            return this
+        }
+        return TableColumnSorting(
+            comparator = comparatorFor(checkNotNull(columnValue) {
+                "A TableColumnSorting without a comparator requires a column value."
+            }),
+            initialDirection = initialDirection
+        )
+    }
+
+    private companion object {
+        val columnValueComparatorMarker: Comparator<Any?> = Comparator { _, _ ->
+            error("The column value comparator must be resolved before it is used.")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun <E> columnValueComparatorMarker(): Comparator<E> =
+            columnValueComparatorMarker as Comparator<E>
+
+        fun <E> comparatorFor(value: (E) -> Comparable<*>?): Comparator<E> =
+            Comparator { leftEntity, rightEntity ->
+                compareColumnValues(value(leftEntity), value(rightEntity))
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        fun compareColumnValues(
+            left: Comparable<*>?,
+            right: Comparable<*>?
+        ): Int = when {
+            left === right -> 0
+            left == null -> -1
+            right == null -> 1
+            else -> (left as Comparable<Any?>).compareTo(right)
+        }
+    }
+}
 
 /**
  * Sorting direction used by the table.
@@ -488,7 +606,7 @@ public class TableSortingState<E>(
      * If the column is not sortable, the state remains unchanged.
      */
     public fun toggle(column: TableColumn<E>) {
-        val columnSorting = column.sorting ?: return
+        val columnSorting = column.effectiveSorting ?: return
         val nextDirection = if (currentSorting?.columnKey == column.columnKey) {
             currentSorting!!.direction.reverse()
         } else {
@@ -623,7 +741,7 @@ private fun <E> HeaderTableRow(
     TableRow(
         columns = columns,
         cellModifier = { column ->
-            if (column.sorting != null) {
+            if (column.sortable) {
                 Modifier
                     .pointerHoverIcon(Hand)
                     .clickable(
@@ -659,7 +777,7 @@ private fun <E> HeaderCell(
     column: TableColumn<E>,
     sortingState: TableSortingState<E>
 ) {
-    val isSortable = column.sorting != null
+    val isSortable = column.sortable
     var isHovered by remember { mutableStateOf(false) }
     Row(
         modifier = Modifier

--- a/core/src/test/kotlin/io/spine/chords/core/table/TableColumnSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/table/TableColumnSpec.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.table
+
+import io.kotest.matchers.shouldBe
+import io.spine.chords.core.table.TableSortingDirection.DESCENDING
+import org.junit.jupiter.api.Test
+
+internal class TableColumnSpec {
+
+    @Test
+    fun `store the extracted column value`() {
+        val column = valuedColumn()
+
+        column.value?.invoke(User("Alice", 2)) shouldBe "Alice"
+    }
+
+    @Test
+    fun `sort naturally by column value`() {
+        val column = valuedColumn()
+        val state = TableSortingState<User>()
+        val users = listOf(User("Charlie", 3), User("Alice", 1), User("Bob", 2))
+
+        state.toggle(column)
+
+        users.sortedWith(state.currentSorting!!.sorting.comparator) shouldBe
+                listOf(User("Alice", 1), User("Bob", 2), User("Charlie", 3))
+    }
+
+    @Test
+    fun `respect the initial sorting direction`() {
+        val column = TableColumn<User>(
+            name = "Created",
+            value = User::created,
+            sorting = TableColumnSorting(initialDirection = DESCENDING)
+        )
+        val state = TableSortingState<User>()
+
+        state.toggle(column)
+
+        state.currentSorting?.direction shouldBe DESCENDING
+    }
+
+    @Test
+    fun `allow custom content for a valued column`() {
+        val column = TableColumn<User>(
+            name = "Name",
+            value = User::name
+        ) { }
+
+        column.value?.invoke(User("Alice", 2)) shouldBe "Alice"
+    }
+
+    @Test
+    fun `preserve explicit entity comparator declarations`() {
+        val column = TableColumn<User>(
+            name = "Name",
+            sorting = TableColumnSorting(compareBy(User::name))
+        ) { }
+        val state = TableSortingState<User>()
+        val users = listOf(User("Charlie", 3), User("Alice", 1), User("Bob", 2))
+
+        state.toggle(column)
+
+        users.sortedWith(state.currentSorting!!.sorting.comparator) shouldBe
+                listOf(User("Alice", 1), User("Bob", 2), User("Charlie", 3))
+    }
+
+    @Test
+    fun `prefer an explicit comparator over natural value sorting`() {
+        val column = TableColumn<User>(
+            name = "Name",
+            sorting = TableColumnSorting(compareBy(User::created)),
+            value = User::name
+        ) { }
+        val state = TableSortingState<User>()
+        val users = listOf(User("Alice", 3), User("Bob", 1), User("Charlie", 2))
+
+        state.toggle(column)
+
+        users.sortedWith(state.currentSorting!!.sorting.comparator) shouldBe
+                listOf(User("Bob", 1), User("Charlie", 2), User("Alice", 3))
+    }
+
+    @Test
+    fun `keep a column without value non-sortable by default`() {
+        val column = TableColumn<User>(name = "Name") { }
+        val state = TableSortingState<User>()
+
+        state.toggle(column)
+
+        state.currentSorting shouldBe null
+    }
+
+    private fun valuedColumn(): TableColumn<User> = TableColumn(
+        name = "Name",
+        value = User::name
+    )
+
+    private data class User(
+        val name: String,
+        val created: Int
+    )
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 22 18:25:55 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 22 22:13:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Wed Jul 22 18:25:55 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 22 18:25:56 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 22 22:13:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Wed Jul 22 18:25:56 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 22 18:25:57 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 22 22:13:10 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Wed Jul 22 18:25:57 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 22 18:25:58 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 22 22:13:11 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Wed Jul 22 18:25:58 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 22 18:25:59 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 22 22:13:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Wed Jul 22 18:25:59 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 22 18:26:00 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 22 22:13:13 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.90</version>
+<version>2.0.0-SNAPSHOT.91</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.90")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.91")


### PR DESCRIPTION
Fixes #125.

Adds an optional comparable `value` extractor to `TableColumn`. Value-backed columns use that extractor for natural sorting, sortability, and default text rendering, eliminating duplicate entity-property declarations while preserving custom cell content and explicit comparators.

Adds regression coverage for value extraction, natural sorting, initial directions, custom cell content, legacy declarations, and comparator precedence. The core checks and full build pass.