### PR TITLE
Equip date/time input fields with a "now" option

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation.Companion.None
-import io.spine.chords.core.InputReviser.Companion.maxLength
 import io.spine.chords.core.keyboard.KeyRange.Companion.Digit
 import io.spine.chords.core.keyboard.KeyRange.Companion.Whitespace
 import io.spine.chords.core.keyboard.matches
@@ -493,7 +492,9 @@ public open class InputField<V> : InputComponent<V>() {
             modifier = modifier(modifier)
                 .focusRequester(focusRequester)
                 .preventWidthAutogrowing()
-                .onPreviewKeyEvent { inputReviser?.filterKeyEvent(it) == true }
+                .onPreviewKeyEvent {
+                    handleKeyEvent(it) || inputReviser?.filterKeyEvent(it) == true
+                }
         )
     }
 
@@ -543,7 +544,52 @@ public open class InputField<V> : InputComponent<V>() {
             currentRawTextContent,
             newRawTextContentCandidate
         ) ?: newRawTextContentCandidate
-        val newText = revisedTextContent.text
+        commitRawText(
+            revisedTextContent.text,
+            revisedTextContent.selection,
+            currentRawTextContent.text
+        )
+    }
+
+    /**
+     * Sets the field's [value] programmatically, updating the field's displayed
+     * text, validation, and dirty state as if the user had entered the text that
+     * corresponds to [newValue].
+     *
+     * The text produced by [formatValue] for [newValue] replaces whatever the
+     * field currently contains, including any incomplete or invalid entry, and
+     * is placed with the cursor at its end. The value is passed through the same
+     * validation as the user's own input (both [parseValue] and [onValidate]),
+     * and the relevant callbacks ([onChange], [onDirtyStateChange]) are invoked
+     * accordingly.
+     *
+     * Unlike assigning [value] directly, this method ensures that the text shown
+     * in the field is refreshed and that any previously displayed validation
+     * error is cleared.
+     *
+     * @param newValue The value to be set into the field.
+     */
+    protected fun applyValue(newValue: V) {
+        val rawText = formatValue(newValue)
+        val prevText = invalidValueText ?: value.value?.let { formatValue(it) } ?: ""
+        commitRawText(rawText, TextRange(rawText.length), prevText)
+    }
+
+    /**
+     * Applies a new raw text to the field, running the same parsing, validation,
+     * and state bookkeeping that a user's edit would trigger.
+     *
+     * @param newText The new raw text to be applied as the field's content.
+     * @param newSelection The cursor/selection to be applied along with
+     *   [newText].
+     * @param prevText The raw text the field had before this change, used to
+     *   detect a transition of the dirty state.
+     */
+    private fun commitRawText(
+        newText: String,
+        newSelection: TextRange,
+        prevText: String
+    ) {
         var validationErrorMessage: String? = null
         val validatedValue: V? = try {
             if (newText.isNotEmpty()) {
@@ -560,12 +606,12 @@ public open class InputField<V> : InputComponent<V>() {
         val prevValue = value.value
         value.value = validatedValue.takeIf { valid }
         invalidValueText = newText.takeIf { !valid }
-        selection = revisedTextContent.selection
+        selection = newSelection
 
         this.valid.value = valid
         ownValidationMessage.value = validationErrorMessage
 
-        val prevTextEmpty = currentRawTextContent.text.isEmpty()
+        val prevTextEmpty = prevText.isEmpty()
         val newTextEmpty = newText.isEmpty()
         if (newTextEmpty != prevTextEmpty) {
             onDirtyStateChange?.invoke(prevTextEmpty)
@@ -574,6 +620,23 @@ public open class InputField<V> : InputComponent<V>() {
             onChange?.invoke(value.value)
         }
     }
+
+    /**
+     * Handles a key event that occurs while the field is focused, before it is
+     * processed by the field's text editing and by [inputReviser].
+     *
+     * Subclasses can override this method to implement field-specific keyboard
+     * shortcuts. Returning `true` consumes the event and stops its further
+     * propagation (so it doesn't reach the text editor); returning `false`
+     * lets the event be processed as usual.
+     *
+     * The default implementation doesn't handle any events and returns `false`.
+     *
+     * @param keyEvent The key event that has occurred within the field.
+     * @return `true` if the event was handled and should be consumed,
+     *   `false` otherwise.
+     */
+    protected open fun handleKeyEvent(keyEvent: KeyEvent): Boolean = false
 
     /**
      * Parses and validates the field's text content.

--- a/core/src/test/kotlin/io/spine/chords/core/time/WallClockSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/time/WallClockSpec.kt
@@ -26,28 +26,22 @@
 
 package io.spine.chords.core.time
 
+import io.kotest.core.spec.DisplayName
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
 import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
+import org.junit.jupiter.api.Test
 
-/**
- * The client's local time characteristics.
- */
-public object WallClock {
+@DisplayName("`WallClock` should")
+internal class WallClockSpec {
 
-    /**
-     * Local time zone offset.
-     */
-    public val zoneOffset: ZoneOffset
-        get() = OffsetDateTime.now().offset
+    @Test
+    fun `provide the current moment`() {
+        val before = Instant.now()
+        val now = WallClock.now
+        val after = Instant.now()
 
-    /**
-     * The current moment on the client, as an [Instant].
-     *
-     * This is the single point through which the current time should be
-     * obtained, so that time-dependent behavior stays consistent with the other
-     * client time characteristics modeled here (such as [zoneOffset]).
-     */
-    public val now: Instant
-        get() = Instant.now()
+        now shouldBeGreaterThanOrEqualTo before
+        now shouldBeLessThanOrEqualTo after
+    }
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 17:32:30 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 19:21:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Fri Jul 24 17:32:30 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 17:32:31 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 19:21:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Fri Jul 24 17:32:31 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 17:32:32 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 19:21:15 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Fri Jul 24 17:32:32 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 17:32:33 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 19:21:16 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Fri Jul 24 17:32:33 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 17:32:34 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 19:21:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Fri Jul 24 17:32:34 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 17:32:35 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 24 19:21:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.93</version>
+<version>2.0.0-SNAPSHOT.94</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ dependencies {
     implementation(project(":core"))
     api(Spine.money)
     implementation(compose.desktop.currentOs)
+    implementation(compose.materialIconsExtended)
     implementation(Material3.Desktop.lib)
     implementation(project(":proto-values"))
     testImplementation(Kotest.runnerJUnit5)

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -26,15 +26,45 @@
 
 package io.spine.chords.proto.time
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Enter
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Exit
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
+import androidx.compose.ui.input.pointer.PointerIcon.Companion.Hand
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextRange
@@ -43,10 +73,13 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.input.getSelectedText
+import androidx.compose.ui.unit.dp
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
 import io.spine.chords.core.ComponentSetup
+import io.spine.chords.core.keyboard.KeyModifiers.Companion.Ctrl
 import io.spine.chords.core.keyboard.KeyRange
+import io.spine.chords.core.keyboard.key
 import io.spine.chords.core.keyboard.matches
 import io.spine.chords.core.InputField
 import io.spine.chords.core.InputReviser
@@ -54,6 +87,7 @@ import io.spine.chords.core.InputReviser.Companion.DigitsOnly
 import io.spine.chords.core.InputReviser.Companion.maxLength
 import io.spine.chords.core.RawTextContent
 import io.spine.chords.core.ParseException
+import io.spine.chords.core.layout.WithTooltip
 import io.spine.chords.core.time.WallClock
 import io.spine.chords.proto.value.time.DefaultDatePattern
 import java.time.Instant
@@ -67,12 +101,59 @@ import java.time.format.DateTimeParseException
 private const val DefaultDateTimeFormat = "$DefaultDatePattern HH:mm"
 
 /**
+ * The text used both as the accessibility description and the tooltip of the
+ * [DateTimeField]'s default "now" button.
+ */
+private const val NowButtonDescription = "Set to the current date and time"
+
+/**
+ * The opacity of the "now" button's state layer while it is hovered.
+ */
+private const val HoveredStateLayerAlpha = 0.08f
+
+/**
+ * The opacity of the "now" button's state layer while it is pressed.
+ */
+private const val PressedStateLayerAlpha = 0.12f
+
+/**
+ * The overall size of the "now" button (its round state layer).
+ *
+ * It matches the height of a single text line, so that the button doesn't
+ * enlarge the field.
+ */
+private val NowButtonSize = 24.dp
+
+/**
+ * The size of the "now" button's icon, kept smaller than [NowButtonSize] so that
+ * the round state layer remains visible around it.
+ */
+private val NowButtonIconSize = 20.dp
+
+/**
  * Date/time pattern as defined by [DateTimeFormatter].
  */
 public typealias DateTimePattern = String
 
 /**
  * A field that allows specifying date and time.
+ *
+ * ### The "now" option
+ *
+ * When [nowOptionEnabled] is set to `true`, the field offers an optional
+ * affordance for filling it with the current date and time, so that the user
+ * doesn't have to type it by hand when recording something at the moment it
+ * happens. The current moment is obtained through
+ * [WallClock][io.spine.chords.core.time.WallClock].
+ *
+ * Since the field always keeps its value consistent with the text it displays,
+ * the filled value is truncated to the resolution of [dateTimePattern] — for
+ * example, to the minute with the default pattern, which has no seconds field.
+ *
+ * The affordance is available both as a button displayed within the field
+ * (while it is focused or already contains a value), and as the Ctrl+N keyboard
+ * shortcut while the field is focused. The button's appearance can be customized
+ * via [nowOptionAffordance].
  */
 public class DateTimeField : InputField<Timestamp>() {
     public companion object : ComponentSetup<DateTimeField>()
@@ -82,6 +163,37 @@ public class DateTimeField : InputField<Timestamp>() {
      * [DateTimeFormatter], no spaces are allowed).
      */
     public var dateTimePattern: DateTimePattern by mutableStateOf(DefaultDateTimeFormat)
+
+    /**
+     * Enables an optional "now" affordance that fills the field with the current
+     * date and time (see the class documentation).
+     *
+     * When set to `true`, the field displays a button (while it is focused or
+     * already contains a value) that fills it with the current date and time
+     * (truncated to the resolution of [dateTimePattern]), and the same can be
+     * done with the Ctrl+N keyboard shortcut while the field is focused.
+     *
+     * It is `false` by default, so that the affordance appears only where
+     * a "current moment" value makes sense.
+     *
+     * @see nowOptionAffordance
+     */
+    public var nowOptionEnabled: Boolean by mutableStateOf(false)
+
+    /**
+     * An optional custom renderer for the "now" affordance, used instead of the
+     * default button when [nowOptionEnabled] is `true`.
+     *
+     * The provided composable receives a `fillNow` callback, which sets the
+     * field to the current date and time; it should be invoked when the user
+     * activates the custom affordance.
+     *
+     * When this property is `null` (by default), a default button is displayed.
+     *
+     * @see nowOptionEnabled
+     */
+    public var nowOptionAffordance: (@Composable (fillNow: () -> Unit) -> Unit)?
+            by mutableStateOf(null)
 
     init {
         label = "Date/time"
@@ -99,17 +211,227 @@ public class DateTimeField : InputField<Timestamp>() {
                 it.text, dateTimePattern
             ).toTransformedString(secondaryColor)
         }
+        suffix = if (nowOptionEnabled) {
+            {
+                val customAffordance = nowOptionAffordance
+                if (customAffordance != null) {
+                    customAffordance(::fillNow)
+                } else {
+                    NowButton(enabled = enabled, onClick = ::fillNow)
+                }
+            }
+        } else {
+            null
+        }
     }
 
-    override fun formatValue(value: Timestamp): String {
-        val instant = Instant.ofEpochSecond(value.seconds)
-        return ofPattern(purifiedPattern(dateTimePattern)).format(
-            OffsetDateTime.ofInstant(instant, WallClock.zoneOffset)
-        )
+    override fun handleKeyEvent(keyEvent: KeyEvent): Boolean {
+        if (nowOptionEnabled && enabled && keyEvent matches Ctrl(Key.N.key).down) {
+            fillNow()
+            return true
+        }
+        return false
     }
+
+    /**
+     * Fills the field with the current date and time, obtained through
+     * [WallClock].
+     *
+     * The stored value is truncated to the resolution of [dateTimePattern], so
+     * that it stays consistent with the text displayed in the field.
+     */
+    private fun fillNow() {
+        if (enabled) {
+            applyValue(WallClock.now.toTimestamp())
+        }
+    }
+
+    override fun formatValue(value: Timestamp): String =
+        formatDateTime(value, dateTimePattern, WallClock.zoneOffset)
 
     override fun parseValue(rawText: String): Timestamp =
         parseDateTime(rawText, dateTimePattern, WallClock.zoneOffset)
+}
+
+/**
+ * The default button of the [DateTimeField]'s "now" affordance.
+ *
+ * It is a compact clickable icon (rather than a full-sized
+ * [androidx.compose.material3.IconButton]), so that it doesn't increase the
+ * height of the field. A round state layer behind the icon is lightened on hover
+ * or focus and darkened while pressed, to give the usual visual feedback.
+ *
+ * The control exposes button semantics (a button role, an accessible click
+ * action, a disabled state, keyboard focusability, and Enter/Space activation),
+ * so that it is discoverable and operable via assistive technologies and
+ * keyboard traversal.
+ *
+ * Mouse activation is handled with low-level pointer events (a primary-button
+ * press on the icon followed by a release over it; a non-primary button or a
+ * press dragged away before release does not activate it). This is used instead
+ * of [androidx.compose.foundation.clickable] because the latter's gesture is
+ * intermittently cancelled when placed inside the text field's decoration, where
+ * the field competes for the same pointer events.
+ *
+ * @param enabled
+ *         whether the button is enabled for interaction.
+ * @param onClick
+ *         a callback invoked when the button is clicked.
+ */
+@Composable
+@OptIn(ExperimentalComposeUiApi::class)
+private fun NowButton(enabled: Boolean, onClick: () -> Unit) {
+    var hovered by remember { mutableStateOf(false) }
+    var pressed by remember { mutableStateOf(false) }
+    var focused by remember { mutableStateOf(false) }
+    val stateLayerColor = nowButtonStateLayerColor(
+        enabled, pressed, hovered || focused, colorScheme.onSurface
+    )
+    WithTooltip(tooltip = NowButtonDescription) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(NowButtonSize)
+                .clip(CircleShape)
+                .background(stateLayerColor)
+                .nowButtonSemantics(enabled, onClick)
+                .onFocusChanged { focused = it.isFocused }
+                .onActivationKeys(enabled, onClick)
+                .focusable(enabled)
+                .pointerHoverIcon(Hand)
+                .nowButtonPointerInput(
+                    enabled,
+                    setHovered = { hovered = it },
+                    isPressed = { pressed },
+                    setPressed = { pressed = it },
+                    onClick = onClick
+                )
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Schedule,
+                contentDescription = null,
+                modifier = Modifier.size(NowButtonIconSize)
+            )
+        }
+    }
+}
+
+/**
+ * The color of the "now" button's state layer for the given interaction state.
+ */
+private fun nowButtonStateLayerColor(
+    enabled: Boolean,
+    pressed: Boolean,
+    active: Boolean,
+    baseColor: Color
+): Color = when {
+    !enabled -> Color.Transparent
+    pressed -> baseColor.copy(alpha = PressedStateLayerAlpha)
+    active -> baseColor.copy(alpha = HoveredStateLayerAlpha)
+    else -> Color.Transparent
+}
+
+/**
+ * Adds button semantics to the "now" button, so that it is exposed to assistive
+ * technologies as an actionable, optionally disabled, button.
+ */
+private fun Modifier.nowButtonSemantics(
+    enabled: Boolean,
+    onClick: () -> Unit
+): Modifier = semantics(mergeDescendants = true) {
+    role = Role.Button
+    contentDescription = NowButtonDescription
+    if (!enabled) {
+        disabled()
+    }
+    onClick(label = NowButtonDescription) {
+        if (enabled) {
+            onClick()
+        }
+        enabled
+    }
+}
+
+/**
+ * Activates the "now" button with the Enter or Space key while it is focused.
+ */
+private fun Modifier.onActivationKeys(
+    enabled: Boolean,
+    onActivate: () -> Unit
+): Modifier = onKeyEvent { event ->
+    if (enabled &&
+        (event matches Key.Enter.key.down || event matches Key.Spacebar.key.down)
+    ) {
+        onActivate()
+        true
+    } else {
+        false
+    }
+}
+
+/**
+ * Handles mouse interaction with the "now" button, invoking [onClick] on a
+ * primary-button press on the button followed by a release over it, and
+ * reporting the hover and press states via [setHovered] and [setPressed].
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.nowButtonPointerInput(
+    enabled: Boolean,
+    setHovered: (Boolean) -> Unit,
+    isPressed: () -> Boolean,
+    setPressed: (Boolean) -> Unit,
+    onClick: () -> Unit
+): Modifier =
+    onPointerEvent(Enter) { setHovered(true) }
+        .onPointerEvent(Exit) {
+            setHovered(false)
+            setPressed(false)
+        }
+        .onPointerEvent(Press) { event ->
+            setPressed(enabled && event.buttons.isPrimaryPressed)
+        }
+        .onPointerEvent(Release) {
+            if (isPressed()) {
+                setPressed(false)
+                onClick()
+            }
+        }
+
+/**
+ * Converts this [Instant] into a Protobuf [Timestamp].
+ */
+internal fun Instant.toTimestamp(): Timestamp =
+    Timestamp.newBuilder()
+        .setSeconds(epochSecond)
+        .setNanos(nano)
+        .build()
+
+/**
+ * Formats the given [value] into the input field's raw text (the editable
+ * characters only) according to [dateTimePattern].
+ *
+ * Only the components present in [dateTimePattern] are emitted, so any finer
+ * resolution of [value] (e.g. seconds or nanoseconds when the pattern has
+ * minute resolution) is not represented in the resulting text. This is the
+ * inverse of [parseDateTime].
+ *
+ * @param value
+ *         the timestamp to format.
+ * @param dateTimePattern
+ *         the pattern used to format the date/time.
+ * @param zoneOffset
+ *         the offset used to convert the instant into a local date/time.
+ * @return the raw text representation of [value].
+ */
+internal fun formatDateTime(
+    value: Timestamp,
+    dateTimePattern: DateTimePattern,
+    zoneOffset: ZoneOffset
+): String {
+    val instant = Instant.ofEpochSecond(value.seconds, value.nanos.toLong())
+    return ofPattern(purifiedPattern(dateTimePattern)).format(
+        OffsetDateTime.ofInstant(instant, zoneOffset)
+    )
 }
 
 /**

--- a/proto/src/test/kotlin/io/spine/chords/proto/time/DateTimeFieldSpec.kt
+++ b/proto/src/test/kotlin/io/spine/chords/proto/time/DateTimeFieldSpec.kt
@@ -79,4 +79,30 @@ internal class DateTimeFieldSpec {
 
         result shouldBe expected
     }
+
+    @Test
+    fun `fill the current moment truncated to the field's pattern`() {
+        val instant = Instant.parse("2025-07-01T12:30:45.123456789Z")
+
+        val text = formatDateTime(instant.toTimestamp(), TestDateTimePattern, ZoneOffset.UTC)
+        val stored = parseDateTime(text, TestDateTimePattern, ZoneOffset.UTC)
+
+        stored shouldBe Timestamp.newBuilder()
+            .setSeconds(Instant.parse("2025-07-01T12:30:00Z").epochSecond)
+            .build()
+    }
+
+    @Test
+    fun `preserve sub-second precision when the pattern includes a fraction`() {
+        val pattern = "yyyy-MM-dd HH:mm:ss.SSS"
+        val instant = Instant.parse("2025-07-01T12:30:45.123Z")
+
+        val text = formatDateTime(instant.toTimestamp(), pattern, ZoneOffset.UTC)
+        val stored = parseDateTime(text, pattern, ZoneOffset.UTC)
+
+        stored shouldBe Timestamp.newBuilder()
+            .setSeconds(Instant.parse("2025-07-01T12:30:45Z").epochSecond)
+            .setNanos(123_000_000)
+            .build()
+    }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.93")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.94")


### PR DESCRIPTION
Closes #140.

## Summary

Adds an opt-in "now" affordance to `DateTimeField` that fills the field with the
current date and time, so the user doesn't have to type it by hand when
recording something at the moment it happens. The current moment is sourced
through `WallClock`, and the filled value is truncated to the resolution of
`dateTimePattern`, keeping the stored value consistent with the displayed text.

## Changes

- **`DateTimeField.nowOptionEnabled`** — opt-in property (off by default) that
  shows a button within the field and enables the `Ctrl+N` shortcut.
- **`DateTimeField.nowOptionAffordance`** — optional custom renderer, receiving a
  `fillNow` callback, used instead of the default button.
- **`formatDateTime`** preserves sub-second precision when the pattern includes
  it; otherwise the value is truncated to the pattern's resolution.
- **`WallClock.now`** — exposes the current moment as an `Instant`, the single
  point through which time-dependent behavior obtains the current time.
- **`InputField`** — `applyValue` sets a value programmatically (reusing the
  normal parse/validate/dirty bookkeeping), and a `handleKeyEvent` hook lets
  subclasses implement field-specific keyboard shortcuts.
- The default button keeps the field's height, gives hover/press/focus feedback
  and a tooltip, and exposes full button semantics (role, accessible click
  action, disabled state, focusability, and Enter/Space activation).
- Adds `compose.materialIconsExtended` to the `proto` module for the button
  icon.
- Tests: `WallClockSpec`, and `DateTimeFieldSpec` cases for pattern truncation
  and sub-second round trips.

## Reviewer notes

Mouse activation of the default button uses low-level pointer events rather than
`clickable`/`IconButton`, because that gesture is intermittently cancelled when
placed inside the text field's decoration slot.