### PR TITLE
Implement automatic dialog size detection

### DIFF
--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,22 +37,6 @@ import androidx.compose.ui.unit.dp
 import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.appshell.Props
 import kotlinx.coroutines.CompletableDeferred
-
-/**
- * Default width of the [ConfirmationDialog].
- */
-private val DefaultDialogWidth = 450.dp
-
-/**
- * Default height of the [ConfirmationDialog].
- */
-private val DefaultDialogHeight = 220.dp
-
-/**
- * The value used to reduce the dialog's height
- * when the description field is empty.
- */
-private val ReservedDescriptionHeight = 32.dp
 
 /**
  * A dialog that prompts the user either to make a boolean decision
@@ -160,8 +144,6 @@ public class ConfirmationDialog : Dialog() {
 
         yesButtonText = "Yes"
         noButtonText = "No"
-        width = DefaultDialogWidth
-        height = DefaultDialogHeight
     }
 
     /**
@@ -203,12 +185,6 @@ public class ConfirmationDialog : Dialog() {
      * makes a decision.
      */
     public suspend fun showConfirmation(): Boolean {
-        // TODO:2025-04-18:oleg.melnik: Remove the code below after automatic
-        //  size detection is implemented for dialogs.
-        //  https://github.com/SpineEventEngine/Chords/issues/118
-        if (description.isBlank() && height == DefaultDialogHeight) {
-            height -= ReservedDescriptionHeight
-        }
         var confirmed = false
         val dialogClosure = CompletableDeferred<Unit>()
         onBeforeSubmit = {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,21 +30,28 @@ import androidx.compose.foundation.layout.Arrangement.End
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment.Companion.Bottom
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key.Companion.Enter
 import androidx.compose.ui.input.key.Key.Companion.Escape
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.spine.chords.core.AbstractComponentSetup
@@ -66,6 +73,19 @@ internal val submitShortcutKey = Ctrl(Enter.key)
 internal val cancelShortcutKey = Escape.key
 
 /**
+ * Describes the height constraints applied to the dialog content.
+ */
+internal enum class DialogContentHeightMode {
+    Natural,
+    AtMost,
+    Exact
+}
+
+private val LocalDialogContentHeightMode = staticCompositionLocalOf {
+    DialogContentHeightMode.Natural
+}
+
+/**
  * A base class for creating modal dialog windows, e.g. ones for displaying,
  * entering or editing some information, making decisions, etc.
  *
@@ -79,10 +99,6 @@ internal val cancelShortcutKey = Escape.key
  *     public companion object : DialogSetup<MyDialog>({ MyDialog() })
  *
  *     init {
- *         // Set up own dialog's properties if/as needed.
- *         width = 650.dp
- *         height = 400.dp
- *
  *         // Include the Submit/Cancel buttons
  *         submitAvailable = true
  *         cancelAvailable = true
@@ -229,16 +245,25 @@ public abstract class Dialog : Component() {
     /**
      * The width of the dialog.
      *
-     * The default value is `700.dp`.
+     * By default, the width is determined automatically from the dialog's
+     * content. Assign a specified [Dp] value to use a fixed width instead.
+     *
+     * Automatic width detection uses intrinsic measurement to keep text-based
+     * dialogs compact. Content implemented with `SubcomposeLayout`, such as a
+     * lazy list, does not support intrinsic measurement in Compose 1.5.12 and
+     * therefore requires an explicitly specified width.
      */
-    public var width: Dp = 700.dp
+    public var width: Dp by mutableStateOf(Dp.Unspecified)
 
     /**
      * The height of the dialog.
      *
-     * The default value is `450.dp`.
+     * By default, the height is determined automatically from the dialog's
+     * content. Assign a specified [Dp] value to use a fixed height instead.
+     * Automatically-sized content is capped by the available window height
+     * and becomes scrollable when it no longer fits.
      */
-    public var height: Dp = 450.dp
+    public var height: Dp by mutableStateOf(Dp.Unspecified)
 
     /**
      * Specifies appearance-related parameters.
@@ -499,7 +524,17 @@ public abstract class Dialog : Component() {
      */
     @Composable
     protected open fun ColumnScope.windowContent() {
-        Column(Modifier.weight(1F)) {
+        val heightMode = LocalDialogContentHeightMode.current
+        val contentModifier = when (heightMode) {
+            DialogContentHeightMode.Natural -> Modifier
+            DialogContentHeightMode.AtMost -> Modifier
+                .weight(1F, fill = false)
+                .verticalScroll(rememberScrollState())
+            DialogContentHeightMode.Exact -> Modifier
+                .weight(1F)
+                .verticalScroll(rememberScrollState())
+        }
+        Column(contentModifier) {
             contentSection()
         }
         buttonsSection()
@@ -510,8 +545,10 @@ public abstract class Dialog : Component() {
      */
     context(ColumnScope)
     @Composable
-    internal fun windowContentInternal() {
-        windowContent()
+    internal fun windowContentInternal(heightMode: DialogContentHeightMode) {
+        CompositionLocalProvider(LocalDialogContentHeightMode provides heightMode) {
+            windowContent()
+        }
     }
 
     /**
@@ -542,6 +579,7 @@ public abstract class Dialog : Component() {
             verticalAlignment = Bottom
         ) {
             Row(
+                modifier = Modifier.width(IntrinsicSize.Max),
                 horizontalArrangement = spacedBy(look.buttonsSpacing)
             ) {
                 buttons()
@@ -698,7 +736,12 @@ private fun DialogButton(
         Row(
             verticalAlignment = CenterVertically
         ) {
-            Text(label)
+            Text(
+                text = label,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/DialogHeading.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/DialogHeading.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Displays explanatory dialog text with the standard gap below it.
+ *
+ * @param content The heading content.
+ */
+@Composable
+public fun DialogHeading(
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 24.dp),
+        content = content
+    )
+}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ package io.spine.chords.core.layout
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
@@ -46,22 +46,6 @@ import kotlinx.coroutines.CompletableDeferred
  * The default number of lines for the input text component.
  */
 private const val InputComponentNoOfLines = 3
-
-/**
- * Default width of the [InputTextDialog].
- */
-private val DefaultDialogWidth = 450.dp
-
-/**
- * Default height of the [InputTextDialog].
- */
-private val DefaultDialogHeight = 300.dp
-
-/**
- * The value used to reduce the dialog's height
- * when the description field is empty.
- */
-private val ReservedDescriptionHeight = 24.dp
 
 /**
  * A dialog that allows input of a text value.
@@ -198,8 +182,6 @@ public class InputTextDialog : Dialog() {
     init {
         submitAvailable = true
         cancelAvailable = true
-        width = DefaultDialogWidth
-        height = DefaultDialogHeight
     }
 
     /**
@@ -209,33 +191,32 @@ public class InputTextDialog : Dialog() {
     protected override fun contentSection() {
         val textStyle = typography.bodyLarge
         Column {
-            Row {
-                Text(
-                    text = message,
-                    style = textStyle
-                )
-            }
-            if (description.isNotBlank()) {
-                Row(
-                    modifier = Modifier.padding(top = 8.dp)
-                ) {
+            DialogHeading {
+                Column {
                     Text(
-                        text = description,
+                        text = message,
                         style = textStyle
                     )
+                    if (description.isNotBlank()) {
+                        Row(
+                            modifier = Modifier.padding(top = 8.dp)
+                        ) {
+                            Text(
+                                text = description,
+                                style = textStyle
+                            )
+                        }
+                    }
                 }
             }
-            Row(
-                modifier = Modifier.padding(top = 16.dp)
-            ) {
+            Row {
                 text.value = defaultText
                 StringField {
                     label = textFieldLabel
                     multiline = noOfTextLines > 1
                     minLines = noOfTextLines
                     maxLines = noOfTextLines
-                    modifier = Modifier.fillMaxSize()
-                        .padding(end = 8.dp)
+                    modifier = Modifier.fillMaxWidth()
                     value = text
                 }
             }
@@ -256,12 +237,6 @@ public class InputTextDialog : Dialog() {
      * pressing the submit button, or `null`, if the user cancels the input.
      */
     private suspend fun show(): String? {
-        // TODO:2025-04-18:oleg.melnik: Remove the code below after automatic
-        //  size detection is implemented for dialogs.
-        //  https://github.com/SpineEventEngine/Chords/issues/118
-        if (description.isBlank() && height == DefaultDialogHeight) {
-            height -= ReservedDescriptionHeight
-        }
         var dialogCancelled = false
         val dialogClosure = CompletableDeferred<Unit>()
         onBeforeSubmit = {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,9 @@ package io.spine.chords.core.layout
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.appshell.Props
 import kotlinx.coroutines.CompletableDeferred
@@ -81,8 +78,6 @@ public class MessageDialog : Dialog() {
 
     init {
         submitAvailable = true
-        width = 550.dp
-        height = 205.dp
     }
 
     /**
@@ -123,9 +118,7 @@ public class MessageDialog : Dialog() {
         val textStyle = typography.bodyLarge
 
         Column {
-            Row(
-                modifier = Modifier.padding(bottom = 6.dp)
-            ) {
+            Row {
                 Text(
                     text = message,
                     style = textStyle

--- a/core/src/main/kotlin/io/spine/chords/core/layout/WindowType.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/WindowType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,16 +29,29 @@ package io.spine.chords.core.layout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MaterialTheme.shapes
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,12 +59,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntOffset.Companion.Zero
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Popup
@@ -86,12 +102,30 @@ public sealed class WindowType {
 
         @Composable
         override fun dialogWindow(dialog: Dialog) {
+            val initialSize = DpSize(dialog.width, dialog.height)
+            val state = remember(dialog, initialSize) {
+                DialogState(size = initialSize)
+            }
+            var contentFittedSize by remember(dialog, initialSize) {
+                mutableStateOf<DpSize?>(null)
+            }
+            LaunchedEffect(state.size) {
+                if (
+                    contentFittedSize == null &&
+                    state.size.width.isSpecified &&
+                    state.size.height.isSpecified
+                ) {
+                    val candidate = state.size
+                    withFrameNanos {}
+                    if (state.size == candidate) {
+                        contentFittedSize = candidate
+                    }
+                }
+            }
             DialogWindow(
                 title = dialog.title,
                 resizable = resizable,
-                state = DialogState(
-                    size = DpSize(dialog.width, dialog.height)
-                ),
+                state = state,
                 onCloseRequest = { dialog.cancel() },
                 onKeyEvent = { event ->
                     if (dialog.cancelAvailableInternal && event matches cancelShortcutKey.down) {
@@ -103,17 +137,49 @@ public sealed class WindowType {
                     false
                 }
             ) {
+                DesktopDialogContent(dialog, state, contentFittedSize)
+            }
+        }
+
+        @Composable
+        private fun DesktopDialogContent(
+            dialog: Dialog,
+            state: DialogState,
+            contentFittedSize: DpSize?
+        ) {
+            BoxWithConstraints {
+                val resized =
+                    resizable && contentFittedSize?.let { state.size != it } == true
+                val sizeModifier = if (resized) {
+                    Modifier.fillMaxSize()
+                } else {
+                    Modifier.dialogSize(
+                        dialog.width,
+                        dialog.height,
+                        maxWidth,
+                        maxHeight,
+                        fillSpecifiedDimensions = true
+                    )
+                }
                 Column(
-                    modifier = Modifier
-                        .fillMaxSize()
+                    modifier = sizeModifier
                         .background(colorScheme.background),
                 ) {
+                    val heightMode =
+                        if (dialog.height.isSpecified || contentFittedSize != null) {
+                            DialogContentHeightMode.Exact
+                        } else {
+                            DialogContentHeightMode.AtMost
+                        }
+                    val contentModifier = if (heightMode == DialogContentHeightMode.Exact) {
+                        Modifier.fillMaxSize()
+                    } else {
+                        Modifier.fillMaxWidth()
+                    }
                     Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(dialog.look.padding),
+                        modifier = contentModifier.padding(dialog.look.padding),
                     ) {
-                        dialog.windowContentInternal()
+                        dialog.windowContentInternal(heightMode)
                         dialog.nestedDialog?.Content()
                     }
                 }
@@ -171,12 +237,14 @@ public sealed class WindowType {
                     }
                 }
             ) {
-                Box(
+                BoxWithConstraints(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(backdropColor),
                     contentAlignment = Center
                 ) {
+                    val availableWidth = maxWidth
+                    val availableHeight = maxHeight
                     val modifier = if (dialog.isBottomDialog) {
                         Modifier.pointerInput(dialog) {
                             detectTapGestures(onPress = {})
@@ -185,27 +253,45 @@ public sealed class WindowType {
                         Modifier
                     }
                     Box(modifier = modifier) {
-                        dialogFrame(dialog)
+                        dialogFrame(dialog, availableWidth, availableHeight)
                     }
                 }
             }
         }
 
         @Composable
-        private fun dialogFrame(dialog: Dialog) {
+        private fun dialogFrame(
+            dialog: Dialog,
+            maxWidth: Dp,
+            maxHeight: Dp
+        ) {
             Column(
                 modifier = Modifier
                     .clip(shapes.large)
-                    .size(dialog.width, dialog.height)
+                    .dialogSize(
+                        dialog.width,
+                        dialog.height,
+                        maxWidth,
+                        maxHeight,
+                        fillSpecifiedDimensions = false
+                    )
                     .background(colorScheme.background),
             ) {
+                val heightMode = if (dialog.height.isSpecified) {
+                    DialogContentHeightMode.Exact
+                } else {
+                    DialogContentHeightMode.AtMost
+                }
+                val contentModifier = if (heightMode == DialogContentHeightMode.Exact) {
+                    Modifier.fillMaxSize()
+                } else {
+                    Modifier.fillMaxWidth()
+                }
                 Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(dialog.look.padding),
+                    modifier = contentModifier.padding(dialog.look.padding),
                 ) {
                     DialogTitle(dialog.title, dialog.look.titlePadding)
-                    dialog.windowContentInternal()
+                    dialog.windowContentInternal(heightMode)
                     dialog.nestedDialog ?.Content()
                 }
             }
@@ -254,6 +340,55 @@ public sealed class WindowType {
 
     }
 }
+
+/**
+ * The minimum width used for automatically-sized dialogs.
+ *
+ * This prevents short text from producing impractically narrow windows while
+ * still allowing wider form layouts to determine their preferred width.
+ */
+private val DefaultDialogMinWidth = 400.dp
+
+/**
+ * Measures unspecified dimensions from the content and caps them at the
+ * available window size.
+ *
+ * Minimum intrinsic width is intentional: it keeps text-based dialogs compact
+ * instead of expanding them to the width of an unwrapped paragraph.
+ */
+private fun Modifier.dialogSize(
+    width: Dp,
+    height: Dp,
+    maxWidth: Dp,
+    maxHeight: Dp,
+    fillSpecifiedDimensions: Boolean
+): Modifier =
+    then(
+        if (width.isSpecified) {
+            if (fillSpecifiedDimensions) {
+                Modifier.fillMaxWidth()
+            } else {
+                Modifier.width(width)
+            }
+        } else {
+            Modifier
+                .width(IntrinsicSize.Min)
+                .widthIn(
+                    min = minOf(DefaultDialogMinWidth, maxWidth),
+                    max = maxWidth
+                )
+        }
+    ).then(
+        if (height.isSpecified) {
+            if (fillSpecifiedDimensions) {
+                Modifier.fillMaxHeight()
+            } else {
+                Modifier.height(height)
+            }
+        } else {
+            Modifier.heightIn(max = maxHeight)
+        }
+    )
 
 /**
  * A [PopupPositionProvider], which makes a lightweight popup to appear at

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,10 @@ import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -73,7 +72,7 @@ import io.spine.chords.core.primitive.HorizontalScrollbar
 import io.spine.chords.core.primitive.VerticalScrollbar
 
 /**
- * Constants for the min and max size of the wizard's content pane.
+ * Bounds of the wizard's content pane.
  */
 private object WizardContentSize {
     val width = 670.dp
@@ -166,13 +165,14 @@ public abstract class Wizard : Component() {
     @Composable
     override fun content() {
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .width(width)
+                .heightIn(minHeight, maxHeight),
             contentAlignment = Center
         ) {
             Column(
                 modifier = Modifier
-                    .widthIn(width, width)
-                    .heightIn(minHeight, maxHeight)
+                    .fillMaxWidth()
                     .padding(32.dp),
                 verticalArrangement = spacedBy(16.dp)
             ) {
@@ -181,7 +181,7 @@ public abstract class Wizard : Component() {
                 }
                 Column(
                     Modifier
-                        .weight(1F)
+                        .weight(1F, fill = false)
                         .on(Ctrl(Enter.key).up) {
                             submitPage(currentPage)
                         }
@@ -348,11 +348,11 @@ private fun PageContainer(page: WizardPage) {
     val stateVertical = rememberScrollState(0, page)
     val stateHorizontal = rememberScrollState(0, page)
     Box(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxWidth()
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .verticalScroll(stateVertical)
                 .horizontalScroll(stateHorizontal),
             horizontalAlignment = Start

--- a/core/src/main/kotlin/io/spine/chords/core/layout/WizardPage.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/WizardPage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 
 package io.spine.chords.core.layout
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.Start
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
@@ -101,7 +102,7 @@ public fun SubheaderText(text: String) {
 }
 
 /**
- * Column layout for wizard's page input fields.
+ * Column layout for input fields.
  *
  * @param padding
  *          padding to be applied to the column.
@@ -123,7 +124,7 @@ public fun InputColumn(
 }
 
 /**
- * Row layout for wizard's page input fields.
+ * Row layout for input fields.
  *
  * @param padding
  *         padding to be applied to the row.
@@ -133,10 +134,34 @@ public fun InputRow(
     padding: PaddingValues = PaddingValues(),
     content: @Composable () -> Unit
 ) {
+    InputRow(
+        modifier = Modifier,
+        horizontalArrangement = spacedBy(40.dp),
+        padding = padding,
+        content = content
+    )
+}
+
+/**
+ * Configurable row layout for input fields.
+ *
+ * @param modifier
+ *         [Modifier] to be applied to the row.
+ * @param horizontalArrangement
+ *         horizontal arrangement of the row's fields.
+ * @param padding
+ *         padding to be applied to the row.
+ */
+@Composable
+public fun InputRow(
+    modifier: Modifier,
+    horizontalArrangement: Arrangement.Horizontal,
+    padding: PaddingValues = PaddingValues(),
+    content: @Composable () -> Unit
+) {
     Row(
-        modifier = Modifier
-            .padding(padding),
-        horizontalArrangement = spacedBy(40.dp)
+        modifier = modifier.padding(padding),
+        horizontalArrangement = horizontalArrangement
     ) {
         content()
     }

--- a/core/src/test/kotlin/io/spine/chords/core/layout/DialogSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/DialogSpec.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class DialogSpec {
+
+    @Test
+    fun `determine dimensions from content by default`() {
+        val dialog = TestDialog()
+
+        dialog.width shouldBe Dp.Unspecified
+        dialog.height shouldBe Dp.Unspecified
+    }
+
+    @Test
+    fun `determine dimensions of built-in dialogs from content`() {
+        val dialogs = listOf(
+            ConfirmationDialog(),
+            InputTextDialog(),
+            MessageDialog()
+        )
+
+        dialogs.forEach { dialog ->
+            dialog.width shouldBe Dp.Unspecified
+            dialog.height shouldBe Dp.Unspecified
+        }
+    }
+
+    @Test
+    fun `allow specifying dimensions explicitly`() {
+        val dialog = TestDialog().apply {
+            width = 600.dp
+            height = 400.dp
+        }
+
+        dialog.width shouldBe 600.dp
+        dialog.height shouldBe 400.dp
+    }
+
+    private class TestDialog : Dialog() {
+
+        override val title: String = "Test"
+
+        @Composable
+        override fun contentSection(): Unit = Unit
+
+        override suspend fun submitContent(): Unit = Unit
+    }
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.94`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.95`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 19:21:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 12:22:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.94`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.95`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Fri Jul 24 19:21:14 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 19:21:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 12:22:11 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.94`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.95`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Fri Jul 24 19:21:14 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 19:21:15 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 12:22:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.94`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.95`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Fri Jul 24 19:21:15 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 19:21:16 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 12:22:13 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.94`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.95`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Fri Jul 24 19:21:16 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 19:21:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 12:22:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.94`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.95`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Fri Jul 24 19:21:17 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 19:21:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 12:22:16 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.94</version>
+<version>2.0.0-SNAPSHOT.95</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.94")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.95")


### PR DESCRIPTION
## Summary

Implement content-driven dialog sizing that follows `JDialog.pack()`-style behavior while preserving explicit width and height overrides.

Fixes #118

## Changes

- Default dialogs to automatic width and height detection and constrain fitted windows to their available bounds.
- Keep content and action buttons reachable through bounded, scrollable content after packing or resizing.
- Apply automatic sizing consistently to desktop, lightweight, built-in, and wizard dialogs.
- Add the reusable `DialogHeading` layout and configurable `InputRow` arrangement support.
- Add regression coverage for automatic and explicitly configured dialog dimensions.
- Bump Chords to `2.0.0-SNAPSHOT.95` and regenerate dependency reports.
