### PR TITLE
Expand agent operating policy: commit/PR workflow and code-review guidance

### DIFF
--- a/.agents/skills/code-reviewer/SKILL.md
+++ b/.agents/skills/code-reviewer/SKILL.md
@@ -14,6 +14,13 @@ contract risk in changed code. Include any security risks you find in the
 review output. Do not duplicate `docs-reviewer` for documentation prose or
 `tester` for test design; hand those findings off instead.
 
+## Running Checks
+
+Review is read-only by default. Do not run verification — including static
+checks such as `./gradlew detekt`, tests, builds, or any other Gradle task —
+unless the task asks for it directly. To judge CI status, read existing results
+(`gh pr checks`) instead of re-running the pipeline.
+
 ## Review Procedure
 
 1. **Scope the diff.** Review changed source files and their direct callers or
@@ -28,6 +35,37 @@ review output. Do not duplicate `docs-reviewer` for documentation prose or
 4. **Verify claims against source.** Confirm Gradle task names, module paths,
    generated API shapes, and toolchain constraints against the relevant build
    file, README, or workflow.
+
+## PR Review Procedure
+
+Use this when the review target is a GitHub pull request. It wraps the standard
+**Review Procedure** above with PR-specific context and reporting; do not
+duplicate its steps.
+
+1. **Read the PR.** Read the title and body with `gh pr view <number>`, list
+   linked issues with `gh pr view <number> --json closingIssuesReferences`, and
+   read every linked issue with `gh issue view <issue-number>`. Establish the
+   intended change and its acceptance criteria before reading code.
+2. **Confirm scope.** Diff the PR (`gh pr diff <number>`) and check it matches
+   the stated intent. Flag unrelated or out-of-scope changes instead of
+   silently reviewing them.
+3. **Review the changed code.** Run the standard Review Procedure and apply the
+   Review Focus over the PR diff. Read affected files fully at the PR head, not
+   just the hunks and not from the local worktree: resolve the head commit with
+   `gh pr view <number> --json headRefOid`, fetch it if absent
+   (`git fetch origin pull/<number>/head`), and read files with
+   `git show <head-oid>:<path>`. If checking out the PR branch instead, do not
+   overwrite or mix it with existing local changes.
+4. **Check verification.** When the PR changes behavior, confirm it adds or
+   updates an appropriate regression test; otherwise confirm that the absence
+   of a test is justified. Inspect all checks with `gh pr checks <number>` for
+   failing and pending jobs, and use `gh pr checks <number> --required` to
+   tell which of them block the merge. Treat a missing or failing required
+   check as a Must fix, and report any other failing workflow as a finding.
+   Report a pending required check as pending, not as passed or missing.
+5. **Report.** Return findings in the Output Format below, keeping file/line
+   references. Posting the review to the PR is a side effect: do it only when
+   the task explicitly asks, otherwise return the review as text.
 
 ## Review Focus
 
@@ -49,6 +87,7 @@ review output. Do not duplicate `docs-reviewer` for documentation prose or
   `dependencies.md` not regenerated when required.
 - Module-ownership violations, leaked state, unjustified reflection, and
   hidden background work.
+- Workarounds that mask a root cause instead of fixing it.
 
 ## Handoffs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,12 @@ step 6), then:
 
 - This is a public open-source repository (Apache 2.0). Do not add secrets,
   credentials, tokens, private keys, or TeamDev-internal data to it.
+- Pull requests and issues opened in this repository are public. Keep their
+  titles, descriptions, comments, and linked references free of any information
+  about dependent private projects. Do not name those projects, describe their
+  domain or business logic, link to their issues, PRs, or repositories, or
+  reference their internal identifiers. Describe the change only in terms of
+  this repository's own libraries and public API.
 - Do not modify files under the `config/` Git submodule; it is owned by the
   [SpineEventEngine/config](https://github.com/SpineEventEngine/config)
   repository, and changes belong upstream.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,55 @@ leave changes unstaged, show the diff or summarize it, and let the user decide.
 
 When moving or renaming tracked files, use `git mv` so file history is preserved.
 
+## Committing and Pushing
+
+The Commit and History Safety rules above apply throughout this procedure.
+
+1. **Confirm authorization.** Commit or push only when the current prompt
+   explicitly asks for it, per "Commit and History Safety" above.
+2. **Choose the branch.**
+   - If the current branch is `master`, create a new branch; never commit
+     directly to `master`.
+   - If the current branch name does not match the task, ask whether to branch
+     from the current branch or from `master` before committing.
+   - If the current branch name matches the task, keep using it.
+   - Name new branches after the task, in the repository's kebab-case style
+     (for example, `dialog-form-dirty-state`); do not include `codex` or other
+     agent-specific identifiers in branches you create.
+3. **Check the version and reports.** Apply "Versioning and Reports" above:
+   inspect the commits and local state, bump `chordsVersion` in
+   `version.gradle.kts` if the changeset has not bumped it yet, and if the
+   generated `pom.xml` and `dependencies.md` reports are not updated yet, run
+   `./gradlew build` and include the regenerated reports in the changeset.
+4. **Commit in logical steps.** Create one or more logical commits; split the
+   work only when each commit is independently coherent. Commit the version
+   bump together with the regenerated `pom.xml` and `dependencies.md`, using
+   the repository's established message format
+   ``Bump version —> `<new-version>`.`` — its position in the sequence does
+   not matter.
+5. **Push.** Push the branch to its remote (for example,
+   `git push -u origin <branch>`).
+6. **Offer a pull request.** Ask whether to open a pull request, unless the
+   prompt already requested one.
+
+## Creating a Pull Request
+
+Open the PR only once it is authorized (see "Committing and Pushing",
+step 6), then:
+
+1. **Create it as a draft** (`gh pr create --draft`), targeting `master` as the
+   base branch unless the task specifies otherwise.
+2. **Assign it to the authenticated GitHub user** (`--assignee @me`).
+3. **Write the description** with a `## Summary` section followed by a
+   `## Changes` section. Optional sections such as `## Important notes` or
+   `## Reviewer notes` may follow when useful. Do not add a "Verifications"
+   section or any agent-attribution section such as `Created by <agent>`.
+4. **Link resolved issues.** For each issue the PR implements or fixes, add a
+   GitHub closing keyword in the description (for example, `Fixes #123`) so the
+   issue appears under "Successfully merging this pull request may close these
+   issues" on GitHub.
+5. **Report the PR URL** in the final response.
+
 ## Safety Rules
 
 - This is a public open-source repository (Apache 2.0). Do not add secrets,
@@ -142,6 +191,15 @@ If verification cannot be run, state the reason clearly in the final response.
 - Get the `config` submodule content with
   `git submodule update --init --recursive` before building.
 
+## Bug Fixes
+
+When fixing a bug, fix the root cause rather than adding a workaround. If the
+root cause cannot be fixed, ask for confirmation before implementing a
+workaround and explain why the root cause cannot be addressed.
+
+Cover the fix with a test that reproduces the bug and fails without the fix. If
+a test cannot be added, state this in the final response and explain why.
+
 ## Code Review
 
 For reviews, lead with findings ordered by severity and include file/line
@@ -165,7 +223,15 @@ Start each task by forming an agent-owned plan before editing or running
 non-trivial commands. While composing that plan, identify missing requirements,
 risks, affected areas, and verification needs.
 
-Ask all clarification questions needed to close uncovered spots in the plan.
-Group related questions together when they are blocking the same decision.
-Prefer a reasonable assumption only when the answer would not materially change
-the plan, implementation, safety posture, or verification path.
+Ask the clarification questions needed to close uncovered spots in the plan,
+following these rules:
+
+- Ask at most one question per message. When a decision has a small set of
+  options, include those options in that question.
+- Do not bundle unrelated questions. Ask the next one only after the user
+  answers the previous.
+- Apply this both when you need clarification and when the prompt means
+  "ask questions".
+- Prefer a reasonable assumption over another question when the answer would
+  not materially change the plan, implementation, safety posture, or
+  verification path.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 01:48:20 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 17:32:30 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Thu Jul 23 01:48:20 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 01:48:21 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 17:32:31 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Thu Jul 23 01:48:21 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 01:48:22 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 17:32:32 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Thu Jul 23 01:48:22 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 01:48:23 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 17:32:33 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Thu Jul 23 01:48:23 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 01:48:23 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 17:32:34 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Thu Jul 23 01:48:23 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 01:48:24 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 17:32:35 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.92</version>
+<version>2.0.0-SNAPSHOT.93</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.92")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.93")


### PR DESCRIPTION
## Summary

Formalizes the agent-facing operating policy so commits, pull requests, bug
fixes, and code reviews follow explicit, consistent procedures.

## Changes

- **`AGENTS.md`**
  - Add a `Committing and Pushing` procedure: per-turn authorization (deferring
    to `Commit and History Safety`), branch off `master` in the repository's
    kebab-case style, verify the `chordsVersion` bump and regenerate the
    reports per `Versioning and Reports`, commit in one or more logical steps
    with the established `Bump version —> ` message, push, and offer a PR.
  - Add a `Creating a Pull Request` procedure: draft PR, base `master`,
    self-assign, `## Summary`/`## Changes` body, and closing keywords.
  - Add a `Bug Fixes` section: fix the root cause over a workaround, and cover
    the fix with a failing-first test.
  - Add a `Safety Rules` bullet prohibiting references to dependent private
    projects in PRs and issues (project names, domain/business logic, linked
    issues/PRs/repositories, or internal identifiers).
  - Revise `Planning and Questions` to ask one focused clarification question
    per message.
- **`.agents/skills/code-reviewer/SKILL.md`**
  - Add a `Running Checks` note (review is read-only by default; read existing
    CI results instead of re-running the pipeline).
  - Add a `PR Review Procedure` covering PR context, scope confirmation,
    reading files at the PR head, and check-status handling that inspects all
    checks (not just required).
  - Require a regression test only when behavior changes, and add a review
    focus on workarounds that mask a root cause.

## Reviewer notes

The `pom.xml` and `dependencies.md` diffs are limited to the version-header and
generation-timestamp lines (`.92` → `.93`); no dependencies changed. The
version was bumped to `2.0.0-SNAPSHOT.93` and the reports regenerated via
`./gradlew generateLicenseReport mergeAllLicenseReports generatePom`.
