### PR TITLE
Add the `proofread` skill and sweep repository prose

### DIFF
--- a/.agents/guidelines/english-style.md
+++ b/.agents/guidelines/english-style.md
@@ -1,0 +1,314 @@
+# English Style
+
+Use these grammar, punctuation, and spelling rules for English prose in Chords
+KDoc and Javadoc, Protobuf doc comments, other code comments, and Markdown.
+For layout, links, terminology, and line wrapping, follow `AGENTS.md` and the
+nearest documentation-writing skill.
+
+This catalog is the source of truth for proofreading existing prose,
+reviewing documentation changes, and writing new Chords documentation.
+
+## Principles
+
+1. Fix errors, not taste. Correct only what this catalog identifies as an
+   error. Do not reword text that is already correct.
+2. Make minimal edits. Preserve the author's wording, meaning, and voice.
+3. Leave ambiguous cases unchanged and report them. A missed error is cheaper
+   than an incorrect fix.
+4. Never edit code or machine-read text.
+5. Keep correct alternatives consistent within each file. Where no spelling
+   dialect or list-punctuation convention dominates, leave the text unchanged
+   and report the mix.
+
+## Where English Prose Lives
+
+| Language      | Prose to check                                                    |
+|---------------|-------------------------------------------------------------------|
+| Kotlin / Java | KDoc/Javadoc bodies and tag descriptions; block and line comments |
+| Protobuf      | `//` doc comments for types and fields, and file-header prose      |
+| Markdown      | Body prose and headings                                           |
+
+Within a doc comment, edit only description text. Tag names, type references,
+parameter names, and link targets are not prose.
+
+## Never Edit
+
+Skip the following content.
+
+In every file:
+
+- Code in any form: string literals, identifiers, fenced or indented code
+  blocks, inline code spans, `{@code}` and `{@literal}` tags, `<pre>` and
+  `<code>` HTML, `@sample` references, and documented commands.
+- Generated files and generated sections, including root `pom.xml` and
+  `dependencies.md` reports.
+- License and copyright headers.
+- Quoted text, URLs, email addresses, version strings, and file paths.
+- Machine-read TODO prefixes. The description after the prefix remains prose.
+- Editor and tool modelines.
+- Text that a style guide cites as an example of an error, including the
+  "Before" column of every table in this file. Those entries are deliberately
+  wrong; correcting them destroys the catalog.
+
+In Kotlin and Java:
+
+- Inspection suppressions such as `//noinspection`.
+- Javadoc and KDoc reference targets: `{@link}`, `{@linkplain}`, `@see`, and
+  KDoc `[Symbol]` references.
+
+In Protobuf:
+
+- Lint directives such as `// buf:lint:ignore`.
+
+In Markdown:
+
+- YAML frontmatter, link-reference definitions, badge markup, and directive
+  comments such as `<!-- markdownlint-disable -->`.
+
+## Error Catalog
+
+Group proofreading reports by these topic headings.
+
+### Restrictive "Which" and "That"
+
+Use "that" for a relative clause that restricts or identifies its antecedent.
+Use "which", preceded by a comma, for a clause that adds information.
+
+| Before                         | After                                      |
+|--------------------------------|--------------------------------------------|
+| a plugin which forces versions | a plugin that forces versions              |
+| the file, which is generated   | the file, which is generated — leave alone |
+
+Replace "which" with "that" only when none of these guards applies:
+
+- A comma, opening parenthesis, or dash precedes "which".
+- A preposition precedes it, as in "in which", "of which", or "with which".
+- It is interrogative or determines a choice, as in "Which plugin?" or
+  "decide which plugin".
+- It starts a sentence.
+- A hyphen abuts it in an identifier such as `which-fixer`.
+- It appears in "that which" or "which is which".
+
+### Articles
+
+Add missing articles in complete sentences. Choose "a" or "an" by the sound
+that follows.
+
+| Before                                   | After                                           |
+|------------------------------------------|-------------------------------------------------|
+| Returns value of given field.            | Returns the value of the given field.           |
+| Throws exception if file does not exist. | Throws an exception if the file does not exist. |
+| a HTTP request                           | an HTTP request                                 |
+| an user, an unique key                   | a user, a unique key                            |
+| a SDK, an URL                            | an SDK, a URL                                   |
+
+Leave unchanged:
+
+- Plural and uncountable nouns used generically.
+- Telegraphic headings, table cells, and list fragments.
+- Initialisms whose pronunciation varies, such as SQL. Follow the file's
+  established usage or report the ambiguity.
+- Bare identifiers used as names, as in "Calls `close` after use."
+
+### Subject-Verb Agreement
+
+Make the verb agree with the grammatical subject, including the head noun of
+a long subject and "there is/are" constructions.
+
+| Before                              | After                              |
+|-------------------------------------|------------------------------------|
+| The methods returns a copy.         | The methods return a copy.         |
+| Each of the listeners are notified. | Each of the listeners is notified. |
+| The list of errors are cleared.     | The list of errors is cleared.     |
+| There is several options.           | There are several options.         |
+
+Leave unchanged:
+
+- "data" used consistently as singular or plural within a file.
+- A backticked identifier used as one named subject.
+- "a number of X are" and "the number of X is".
+
+### API Summary Verb Form
+
+Describe what a function or method does in the third-person singular:
+"Returns", "Creates", or "Validates". Do not use an imperative opener.
+
+| Before                             | After                               |
+|------------------------------------|-------------------------------------|
+| `/** Return the current state. */` | `/** Returns the current state. */` |
+
+Leave unchanged:
+
+- Imperative instructions in procedures, tutorials, commands, and CLI help.
+- Type summaries written as noun phrases or beginning with "Represents".
+- "This method returns". It is wordy but grammatical.
+
+### Prepositions
+
+Fix only these established pairs. Other pairings can vary legitimately.
+
+| Before                            | After                             |
+|-----------------------------------|-----------------------------------|
+| depends of                        | depends on                        |
+| independent from                  | independent of                    |
+| consists from                     | consists of                       |
+| capable to handle                 | capable of handling               |
+| waits the result                  | waits for the result              |
+| listens the event                 | listens to the event              |
+| in runtime, in compile time       | at runtime, at compile time       |
+| on practice                       | in practice                       |
+| on the screenshot, on the diagram | in the screenshot, in the diagram |
+| typical for                       | typical of                        |
+| access of the file                | access to the file                |
+
+Leave unchanged:
+
+- Correct transitive verbs such as "awaits", "accesses", and "discusses".
+- "listens for" when it means awaiting a specific occurrence.
+- Idioms such as "in search of" and "on the basis of".
+- Dialect variants of "different from/to/than".
+
+### Verb Complementation
+
+"Allow", "enable", and "permit" need an object before a to-infinitive.
+Without an object, use a gerund or rephrase. "Recommend" and "suggest" take a
+gerund, not a bare infinitive.
+
+| Before                        | After                        |
+|-------------------------------|------------------------------|
+| allows to configure the build | allows configuring the build |
+| enables to run tests          | enables running tests        |
+| permits to access the field   | permits access to the field  |
+| We recommend to use the DSL.  | We recommend using the DSL.  |
+| suggest to add a test         | suggest adding a test        |
+| It is worth to note           | It is worth noting           |
+
+Leave unchanged:
+
+- A construction with an object, such as "allows the caller to configure".
+- "allows for" followed by a noun.
+- Passive "It is recommended to use".
+- Either form of "helps (to) do".
+- "provides the possibility to". Report it rather than automatically
+  rewriting it because its grammaticality is disputed.
+
+### Comparatives
+
+Keep each comparison's function word: "greater than" and "equal to".
+
+| Before                               | After                                      |
+|--------------------------------------|--------------------------------------------|
+| the day is less or equal zero        | the day is less than or equal to zero      |
+| a value greater or equal the limit   | a value greater than or equal to the limit |
+| the size is equal or greater than 10 | the size is greater than or equal to 10    |
+
+Leave unchanged:
+
+- Complete "greater than or equal to" and "less than or equal to" forms.
+- Comparison operators in code spans.
+- "no less than", "no more than", "at least", and "at most".
+- Transitive "equals", as in "the result equals zero".
+
+### Commas
+
+Treat only these mechanical cases as errors:
+
+- Add a comma after an introductory subordinate clause.
+- Replace a comma splice with a semicolon or period.
+- Remove a comma between a subject and its verb.
+- Keep serial-comma usage internally consistent. Add a serial comma only when
+  its absence is ambiguous; do not churn existing lists.
+
+Leave commas inside quoted text unchanged. The restrictive
+"which"/"that" topic owns the comma before "which". Either convention for a
+comma after "e.g." or "i.e." is acceptable.
+
+### Hyphenated Compound Modifiers
+
+Hyphenate two words acting as one adjective before a noun.
+
+| Before                    | After                     |
+|---------------------------|---------------------------|
+| read only mode            | read-only mode            |
+| well known issue          | well-known issue          |
+| case sensitive comparison | case-sensitive comparison |
+| third party library       | third-party library       |
+| long running task         | long-running task         |
+
+Leave unchanged:
+
+- Predicative use, as in "the mode is read only".
+- Adverbs ending in "-ly", as in "fully qualified name".
+- A number followed by a unit symbol, as in "a 5 GiB limit".
+
+### Confusables
+
+Correct these only when the intended meaning is unambiguous.
+
+| Before                               | After                                 |
+|--------------------------------------|---------------------------------------|
+| The method returns it's result.      | The method returns its result.        |
+| Let's you configure the build.       | Lets you configure the build.         |
+| This value maybe null.               | This value may be null.               |
+| more efficient then the default      | more efficient than the default       |
+| Use this method to setup the server. | Use this method to set up the server. |
+| Users can login with a token.        | Users can log in with a token.        |
+| The server can not recover.          | The server cannot recover.            |
+
+Use one word for nouns or adjectives and two for verbs: setup/set up,
+login/log in, backup/back up, shutdown/shut down, and checkout/check out.
+Use "cannot" except when "can not" deliberately means "is able not to".
+Report ambiguous "e.g."/"i.e." and "affect"/"effect" cases.
+
+### Punctuation and Spacing
+
+- End a doc-comment summary sentence with a period.
+- Use one space between sentences.
+- Remove spaces before `.`, `,`, `;`, `:`, `?`, and `!`.
+- Remove spaces just inside parentheses or brackets in prose.
+- Remove duplicated terminal punctuation, but preserve `...` and `…`.
+- Start sentences with a capital letter. Never change an identifier's case;
+  reword the sentence if necessary.
+- Add missing apostrophes in contractions.
+- Keep list-item punctuation internally consistent. Fragments need no period.
+
+### Duplicated and Dropped Words
+
+Repair editing artifacts: a word repeated, two words run together, or a clause
+left fused to its replacement. These are mechanical slips rather than
+word-choice errors. Fix one only when the surrounding sentence makes the
+intended wording certain.
+
+| Before                               | After                            |
+|--------------------------------------|----------------------------------|
+| recommended to register registers it | recommended to register it       |
+| the value is usedThe when searching  | the value is used when searching |
+| The state is updated Text is parsed  | Text is parsed                   |
+
+Leave unchanged:
+
+- A correct repetition, as in "had had" or "that that".
+- A run-together token that matches an identifier or belongs in a code span.
+- A gap with more than one plausible completion. Report it instead.
+
+### Spelling and Dialect
+
+Correct genuine misspellings:
+
+| Before                      | After                        |
+|-----------------------------|------------------------------|
+| recieve, occured, seperate  | receive, occurred, separate  |
+| existance, paramter, lenght | existence, parameter, length |
+| successfull, usefull        | successful, useful           |
+| compatable, preferrable     | compatible, preferable       |
+
+For American and British variants, keep each file internally consistent:
+
+- Align a clear outlier with the file's dominant dialect.
+- If neither dialect dominates, leave the text unchanged and report the mix.
+- Treat `-or`/`-our`, `-er`/`-re`, licence/license, and gray/grey as strong
+  markers. Treat `-ise`/`-ize` as weak evidence.
+- Never change dialect in identifiers, code, quoted text, proper nouns, or
+  prose that deliberately matches an identifier.
+
+Chords has no repository-wide English dialect requirement.

--- a/.agents/guidelines/project-owned-files.md
+++ b/.agents/guidelines/project-owned-files.md
@@ -1,0 +1,43 @@
+# Project-Owned Files
+
+Use this boundary for repository-wide or path-scoped edits. Chords owns its
+library sources, module documentation, repository-specific build files,
+`AGENTS.md`, `CLAUDE.md`, and `.agents/` content. It does not own the `config`
+submodule or files that the pinned `config/pull` script distributes into the
+project tree.
+
+## Chords Exclusions
+
+Skip these paths in every proofreading mode:
+
+- `config/` and anything beneath it. `.gitmodules` declares this directory as
+  the `SpineEventEngine/config` submodule.
+- Any `buildSrc/<path>` for which `config/buildSrc/<path>` exists. The
+  `config/pull` script copies these paths into the root `buildSrc/` tree.
+  Chords-specific root files with no matching submodule path remain
+  project-owned.
+- `CODE_OF_CONDUCT.md`, which `config/pull` copies unconditionally.
+- `CONTRIBUTING.md`, which `config/pull` copies unconditionally.
+
+The exclusions apply even though copied files are ordinary tracked files.
+A later `config` update can overwrite edits to them.
+
+For proofreading, generated sources, build outputs, codegen `_out/`
+workspaces, and generated root `pom.xml` and `dependencies.md` reports are
+also out of scope.
+
+## Resolving Ownership
+
+Enumerate tracked files with `git ls-files`. A submodule appears as one gitlink
+rather than as its contents, but explicitly drop its path from diff-based
+candidate lists.
+
+Determine submodule ownership from `.gitmodules`, not from a directory name.
+If Chords adds another submodule, exclude its declared path and descendants.
+
+When `config` is unavailable, continue excluding the fixed distributed paths
+and conservatively skip all of `buildSrc/`. A missed proofreading case is
+preferable to changing an upstream-owned file.
+
+Do not exclude a path merely because a same-named file exists somewhere under
+`config/`. The submodule contains files that it does not distribute.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -25,6 +25,8 @@ routing source of truth.
 - `docs-writer`: documentation authoring, editing, restructuring, and claim
   checks.
 - `docs-reviewer`: documentation review for prose, examples, and comments.
+- `proofread`: minimal English grammar, punctuation, and spelling corrections
+  in project-owned comments and documentation.
 
 ## Skill Directory Layout
 

--- a/.agents/skills/proofread/SKILL.md
+++ b/.agents/skills/proofread/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: proofread
+description: >
+  Proofreads project-owned Chords comments and documentation for English
+  grammar, punctuation, and spelling. Use for branch changes, a repository-wide
+  prose sweep, or a path-scoped review of Kotlin/Java comments, Protobuf
+  comments, and Markdown. Applies the Chords English catalog, preserves code and
+  machine-read text, and reports ambiguous cases instead of guessing.
+---
+
+# Proofread
+
+Fix English-language errors in comments and documentation by applying
+`.agents/guidelines/english-style.md`. Treat that catalog as the source of truth
+for what is an error and when to leave an occurrence unchanged. Use this skill
+only for scoping, scanning, editing, and reporting.
+
+Prefer a missed error to an incorrect edit. When a fix is not clearly correct,
+leave the text unchanged and report it.
+
+## Workflow
+
+1. Choose the mode from the caller's argument.
+
+   - No argument: use branch-diff mode. Scan the union of:
+     - `git diff --name-only --diff-filter=ACMR <base>...HEAD`;
+     - `git diff --name-only --diff-filter=ACMR HEAD`; and
+     - `git ls-files --others --exclude-standard`.
+
+     Resolve `<base>` to `origin/master`, then `master`. If neither exists, use
+     the working-tree lists and report the missing base. The three-dot diff
+     includes committed changes since the branch diverged; the other lists add
+     staged, unstaged, and untracked non-ignored files. On a stacked branch,
+     review the resulting file list before editing because it can include
+     changes inherited from the parent branch.
+
+   - Argument `all`: use full-sweep mode. Enumerate candidates with
+     `git ls-files`. To scan a path literally named `all`, pass `./all`.
+
+   - Any other argument: use scoped-sweep mode. Treat the argument as a file or
+     directory path and enumerate tracked candidates with
+     `git ls-files -- <path>`.
+
+2. Identify target files.
+
+   Keep only Chords prose-bearing file types:
+
+   - `*.kt`, `*.kts`, and `*.java`;
+   - `*.proto`; and
+   - `*.md`.
+
+   In full-sweep and scoped-sweep modes, scan tracked files only. In branch-diff
+   mode, retain eligible untracked, non-ignored files.
+
+   Drop generated content and build outputs, as listed in `AGENTS.md`:
+   `generated/` folders, a module's `build/` or `.gradle/` output directory,
+   codegen `_out/` workspaces, and the generated root `pom.xml` and
+   `dependencies.md` reports.
+
+   Match those as output directories, not as any path segment with the same
+   name. A source package directory named `build` is ordinary project-owned
+   code, as in
+   `codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/build/`.
+
+   Apply `.agents/guidelines/project-owned-files.md` in every mode. In
+   particular, do not edit the `config/` submodule or files distributed by it.
+   Deciding whether `buildSrc/<path>` is distributed needs a working-tree check
+   for `config/buildSrc/<path>`, such as `Glob`. `git ls-files` cannot answer
+   it: the submodule is tracked as a single gitlink, so it reports none of the
+   submodule's contents and every `buildSrc` file looks project-owned.
+
+3. Scan and edit each file.
+
+   Read the complete English catalog before editing. Restrict changes to the
+   prose identified in its "Where English Prose Lives" section:
+
+   - In Kotlin, Kotlin script, Java, and Protobuf files, edit only comment text.
+   - In Markdown, edit only headings and body prose.
+   - Never edit code tokens, string literals, identifiers, code examples,
+     link targets, file paths, commands, generated content, copyright headers,
+     or machine-read directives listed in the catalog.
+   - Never edit text that a style guide cites as an example of an error.
+     Full-sweep mode includes `.agents/guidelines/english-style.md` itself, and
+     the "Before" column of its tables is deliberately wrong. Correcting those
+     entries destroys the catalog.
+
+   Apply every relevant catalog topic, but only when none of its leave-alone
+   guards matches. Preserve the author's meaning and voice. Make the smallest
+   change that fixes the error and keep each file's spelling dialect and list
+   punctuation internally consistent.
+
+   Group a file's corrections into as few edits as the editing tool allows,
+   and anchor every one. The same comment line recurs across overloads and
+   `@param` blocks, so a match that carries no surrounding context can land on
+   the wrong occurrence. Include enough context to make each match unique, and
+   replace every occurrence at once only when they all need the same fix.
+
+   If an occurrence is ambiguous, leave it unchanged and add it to `Skipped[]`
+   with its catalog topic and the reason `ambiguous`.
+
+4. Review the diff.
+
+   Read the whole `git diff`, not just the list of changed files. Confirm that
+   every changed line is prose, no code or machine-read text changed, and no
+   excluded or generated file was touched. Revert any speculative or
+   out-of-scope edit.
+
+   A comments-only sweep normally keeps insertions and deletions equal per
+   file, so check `git diff --stat` and account for any file where they
+   differ. Rewrapping a paragraph explains it; a moved code line does not.
+
+5. Report the result.
+
+## Report
+
+Return:
+
+- `Mode`: `branch-diff`, `all`, or `path:<path>`;
+- `FilesScanned` and `FilesChanged`;
+- `Changes[]`, grouped by catalog topic, with file, line, and
+  `before` → `after`. When one topic covers many instances of the same
+  correction, state that correction once with a count and cite the files,
+  instead of repeating an identical `before` → `after` per line; and
+- `Skipped[]`, with file, line, catalog topic, and reason.
+
+If no file qualifies, report zero counts. If the base ref was unavailable,
+state that branch-diff mode covered only the working tree.

--- a/.agents/skills/proofread/agents/openai.yaml
+++ b/.agents/skills/proofread/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Proofread"
+  short_description: "Proofread Chords comments and documentation"
+  default_prompt: >-
+    Use $proofread to fix English grammar, punctuation, and spelling errors in
+    Chords comments and documentation. Pass `all` for a full sweep, a path for
+    a scoped sweep, or no argument to check the current branch.

--- a/.claude/commands/proofread.md
+++ b/.claude/commands/proofread.md
@@ -1,0 +1,13 @@
+---
+description: >
+  Fix English grammar, punctuation, and spelling errors in project-owned
+  Chords comments and documentation.
+argument-hint: "[all | <path>]"
+allowed-tools: >-
+  Read, Edit, Grep, Glob, Bash(git diff:*), Bash(git ls-files:*),
+  Bash(git status:*), Bash(git rev-parse:*)
+model: sonnet
+---
+
+Follow the [proofread skill](../../.agents/skills/proofread/SKILL.md) exactly,
+passing `$ARGUMENTS` as its argument.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,15 +74,17 @@ step 6), then:
 1. **Create it as a draft** (`gh pr create --draft`), targeting `master` as the
    base branch unless the task specifies otherwise.
 2. **Assign it to the authenticated GitHub user** (`--assignee @me`).
-3. **Write the description** with a `## Summary` section followed by a
+3. **Omit a trailing period.** Do not end a pull request title with a period
+   (`.`).
+4. **Write the description** with a `## Summary` section followed by a
    `## Changes` section. Optional sections such as `## Important notes` or
    `## Reviewer notes` may follow when useful. Do not add a "Verifications"
    section or any agent-attribution section such as `Created by <agent>`.
-4. **Link resolved issues.** For each issue the PR implements or fixes, add a
+5. **Link resolved issues.** For each issue the PR implements or fixes, add a
    GitHub closing keyword in the description (for example, `Fixes #123`) so the
    issue appears under "Successfully merging this pull request may close these
    issues" on GitHub.
-5. **Report the PR URL** in the final response.
+6. **Report the PR URL** in the final response.
 
 ## Safety Rules
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ contents and usage:
 - [Chords Codegen Runtime](codegen/runtime) — an auxiliary library, which is
   technically needed at runtime by the Chords Proto and Chords Client libraries
   for them to be able to gain advantage of Chords code generation facilities
-  which enrich the Protobuf message APIs.
+  that enrich the Protobuf message APIs.
 
 # Supported environment
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunCodegenPlugins.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunCodegenPlugins.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 
 /**
- * A Gradle task which runs `codegen-plugins` in a separate Gradle process.
+ * A Gradle task that runs `codegen-plugins` in a separate Gradle process.
  *
  * Launches Gradle wrapper under a [workspaceDir] with the
  * specified [taskNames] and [dependencies].

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,7 +246,7 @@ public interface Client {
      *
      * @param command The command that should be posted.
      * @param consequences A configuration of possible consequences and their
-     *   respective  handlers.
+     *   respective handlers.
      * @return An object, which allows managing (e.g. cancelling) all event
      *   subscriptions made by this method according to the
      *   [consequences] parameter.

--- a/client/src/main/kotlin/io/spine/chords/client/CommandConsequences.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/CommandConsequences.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,7 +323,7 @@ public open class CommandConsequencesScopeImpl<out C: CommandMessage>(
 ) : CommandConsequencesScope<C> {
 
     /**
-     * Allows to manage subscriptions made in this scope.
+     * Allows managing subscriptions made in this scope.
      */
     private val subscriptions: EventSubscriptions = object : EventSubscriptions {
         override fun cancelAll() {

--- a/client/src/main/kotlin/io/spine/chords/client/appshell/ClientApplication.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/appshell/ClientApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public val Application.client: Client get() = (app as ClientApplication).client
  * @param client A [Client] that handles the server communication, which should be
  *   used throughout the application.
  * @param views The list of application's views.
- * @param initialView Allows to specify a view from the list of [views], if any view other
+ * @param initialView Allows specifying a view from the list of [views], if any view other
  *   than the first one has to be displayed when the application starts.
  * @param minWindowSize The minimal size of the application window.
  */

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import io.spine.protobuf.ValidatingBuilder
  * the respective command.
  *
  * It can be used in the same way as the [MessageForm] class, and adds
- * the [postCommand] function, which post the command with the entered field
+ * the [postCommand] function, which posts the command with the entered field
  * values, and awaits for receiving the feedback upon its processing.
  *
  * Please see the [MessageForm]'s documentation, which applies to
@@ -175,7 +175,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
          * @param builder A lambda that should create and return a new builder
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
-         * @param onBeforeBuild A lambda that allows to amend the command
+         * @param onBeforeBuild A lambda that allows amending the command
          *   message after any valid field is entered to it.
          * @param props A lambda that can set any additional props on the form.
          * @param content A form's content, which can contain an arbitrary
@@ -220,7 +220,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
          * @param value The command message value to be edited within the form.
          * @param builder A lambda that should create and return a new builder
          *   for a command message of type [C].
-         * @param onBeforeBuild A lambda that allows to amend the command
+         * @param onBeforeBuild A lambda that allows amending the command
          *   message after any valid field is entered to it.
          * @param props A lambda that can set any additional props on the form.
          * @param content A form's content, which can contain an arbitrary
@@ -255,7 +255,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
          *
          * This method can be used to create a form's instance outside
          * a composable context, and render it separately. A form's instance
-         * created in this way, has to be rendered  explicitly by calling either
+         * created in this way, has to be rendered explicitly by calling either
          * its [Content] method (for single-part forms) or its
          * [MultipartContent] method (for rendering a multipart form) in
          * a composable context where it needs to be displayed.
@@ -273,7 +273,7 @@ public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {
          * @param builder A lambda that should create and return a new builder
          *   for a command of type [C].
          * @param value The command message value to be edited within the form.
-         * @param onBeforeBuild A lambda that allows to amend the command
+         * @param onBeforeBuild A lambda that allows amending the command
          *   message after any valid field is entered to it. Note that this
          *   callback is invoked repeatedly as the user edits the form and its
          *   implementation should avoid long or performance-intensive

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -208,7 +208,7 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
     protected abstract fun ModalCommandConsequencesScope<C>.commandConsequences()
 
     /**
-     * Allows to programmatically amend the command message builder before
+     * Allows programmatically amending the command message builder before
      * the command is built.
      *
      * This function is invoked upon every attempt to build the command edited

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,7 +182,7 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
     protected abstract fun ModalCommandConsequencesScope<C>.commandConsequences()
 
     /**
-     * Allows to programmatically amend the command message builder before
+     * Allows programmatically amending the command message builder before
      * the command is built.
      *
      * This function is invoked upon every attempt to build the command edited

--- a/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import io.spine.chords.core.layout.MessageDialog.Companion.showMessage
 import kotlin.time.Duration
 
 /**
- * A specialized type of [CommandConsequences] which simplify specifying
+ * A specialized type of [CommandConsequences] that simplifies specifying
  * command consequences for commands posted by model UIs (such as dialogs
  * or wizards).
  *
@@ -133,7 +133,7 @@ import kotlin.time.Duration
  * @param postingState A "posting" state of the UI that backs this object.
  * @param close A lambda that closes the UI that backs this object.
  * @param consequences A lambda, which uses the [ModalCommandConsequencesScope]
- *   API to define consequences which are possible as a result of posting
+ *   API to define consequences that are possible as a result of posting
  *   commands of type [C] along with respective handlers.
  */
 @Suppress("UNCHECKED_CAST")
@@ -202,7 +202,7 @@ public open class ModalCommandConsequences<C : CommandMessage>(
          *   this object.
          * @param close A lambda that closes the UI that backs this object.
          * @param consequences A lambda, which uses the
-         *   [ModalCommandConsequencesScope] API to define consequences which
+         *   [ModalCommandConsequencesScope] API to define consequences that
          *   are possible as a result of posting commands of type [C] along with
          *   respective handlers.
          * @return The [ModalCommandConsequences] instance that was created.

--- a/codegen/plugins/README.md
+++ b/codegen/plugins/README.md
@@ -1,6 +1,6 @@
 # `codegen-plugins`
 
-A separate Gradle project with ProtoData plugins which generate
+A separate Gradle project with ProtoData plugins that generate
 [MessageField](../runtime/src/main/kotlin/io/spine/chords/runtime/MessageField.kt),
 [MessageOneof](../runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt),
 and [MessageDef](../runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt)

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/build/FindBugs.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/build/FindBugs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ package io.spine.dependency.build
  * The FindBugs project is dead since 2017. It has a successor called SpotBugs, but we don't use it.
  * We use ErrorProne for static analysis instead. The only reason for having this dependency is
  * the annotations for null-checking introduced by JSR-305. These annotations are troublesome,
- * but no alternatives are known for some of them so far.  Please see
+ * but no alternatives are known for some of them so far. Please see
  * [this issue](https://github.com/SpineEventEngine/base/issues/108) for more details.
  */
 @Suppress("unused", "ConstPropertyName")

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsCli.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsCli.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 package io.spine.dependency.lib
 
 /**
- * Commons CLI is a transitive dependency which we don't use directly.
+ * Commons CLI is a transitive dependency that we don't use directly.
  * We `force` it in [forceVersions].
  *
  * [Commons CLI](https://commons.apache.org/proper/commons-cli/)

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsLogging.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsLogging.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ package io.spine.dependency.lib
 
 /**
  * [Commons Logging](https://commons.apache.org/proper/commons-logging/) is a transitive
- * dependency which we don't use directly. This object is used for forcing the version.
+ * dependency that we don't use directly. This object is used for forcing the version.
  */
 @Suppress("unused", "ConstPropertyName")
 object CommonsLogging {

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/Gson.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/Gson.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 package io.spine.dependency.lib
 
 /**
- * Gson is a transitive dependency which we don't use directly.
+ * Gson is a transitive dependency that we don't use directly.
  * We `force` it in [DependencyResolution.forceConfiguration()].
  *
  * [Gson](https://github.com/google/gson)

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/J2ObjC.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/J2ObjC.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ package io.spine.dependency.lib
 
 /**
  * [J2ObjC](https://developers.google.com/j2objc) is a transitive dependency
- * which we don't use directly. This object is used for forcing the version.
+ * that we don't use directly. This object is used for forcing the version.
  */
 @Suppress("unused", "ConstPropertyName")
 object J2ObjC {

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ package io.spine.dependency.lib
 
 @Suppress("unused", "ConstPropertyName")
 object JavaX {
-    // This artifact which used to be a part of J2EE moved under Eclipse EE4J project.
+    // This artifact that used to be a part of J2EE moved under Eclipse EE4J project.
     // https://github.com/eclipse-ee4j/common-annotations-api
     const val annotations = "javax.annotation:javax.annotation-api:1.3.2"
 

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/Repositories.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ fun applyWithStandard(
  * @param shortRepositoryName
  *          the short name of the GitHub repository (e.g. "core-java")
  * @param project
- *          the project which is going to consume artifacts from the repository
+ *          the project that is going to consume artifacts from the repository
  * @see applyGitHubPackages
  */
 @Suppress("unused")
@@ -115,7 +115,7 @@ fun doApplyStandard(repositories: RepositoryHandler) = repositories.standardToSp
  * @param shortRepositoryName
  *          short names of the GitHub repository (e.g. "base", "core-java", "model-tools")
  * @param project
- *          the project which is going to consume artifacts from repositories
+ *          the project that is going to consume artifacts from repositories
  */
 fun RepositoryHandler.applyGitHubPackages(shortRepositoryName: String, project: Project) {
     val repository = gitHub(shortRepositoryName)
@@ -136,7 +136,7 @@ fun RepositoryHandler.applyGitHubPackages(shortRepositoryName: String, project: 
  * @param shortRepositoryName
  *          the short name of the GitHub repository (e.g. "core-java")
  * @param project
- *          the project which is going to consume or publish artifacts from
+ *          the project that is going to consume or publish artifacts from
  *          the registered repository
  */
 fun RepositoryHandler.applyGitHubPackages(project: Project, vararg shortRepositoryName: String) {

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/RunCodegenPlugins.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/RunCodegenPlugins.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 
 /**
- * A Gradle task which runs `codegen-plugins` in a separate Gradle process.
+ * A Gradle task that runs `codegen-plugins` in a separate Gradle process.
  *
  * Launches Gradle wrapper under a [workspaceDir] with the
  * specified [taskNames] and [dependencies].

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ private fun Project.readGitHubToken(): String {
 }
 
 /**
- * Read the personal access token for the `developers@spine.io` account which
+ * Read the personal access token for the `developers@spine.io` account that
  * has only the permission to read public GitHub packages.
  *
  * The token is extracted from the archive called `aus.weis` stored under `buildSrc`.

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/JarDsl.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/JarDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 package io.spine.gradle.publish
 
 /**
- * A DSL element of [SpinePublishing] extension which allows enabling publishing
+ * A DSL element of [SpinePublishing] extension that allows enabling publishing
  * of [testJar] artifact.
  *
  * This artifact contains compilation output of `test` source set. By default, it is not published.
@@ -50,7 +50,7 @@ class TestJar {
 }
 
 /**
- * A DSL element of [SpinePublishing] extension which allows disabling publishing
+ * A DSL element of [SpinePublishing] extension that allows disabling publishing
  * of [protoJar] artifact.
  *
  * This artifact contains all the `.proto` definitions from `sourceSets.main.proto`. By default,

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/Publications.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/Publications.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ internal class StandardJavaPublicationHandler(
  * which is <em>created</em> for a module. Instead, since the publications are already declared,
  * this class only [assigns maven coordinates][copyProjectAttributes].
  *
- * A module which declares custom publications must be specified in
+ * A module that declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.
  *
  * If a module with [publications] declared locally is not specified as one with custom publishing,

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,7 +242,7 @@ internal fun TaskContainer.getOrCreate(name: String, init: Jar.() -> Unit): Task
  * Obtains as a set of [Jar] tasks, output of which is used as Maven artifacts.
  *
  * By default, only a jar with Java compilation output is included into publication. This method
- * registers tasks which produce additional artifacts according to the values of [jarFlags].
+ * registers tasks that produce additional artifacts according to the values of [jarFlags].
  *
  * @return the list of the registered tasks.
  */

--- a/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
+++ b/codegen/plugins/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ import org.gradle.kotlin.dsl.findByType
  * }
  * ```
  *
- * It is worth to mention, that publishing of a module can be configured only from a single place.
+ * It is worth mentioning, that publishing of a module can be configured only from a single place.
  * For example, declaring `subprojectA` as published in a root project and opening
  * `spinePublishing` extension within `subprojectA` itself would lead to an exception.
  *

--- a/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefFileGenerator.kt
+++ b/codegen/plugins/codegen-plugins/src/main/kotlin/io/spine/chords/codegen/plugins/MessageDefFileGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ internal class MessageDefFileGenerator(
     }
 
     /**
-     * The list of [FileFragmentGenerator]s which are used to generate the file.
+     * The list of [FileFragmentGenerator]s that are used to generate the file.
      */
     private val codeGenerators = listOf(
         MessageDefObjectGenerator(messageTypeName, fields, typeSystem),

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageDef.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ package io.spine.chords.runtime
 import com.google.protobuf.Message
 
 /**
- * Allows to access the fields of a Proto message at runtime.
+ * Allows accessing the fields of a Proto message at runtime.
  *
  * The codegen plugin relies onto this interface as well.
  *

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageField.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public typealias MessageFieldValue = Any
 
 
 /**
- * Allows to access the value of the field in a Proto message at runtime.
+ * Allows accessing the value of the field in a Proto message at runtime.
  *
  * The codegen plugin relies on this interface as well.
  *

--- a/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt
+++ b/codegen/runtime/src/main/kotlin/io/spine/chords/runtime/MessageOneof.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ package io.spine.chords.runtime
 import com.google.protobuf.Message
 
 /**
- * Allows to access the value of the oneof field in a Proto message at runtime.
+ * Allows accessing the value of the oneof field in a Proto message at runtime.
  *
  * The codegen plugin relies onto this interface as well.
  *

--- a/core/src/main/kotlin/io/spine/chords/core/Component.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/Component.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -541,7 +541,7 @@ import kotlinx.coroutines.launch
  *
  * These recommendations are optional, but can be considered in cases when UI's
  * performance becomes an issue for some components or when you're creating
- * components which are going to be widely reusable.
+ * components that are going to be widely reusable.
  *
  * Just like for any other composable function, Compose decides whether to
  * invoke the [Component.content] function along with the parent's composition
@@ -615,7 +615,7 @@ public abstract class Component : DefaultPropsOwnerBase() {
     internal var props: Props<Component>? = null
 
     /**
-     * A state variable which specifies whether the component's [initialize]
+     * A state variable that specifies whether the component's [initialize]
      * method has been called.
      */
     private val initialized = mutableStateOf(false)

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownListBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,7 +228,7 @@ public class DropdownListBox<I> : Component() {
     public var noneItemText: String = "<None>"
 
     /**
-     * Boolean which indicates if drop-down list should contain none item.
+     * Boolean that indicates if drop-down list should contain none item.
      */
     public var noneItemEnabled: Boolean = true
 
@@ -505,7 +505,7 @@ public class DropdownListBox<I> : Component() {
     }
 
     /**
-     * Determines should the drop-down list be shown above or below layout which
+     * Determines should the drop-down list be shown above or below layout that
      * expands it and maximum available height that drop-down list can have.
      */
     private fun calculateDropdownListPosition() {
@@ -587,7 +587,7 @@ public class DropdownListBox<I> : Component() {
      * Handles user's click on drop-down list item.
      *
      * @param item
-     *         the drop-down list item which is clicked.
+     *         the drop-down list item that is clicked.
      */
     private fun handleItemClick(item: I) {
         onSelectItem(item)
@@ -598,7 +598,7 @@ public class DropdownListBox<I> : Component() {
      * Handles user's key presses whether drop-down list is expanded or not.
      *
      * @param event
-     *         a key event which occurs when user presses key.
+     *         a key event that occurs when user presses key.
      */
     private fun handleDropdownKeyEvent(event: KeyEvent): Boolean {
         if (expanded.value) {
@@ -636,7 +636,7 @@ public class DropdownListBox<I> : Component() {
      * Handles user's key presses when drop-down list is expanded.
      *
      * @param event
-     *         a key event which occurs when user presses key.
+     *         a key event that occurs when user presses key.
      */
     private fun handleKeyEventWhenDropdownExpanded(event: KeyEvent): Boolean {
         var stopPropagation = false
@@ -711,7 +711,7 @@ public class DropdownListBox<I> : Component() {
      * Handles user's printable key presses when drop-down list is expanded.
      *
      * @param event
-     *         a key event which occurs when user presses key.
+     *         a key event that occurs when user presses key.
      */
     private fun handleKeyEvent(event: KeyEvent) {
         val keyEvent = event.awtEventOrNull
@@ -727,7 +727,7 @@ public class DropdownListBox<I> : Component() {
      * Handles user's key presses when search selection field is shown.
      *
      * @param event
-     *         a key event which occurs when user presses key.
+     *         a key event that occurs when user presses key.
      */
     private fun handleKeyEventWhenSearchSelectionIsShown(event: KeyEvent): Boolean {
         var stopPropagation = false
@@ -1057,7 +1057,7 @@ public class DropdownListBox<I> : Component() {
  * Trim whitespace characters except space from input string.
  *
  * @param input
- *         a string which should be trimmed.
+ *         a string that should be trimmed.
  * @return trimmed string.
  */
 private fun trimWhitespacesExceptSpace(input: String): String {
@@ -1079,7 +1079,7 @@ public interface DropdownListBoxScope {
      * by invoking this function.
      *
      * @param event
-     *         a key event which occurs when user presses key.
+     *         a key event that occurs when user presses key.
      */
     public fun handleKeyEvent(event: KeyEvent): Boolean
 
@@ -1095,7 +1095,7 @@ public interface DropdownListBoxScope {
      * if the invoker has any.
      *
      * Function that should be called by [Modifier.onGloballyPositioned]
-     * modifier of [Text] composable which represents supporting text of the
+     * modifier of [Text] composable that represents supporting text of the
      * invoker that is placed inside the scope.
      */
     public fun adjustPositionBasedOnSupportingTextHeight(height: Int)
@@ -1116,15 +1116,15 @@ public interface DropdownListBoxScope {
  * Implementation of [DropdownListBoxScope], which is used by [DropdownListBox].
  *
  * @property onInvokerKeyEvent
- *         a callback which is invoked when user presses key.
+ *         a callback that is invoked when user presses key.
  * @property onInvokerClick
- *         a callback which is invoked when user presses mouse inside the
+ *         a callback that is invoked when user presses mouse inside the
  *         invoker of [DropdownListBox].
  * @property onAdjustPositionBasedOnSupportingTextHeight
- *         a callback which is invoked if the invoker of [DropdownListBox]
+ *         a callback that is invoked if the invoker of [DropdownListBox]
  *         has supporting text.
  * @property onClearSelectedItemPress
- *         a callback which is invoked when user presses mouse on clear
+ *         a callback that is invoked when user presses mouse on clear
  *         selected item icon inside the invoker of [DropdownListBox].
  */
 private class DropdownListBoxScopeImpl(
@@ -1157,7 +1157,7 @@ private class DropdownListBoxScopeImpl(
  * @param onClick
  *         the callback that is triggered when the item is clicked.
  * @param onMeasureHeight
- *         callback which is invoked when item is positioned.
+ *         callback that is invoked when item is positioned.
  * @param color
  *         the background color of drop-down list item.
  * @param content
@@ -1227,7 +1227,7 @@ private fun DropdownListNoItems(content: @Composable (() -> Unit)) {
  * @param color
  *         the background color of drop-down list none item.
  * @param onMeasureHeight
- *         callback which is invoked when item is positioned.
+ *         callback that is invoked when item is positioned.
  * @param onClick
  *         the callback that is triggered when the item is clicked.
  */

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ import java.util.*
  * An implementation of the concrete component has to provide the following:
  * - Implement the [items] property to provide a list of items to choose from.
  * - Implement the [itemText] method to provide a text item's representation,
- *   which is displayed in the drop-down list by default, and which is usedThe
+ *   which is displayed in the drop-down list by default, and which is used
  *   when searching items by typing their content.
  * - By default, dropdown items display the respective item's text as defined by
  *   [itemText], but it's possible to display an arbitrary composable content in
@@ -351,7 +351,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
      * Invoked when the user enters new text in a field in [DropdownSelector].
      *
      * @param searchValue
-     *         a [TextFieldValue] which holds raw text content that was
+     *         a [TextFieldValue] that holds raw text content that was
      *         just modified by the user.
      */
     private fun handleDropdownInputChange(searchValue: TextFieldValue) {
@@ -449,7 +449,7 @@ private fun DropdownListBoxScope.TrailingIcons(
 
 
 /**
- * The `DropdownSelector`'s trailing icon, which allows to clear
+ * The `DropdownSelector`'s trailing icon, which allows clearing
  * the current selection.
  *
  * @param containsValue

--- a/core/src/main/kotlin/io/spine/chords/core/FocusRequestDispatcher.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/FocusRequestDispatcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ import androidx.compose.ui.focus.focusRequester
  *   of receiving such a request.
  *
  *   @param focusRequester
- *           [FocusRequester] which should receive focus requests, if specified.
+ *           [FocusRequester] that should receive focus requests, if specified.
  */
 public class FocusRequestDispatcher(focusRequester: FocusRequester? = null) {
     private val lazyRequester = lazy { focusRequester ?: FocusRequester() }

--- a/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputComponent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ public interface InputContext {
  *
  * #### The "dirty" state
  *
- * An input component also discerns a so called "dirty" state.  An input
+ * An input component also discerns a so-called "dirty" state. An input
  * component is considered to be "dirty" if it contains any entry relative to
  * its `null` [value] state, regardless of whether it is classified to be valid
  * or not.
@@ -171,7 +171,7 @@ public interface InputContext {
  * Whenever the input component transitions from/to the dirty state, it has
  * to invoke the [onDirtyStateChange] callback.
  *
- * @param V A type of values that this input component allows to edit.
+ * @param V A type of values that this input component allows editing.
  *
  * @constructor A constructor, which is used internally by the input component's
  *   implementation. Use [companion object's][ComponentSetup]

--- a/core/src/main/kotlin/io/spine/chords/core/InputField.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/InputField.kt
@@ -92,12 +92,12 @@ public typealias RawTextContent = TextFieldValue
  *
  * A [parseValue] and [formatValue] of `null` means that no custom parsing and
  * formatting takes place, and raw text will reflect whatever is stored in
- * [value] (and vice versa). [parseValue] and [formatValue] are  allowed to be
+ * [value] (and vice versa). [parseValue] and [formatValue] are allowed to be
  * `null` only when [V] is `String`.
  *
  * ### Advanced formatting
  *
- * There are some advanced configuration options that allow to configure how
+ * There are some advanced configuration options that allow configuring how
  * the text entered by the user is processed, parsed/formatted, and displayed.
  * This concerns the optional [inputReviser] and [visualTransformation]
  * properties and their relationship with what is called a raw text (see below).
@@ -158,8 +158,8 @@ public typealias RawTextContent = TextFieldValue
  * Whenever the user makes any change within the field, the field undergoes
  * a two-stage validation mechanism:
  *
- *  - The [value] state is updated Field's raw text is parsed using [parseValue]
- *    to obtain value of type [V].
+ *  - Field's raw text is parsed using [parseValue]
+ *    to obtain a value of type [V].
  *
  *    The value in the [value] [MutableState] is set to a non-`null` value of
  *    type [V] whenever the currently edited field's text (raw text) can
@@ -220,7 +220,7 @@ public typealias RawTextContent = TextFieldValue
  * When both `placeholder` and `promptText` properties are specified, then only
  * the `placeholder` is used.
  *
- * @param V A type of values that an input field allows to edit.
+ * @param V A type of values that an input field allows editing.
  *
  * @constructor A constructor, which is used internally by the input component's
  *   implementation. Use [companion object's][ComponentSetup]
@@ -906,9 +906,9 @@ public interface InputReviser {
      *
      * @param current A [RawTextContent], which represents the
      *   current value of text that field has, before user modification.
-     * @param candidate A [RawTextContent] which holds raw text
+     * @param candidate A [RawTextContent] that holds raw text
      *   content that was just modified by the user.
-     * @return [RawTextContent] which holds revised user input text.
+     * @return [RawTextContent] that holds revised user input text.
      */
     public fun reviseRawTextContent(
         current: RawTextContent,
@@ -917,7 +917,7 @@ public interface InputReviser {
 
     /**
      * A function, which is invoked when user presses any key inside
-     * input field, which has ability to stop further propagation of pressed
+     * input field, which has an ability to stop further propagation of pressed
      * key event.
      *
      * This function should only make decision whether to stop propagation of
@@ -926,7 +926,7 @@ public interface InputReviser {
      * for implementing sophisticated key processing logic for purposes
      * other than key event filtering.
      *
-     * @param keyEvent A key event which occurs when user presses key.
+     * @param keyEvent A key event that occurs when user presses key.
      * @return `true` if [keyEvent] should be stopped from
      *         further propagation, `false` otherwise.
      */

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ import java.awt.Dimension
  * @param signInScreenContent A content for the [SignInScreen].
  * @param views The list of [AppView]s that will be selectively displayed
  * on the [MainScreen] screen.
- * @param initialView Allows to specify a view from the list of `views`, if any
+ * @param initialView Allows specifying a view from the list of `views`, if any
  *   view other than the first one has to be displayed when
  *   the application starts.
  * @param onCloseRequest An action that should be performed on window closing.

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,7 @@ public var app: Application by writeOnce(false)
  * @param name An application's name, which is in particular displayed in
  *   the application window's title.
  * @param views The list of application's views.
- * @param initialView Allows to specify a view from the list of [views], if any
+ * @param initialView Allows specifying a view from the list of [views], if any
  *   view other than the first one has to be displayed when the application starts.
  * @param minWindowSize The minimal size of the application window.
  */

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/MainScreen.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/MainScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import cafe.adriel.voyager.navigator.Navigator
  * functionality provided by the Voyager multiplatform navigation library.
  * See [AppWindow] for detail on how to display a screen.
  *
- * Provides internal API which allows selecting one of the [AppView]s
+ * Provides internal API that allows selecting one of the [AppView]s
  * to be displayed on the main screen.
  *
  * @param appViews The list of [AppView]s that will be selectively displayed on the screen.

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/SharedDefaults.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/SharedDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public interface SharedDefaultsScope {
 /**
  * An implementation of [SharedDefaultsScope], which serves as a registry for
  * component defaults that were configured to be applicable across the entire
- * application, and provides an API that allows to apply the default properties
+ * application, and provides an API that allows applying the default properties
  * to components.
  */
 internal class SharedDefaults : SharedDefaultsScope {

--- a/core/src/main/kotlin/io/spine/chords/core/keyboard/Keystroke.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/keyboard/Keystroke.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,7 +217,7 @@ public open class KeyRange internal constructor(
         }
 
     /**
-     * Creates [KeyRange] which checks whether the key that triggered
+     * Creates [KeyRange] that checks whether the key that triggered
      * the passed [KeyEvent] belongs to any of the keys represented
      * by this [KeyRange] or any of the keys represented by [other] [KeyRange].
      *
@@ -231,7 +231,7 @@ public open class KeyRange internal constructor(
     }
 
     /**
-     * Creates [KeyRange] which checks whether the key that triggered
+     * Creates [KeyRange] that checks whether the key that triggered
      * the passed [KeyEvent] belongs to any of the keys represented
      * by this [KeyRange] and any of the keys represented by [other] [KeyRange].
      *
@@ -245,7 +245,7 @@ public open class KeyRange internal constructor(
     }
 
     /**
-     * Creates [KeyRange] which checks whether the key that triggered
+     * Creates [KeyRange] that checks whether the key that triggered
      * the passed [KeyEvent] doesn't belong to any of the keys represented
      * by this [KeyRange].
      *

--- a/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/table/Table.kt
@@ -181,7 +181,7 @@ public abstract class Table<E> : Component() {
     public var columns: List<TableColumn<E>> by mutableStateOf(listOf())
 
     /**
-     * A callback that allows to modify any row behaviour and style.
+     * A callback that allows modifying any row behavior and style.
      *
      * An entity displayed in a row comes as a parameter of a callback.
      */

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 12:22:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 14:19:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Tue Jul 28 12:22:09 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 12:22:11 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 14:19:18 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Tue Jul 28 12:22:11 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 12:22:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 14:19:19 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Tue Jul 28 12:22:12 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 12:22:13 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 14:19:20 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Tue Jul 28 12:22:13 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 12:22:14 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 14:19:21 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Tue Jul 28 12:22:14 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 12:22:16 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 28 14:19:21 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.95</version>
+<version>2.0.0-SNAPSHOT.96</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto-values/src/main/kotlin/io/spine/chords/proto/value/person/PersonNameExts.kt
+++ b/proto-values/src/main/kotlin/io/spine/chords/proto/value/person/PersonNameExts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public fun KClass<PersonName>.parse(nameString: String): PersonName {
  * of [PersonName]. Values of other fields are not taken into account.
  *
  * @receiver a person name that should be formatted as a string.
- * @return a string which contains the given name and family name from
+ * @return a string that contains the given name and family name from
  *         the [PersonName] value on which this function was invoked.
  */
 public fun PersonName.format(): String {

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/CustomMessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/CustomMessageForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import io.spine.chords.core.Component
  * A base class, which should be used for implementing custom form components
  * that edit values of some specific type [M].
  *
- * Custom components which extend this class can have the same capabilities as
+ * Custom components that extend this class can have the same capabilities as
  * [MessageForm], but they would typically not require the user (developer) to
  * provide a message's builder and the content (message field editors) for the
  * form, since they would be a part of the custom form's implementation itself.

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -450,7 +450,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param builder A lambda that should create and return a new builder
          *   for a message of type [M].
          * @param props A lambda that can set any additional props on the form.
-         * @param onBeforeBuild A lambda that allows to amend the message
+         * @param onBeforeBuild A lambda that allows amending the message
          *   after any valid field is entered to it.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
@@ -498,7 +498,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param props A lambda that can set any additional props on the form.
          * @param defaultValue A value that should be displayed in the form
          *   by default.
-         * @param onBeforeBuild A lambda that allows to amend the message
+         * @param onBeforeBuild A lambda that allows amending the message
          *   after any valid field is entered to it.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
@@ -549,7 +549,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param builder A lambda that should create and return a new builder
          *   for a message of type [M].
          * @param props A lambda that can set any additional props on the form.
-         * @param onBeforeBuild A lambda that allows to amend the message
+         * @param onBeforeBuild A lambda that allows amending the message
          *   after any valid field is entered to it.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
@@ -599,7 +599,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param props A lambda that can set any additional props on the form.
          * @param defaultValue A value that should be displayed in the form
          *   by default.
-         * @param onBeforeBuild A lambda that allows to amend the message
+         * @param onBeforeBuild A lambda that allows amending the message
          *   after any valid field is entered to it.
          * @param content A form's content, which can contain an arbitrary
          *   layout along with field editor declarations.
@@ -640,7 +640,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          *
          * This method can be used to create a form's instance outside
          * a composable context, and render it separately. A form's instance
-         * created in this way, has to be rendered  explicitly by calling either
+         * created in this way, has to be rendered explicitly by calling either
          * its [Content] method (for singlepart forms) or its
          * [MultipartContent] method (for rendering a multipart form) in
          * a composable context where it needs to be displayed.
@@ -659,7 +659,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * @param value The message value to be edited within the form.
          * @param builder A lambda that should create and return a new builder
          *   for a message of type [M].
-         * @param onBeforeBuild A lambda that allows to amend the message
+         * @param onBeforeBuild A lambda that allows amending the message
          *   after any valid field is entered to it.
          * @param props A lambda that can set any additional props on the form.
          * @return A form's instance that has been created for this
@@ -1077,7 +1077,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
     public var validationDisplayMode: ValidationDisplayMode by mutableStateOf(DEFAULT)
 
     /**
-     * Allows to programmatically amend the message builder before the message
+     * Allows programmatically amending the message builder before the message
      * is built.
      *
      * See the "The `onBeforeBuild` callback" section in the
@@ -1227,7 +1227,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * A "dirty" state means that a component currently displays any data
      * (either valid or invalid). For the form this means that any of its fields
      * display any valid or invalid data (e.g. even if the user has entered
-     * something which is not valid so far).
+     * something that is not valid so far).
      *
      * A value of `false` means that neither of the form's fields displays
      * any data.
@@ -1534,7 +1534,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * form's validation is also considered to fail.
      *
      * This method states a validation error (sets [valid] to `true`, and
-     * [value] to `null`),  if any of the validation constraints fail during
+     * [value] to `null`), if any of the validation constraints fail during
      * `vBuild()`, or if any fields have their internal validation errors.
      * The form's status is updated to reflect the validation failures before
      * the exception is thrown, which can include focusing the respective field
@@ -1832,7 +1832,7 @@ public enum class ValidationDisplayMode {
      * the [LIVE] value.
      *
      * If there is a parent form, the validation display mode is the same as
-     * that of the parent form. Thus, this allows to "inherit" validation
+     * that of the parent form. Thus, this allows "inheriting" validation
      * behavior from the parent form. For convenience, in `MessageForm`
      * documentation, the form's mode when it is either set to [LIVE] explicitly
      * or is set to [DEFAULT] but inherits [LIVE] from the parent is said to be

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormScopes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ internal class MultipartFormScopeImpl<M : Message>(
  * A kind of scope where form field editors can be declared
  * (using the [Field] function).
  *
- * This is a base type which roots its more concrete ancestors, which represent
+ * This is a base type that roots its more concrete ancestors, which represent
  * different contexts where fields can be declared (see [FormPartScope]
  * and [OneOfFieldsScope]).
  *
@@ -360,10 +360,10 @@ public sealed interface FormFieldScope<V : MessageFieldValue> {
 
     /**
      * If the value editor is implemented as a class-based component (descendant
-     * from [InputComponent]), it's recommended to register registers the given
+     * from [InputComponent]), it's recommended to register the given
      * `ValueEditor` instance by invoking this function.
      *
-     * Such registration allows to perform deep hierarchical validation
+     * Such registration allows performing deep hierarchical validation
      * activities that need to work on the whole hierarchy of forms (or other
      * value editors).
      */

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetupBase.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageFormSetupBase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
      * @param builder A lambda that should create and return a new builder for
      *   a message of type [M].
      * @param props A lambda that can set any additional props on the form.
-     * @param onBeforeBuild A lambda that allows to amend the message
+     * @param onBeforeBuild A lambda that allows amending the message
      *   after any valid field is entered to it.
      * @param content A form's content, which can contain an arbitrary
      *   layout along with field editor declarations.
@@ -101,7 +101,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
      * @param props A lambda that can set any additional props on the form.
      * @param defaultValue A value that should be displayed in the form
      *   by default.
-     * @param onBeforeBuild A lambda that allows to amend the message
+     * @param onBeforeBuild A lambda that allows amending the message
      *   after any valid field is entered to it.
      * @param content A form's content, which can contain an arbitrary
      *   layout along with field editor declarations.
@@ -140,7 +140,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
      * @param builder A lambda that should create and return a new builder
      *   for a message of type [M].
      * @param props A lambda that can set any additional props on the form.
-     * @param onBeforeBuild A lambda that allows to amend the message
+     * @param onBeforeBuild A lambda that allows amending the message
      *   after any valid field is entered to it.
      * @param content A form's content, which can contain an arbitrary
      *   layout along with field editor declarations.
@@ -192,7 +192,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
      *   for a message of type [M].
      * @param props A lambda that can set any additional props on the form.
      * @param defaultValue A value that should be displayed in the form by default.
-     * @param onBeforeBuild A lambda that allows to amend the message
+     * @param onBeforeBuild A lambda that allows amending the message
      *   after any valid field is entered to it.
      * @param content A form's content, which can contain an arbitrary
      *   layout along with field editor declarations.
@@ -233,7 +233,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
      *
      * This method can be used to create a form's instance outside
      * a composable context, and render it separately. A form's instance
-     * created in this way, has to be rendered  explicitly by calling either
+     * created in this way, has to be rendered explicitly by calling either
      * its [Content][MessageForm.Content] method (for singlepart forms) or its
      * [MultipartContent][MessageForm.MultipartContent] method (for rendering a
      * multipart form) in a composable context where it needs to be displayed.
@@ -251,7 +251,7 @@ public open class MessageFormSetupBase<M: Message, F: MessageForm<M>>(
      * @param value The message value to be edited within the form.
      * @param builder A lambda that should create and return a new builder
      *   for a message of type [M].
-     * @param onBeforeBuild A lambda that allows to amend the message
+     * @param onBeforeBuild A lambda that allows amending the message
      *   after any valid field is entered to it.
      * @param props A lambda that can set any additional props on the form.
      * @return A form's instance that has been created for this

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,7 +323,7 @@ internal class MoneyFieldReviser(
      *   text input value and cursor position.
      * @param candidate A [RawTextContent] that encapsulates
      *   updated text input value and updated cursor position.
-     * @return [RawTextContent] which contains updated text input and updated
+     * @return [RawTextContent] that contains updated text input and updated
      *   cursor input position.
      */
     private fun updateCandidateWhenTextIsSelected(
@@ -374,7 +374,7 @@ internal class MoneyFieldReviser(
      *   value and cursor position.
      * @param candidate A [RawTextContent] that encapsulates updated text input
      *   value and updated cursor position.
-     * @return [RawTextContent] which contains updated text input and
+     * @return [RawTextContent] that contains updated text input and
      *   updated cursor input position.
      */
     private fun updateCandidateWhenTextIsNotSelected(
@@ -430,7 +430,7 @@ internal class MoneyFieldReviser(
      *   value and cursor position.
      * @param rawCandidate A [RawTextContent] that encapsulates updated text
      *   input value and updated cursor position.
-     * @return [RawTextContent] which contains revised text input and
+     * @return [RawTextContent] that contains revised text input and
      *   updated cursor input position.
      */
     private fun updateDecimalPart(
@@ -498,7 +498,7 @@ internal class MoneyFieldReviser(
      *   value and cursor position.
      * @param candidate A [RawTextContent] that encapsulates updated text input
      *   value and cursor position that should be sanitized.
-     * @return [RawTextContent] which holds updated cursor position and
+     * @return [RawTextContent] that holds updated cursor position and
      *         sanitized modification of [rawTextCandidate] text value.
      */
     private fun sanitizeMoneyField(
@@ -536,19 +536,19 @@ internal class MoneyFieldReviser(
 
     /**
      * Sanitizes amount part of money string, which includes removing
-     * non-digit characters which are not first detected decimal separator
+     * non-digit characters that are not first detected decimal separator
      * character, and based on those removed characters calculates by how much
      * input cursor position should be updated.
      *
-     * Calculates an input cursor offset which represents number of whitespace
+     * Calculates an input cursor offset that represents a number of whitespace
      * characters that can be trimmed in new text input value, and it calculates
-     * trim start offset which is number of whitespace characters
+     * trim start offset that is a number of whitespace characters
      * at the beginning of new text input value.
      *
      * @param currentRawTextContent
      *         a current [RawTextContent], which is used to determine if user
      *         has selected part of input text that starts from the beginning
-     *         of the input which is getting modified. If yes, then check is
+     *         of the input that is getting modified. If yes, then check is
      *         being done to see if there are any whitespace characters at
      *         the beginning of new text input value [rawTextCandidate].
      * @param rawTextContentCandidate
@@ -626,7 +626,7 @@ internal class MoneyFieldReviser(
     }
 
     /**
-     * Returns amount after decimal separator which is filled with additional
+     * Returns amount after decimal separator that is filled with additional
      * '0's if size of decimal part candidate is less than it is defined by
      * currency, or empty string if currency doesn't have decimal separator.
      *

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeField.kt
@@ -619,7 +619,7 @@ private fun complementWithPattern(rawStr: String, pattern: DateTimePattern): Mas
  * to stop propagation of specific key events for [DateTimeField].
  *
  * @property dateTimePattern
- *         a date/time pattern which is used by [DateTimeField].
+ *         a date/time pattern that is used by [DateTimeField].
  */
 internal class DateTimeFieldReviser(
     private val dateTimePattern: DateTimePattern
@@ -657,7 +657,7 @@ internal class DateTimeFieldReviser(
      *   text input value and cursor position.
      * @param rawTextContentCandidate A [RawTextContent] that encapsulates
      *   updated text input value and updated cursor position.
-     * @return [RawTextContent] which contains updated text input and
+     * @return [RawTextContent] that contains updated text input and
      *   updated cursor input position.
      */
     private fun updateCandidateWhenTextIsSelected(
@@ -720,7 +720,7 @@ internal class DateTimeFieldReviser(
      *   text input value and cursor position.
      * @param rawTextContentCandidate A [RawTextContent] that encapsulates
      *   updated text input value and updated cursor position.
-     * @return [RawTextContent] which contains updated text input and
+     * @return [RawTextContent] that contains updated text input and
      *   updated cursor input position.
      */
     private fun updateCandidateWhenTextIsNotSelected(
@@ -769,7 +769,7 @@ internal class DateTimeFieldReviser(
      * @param rawTextContentCandidate
      *         a [RawTextContent] that encapsulates updated text input value
      *         and updated cursor position.
-     * @return [RawTextContent] which contains updated text input and
+     * @return [RawTextContent] that contains updated text input and
      *         updated cursor input position.
      */
     private fun updateRawTextContent(

--- a/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeText.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/time/DateTimeText.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.google.protobuf.Timestamp
 import java.time.format.DateTimeFormatter
 
 /**
- * Renders the given timestamp with the pattern which includes the date
+ * Renders the given timestamp with the pattern that includes the date
  * and time values being interpreted in the system time zone.
  *
  * @param dateTime A dateTime value that should be displayed as text.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.95")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.96")


### PR DESCRIPTION
## Summary

Adds a `proofread` skill that corrects English grammar, punctuation, and
spelling in project-owned comments and documentation, together with the style
catalog and file-ownership boundary it applies. Also lands the skill's first
repository-wide sweep and updates the agent policy for pull request titles.

The repository-wide sweep touches comment and Markdown prose only. Within that
sweep, no code, identifier, string literal, link target, or generated file
changed, and every affected source file stays balanced at equal insertions and
deletions.

## Changes

**Skill, command, and guidelines**

- Add `.agents/skills/proofread/` (`SKILL.md`, `agents/openai.yaml`) and the
  `.claude/commands/proofread.md` entry point. The skill runs in three modes:
  branch diff (default), `all` for a full sweep, or a path for a scoped sweep.
- Add `.agents/guidelines/english-style.md`, the catalog that defines what
  counts as an error and, for each topic, when to leave an occurrence alone.
- Add `.agents/guidelines/project-owned-files.md`, the boundary that keeps any
  sweep out of the `config` submodule and the files it distributes.
- Index the skill in `.agents/skills/README.md`.
- Update `AGENTS.md` to require pull request titles without a trailing period.

**Prose sweep — 47 files**

- Restrictive `which` to `that` where the clause identifies its antecedent,
  leaving non-restrictive and preposition-governed uses alone (~45 places).
- `allows to <verb>` to the gerund form required after `allow` without an
  object, for example `allows to amend` to `allows amending` (~20 places).
- Subject-verb agreement, missing articles, one hyphenation, several double
  spaces, and one dialect outlier (`behaviour` to `behavior` in a file that is
  otherwise American).
- Repair three editing artifacts: a duplicated word, a run-together token, and
  a clause left fused to its replacement.
- Refresh the copyright year to 2026 on every file touched, per `AGENTS.md`.

**Version**

- Bump `chordsVersion` to `2.0.0-SNAPSHOT.96` and regenerate the `pom.xml` and
  `dependencies.md` reports.
