### PR TITLE
Implement handling marginal data observation states

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,6 +33,44 @@ which includes a server connection. This way, a `Client` API is made accessible
 via the [app.client](src/main/kotlin/io/spine/chords/client/appshell/ClientApplication.kt)
 property, which is available globally.
 
+### Observing server data and connection status
+
+The `readAndObserve()` and `readOneAndObserve()` functions return a
+[`DataObservation`](src/main/kotlin/io/spine/chords/client/Client.kt). A data
+observation is a Compose `State`, so it supports ordinary property delegation:
+
+```kotlin
+val projects by app.client.readAndObserve(
+    Project::class.java,
+    Project::getId
+)
+```
+
+If the server connection is lost, an observation retains its last value. After
+the connection is restored, it automatically re-reads its complete value and
+creates a new subscription. Consumers can inspect `DataObservation.status`
+when they need to distinguish active, waiting, refreshing, failed, and
+cancelled observations.
+
+The caller owns each observation's lifecycle. Call `DataObservation.cancel()`
+when an observation is no longer needed so its server subscription and
+automatic recovery registration can be released.
+
+Failures that are not classified as temporary connection loss produce a
+`DataObservationStatus.Failed` status. They are not retried during later
+connection cycles. After resolving the cause, call `DataObservation.refresh()`
+explicitly to retry the observation.
+
+Applications can collect `Client.connectionStatus` to show connection-wide UI:
+
+```kotlin
+val connectionStatus by app.client.connectionStatus.collectAsState()
+```
+
+The status distinguishes connecting, connected, temporarily unavailable, and
+closed clients. It lets applications notify users while ordinary data
+observations recover automatically.
+
 ### Server-aware components
 
 This library also introduces some components that leverage 

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -37,6 +37,7 @@ import io.spine.client.CompositeEntityStateFilter
 import io.spine.client.CompositeQueryFilter
 import io.spine.core.UserId
 import kotlin.time.Duration
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Provides an API for interacting with the application server.
@@ -51,36 +52,53 @@ public interface Client {
     public val isOpen: Boolean
 
     /**
+     * The current status of the connection with the server.
+     *
+     * This status is independent from [isOpen]. An open client can temporarily
+     * have an unavailable connection and reconnect later.
+     */
+    public val connectionStatus: StateFlow<ConnectionStatus>
+
+    /**
      * The ID of the user on whose behalf this `Client` should send requests to
      * the server.
      */
     public val userId: UserId?
 
     /**
-     * Reads the list of entities with the [entityClass] class and returns the
-     * respective [State], which is maintained to contain an up-to-date list.
+     * Reads the list of entities with the [entityClass] class and returns an
+     * observation that maintains an up-to-date list.
+     *
+     * If the connection with the server is lost, the returned observation
+     * retains the last received list. It automatically re-reads the complete
+     * list and creates a new subscription when the connection is restored.
+     * Call [DataObservation.cancel] when the observation is no longer needed.
      *
      * @param E A type of entities being read and observed.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of
      *   the entity's ID.
-     * @return A [State] that contains a list whose content should be populated
-     *   and kept up to date by this function.
+     * @return An observation that contains the current list and its
+     *   observation status.
      */
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any
-    ): State<List<E>>
+    ): DataObservation<List<E>>
 
     /**
      * Reads all entities of type [entityClass] that match the given
-     * [queryFilter] and invokes the [onNext] callback with the initial list of
-     * entities. Then sets up observation to receive future updates to the
+     * [queryFilter]. Then sets up observation to receive future updates to the
      * entities, filtering the observed updates using the provided
-     * [observeFilter]. Each time any entity that matches the [observeFilter]
-     * changes, the [onNext] callback will be invoked again with the updated
-     * list of entities.
+     * [observeFilter].
+     *
+     * If the connection with the server is lost, the returned observation
+     * retains the last received list. It automatically re-reads the complete
+     * list and creates a new subscription when the connection is restored.
+     * Call [DataObservation.cancel] when the observation is no longer needed.
+     *
+     * @param E A type of entities being read and observed.
      *
      * @param entityClass A class of entities that should be read and observed.
      * @param extractId A callback that should read the value of the entity's ID.
@@ -88,30 +106,30 @@ public interface Client {
      *   of entities.
      * @param observeFilter A filter to apply when observing updates to
      *   the entities, whose criteria should match the ones in [queryFilter].
-     * @param onNext A callback function that is called with the list of
-     *   entities after the initial query completes, and each time any of the
-     *   observed entities is updated.
+     * @return An observation that contains the current list and its
+     *   observation status.
      */
     public fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
         queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter,
-        onNext: (List<E>) -> Unit
-    )
+        observeFilter: CompositeEntityStateFilter
+    ): DataObservation<List<E>>
 
     /**
-     * Returns a [State], which maintains an up-to-date entity value according
-     * to the given filter parameters.
+     * Returns an observation that maintains an up-to-date nullable entity value
+     * according to the given filter parameters.
      *
      * Note the following specifics of how special cases are handled:
      * - If more than one entity matches the criteria specified by [queryFilter]
-     * or [observeFilter] parameters, then the returned [State] gets the first
-     * matching value.
-     * - If no entries match the specified criteria, then the
-     * state gets the value of the [defaultValue] parameter, provided that it
-     * contains non-`null` value.
-     * - If [defaultValue] is `null`, then [NoMatchingDataException] is thrown.
+     *   or [observeFilter], the returned observation gets the first matching
+     *   value.
+     * - If no entries match the specified criteria, the value is `null`.
+     *
+     * If the connection with the server is lost, the returned observation
+     * retains the last received value. It automatically re-reads the value and
+     * creates a new subscription when the connection is restored.
+     * Call [DataObservation.cancel] when the observation is no longer needed.
      *
      * @param E A type of entity being read and observed.
      *
@@ -120,20 +138,44 @@ public interface Client {
      * @param queryFilter A filter to use for querying the initial entity value.
      * @param observeFilter A filter to use for observing entity updates, whose
      *   criteria should match the ones in [queryFilter].
-     * @param defaultValue Specifying a non-`null` value prevents this function
-     *   from thrown an exception if no matching records were found by using
-     *   this value as a result.
-     * @return A [State] that contains an up-to-date entity value according to
-     *   the given criteria.
-     * @throws NoMatchingDataException If there is no entity that matches the
-     *   given criteria and there's no non-`null` [defaultValue] provided.
+     * @return An observation that contains an up-to-date entity value according
+     *   to the given criteria, or `null` if no matching entity exists.
+     */
+    public fun <E : EntityState> readOneAndObserve(
+        entityClass: Class<E>,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter
+    ): DataObservation<E?>
+
+    /**
+     * Returns an observation that maintains an up-to-date entity value
+     * according to the given filter parameters.
+     *
+     * This overload guarantees a non-null value by using [defaultValue] when no
+     * entity matches. If several entities match, the first one is used.
+     *
+     * If the connection with the server is lost, the returned observation
+     * retains the last received value. It automatically re-reads the value and
+     * creates a new subscription when the connection is restored.
+     * Call [DataObservation.cancel] when the observation is no longer needed.
+     *
+     * @param E A type of entity being read and observed.
+     *
+     * @param entityClass A class of entity value that should be
+     *   read and observed.
+     * @param queryFilter A filter to use for querying the initial entity value.
+     * @param observeFilter A filter to use for observing entity updates, whose
+     *   criteria should match the ones in [queryFilter].
+     * @param defaultValue A value to use when no matching records were found.
+     * @return An observation that always contains either a matching entity or
+     *   [defaultValue].
      */
     public fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter,
-        defaultValue: E? = null
-    ): State<E>
+        defaultValue: E
+    ): DataObservation<E>
 
     /**
      * Retrieves an entity of the specified class with the given ID.
@@ -150,13 +192,11 @@ public interface Client {
      * Posts a command to the server.
      *
      * @param command A command that has to be posted.
-     * @throws ServerCommunicationException If a net work error has occurred
-     *   when posting a command.
      * @throws ServerError If the command couldn't be acknowledged due to an
      *   error on the server.
      * @throws ServerCommunicationException In case of a network communication
      *   failure that has occurred during posting of the command. It is unknown
-     *   whether the command has been acknowledged or no in this case.
+     *   whether the command has been acknowledged in this case.
      */
     public fun <C: CommandMessage> postCommand(command: C)
 
@@ -303,6 +343,121 @@ public interface Client {
 }
 
 /**
+ * The current connection status of a [Client].
+ */
+public enum class ConnectionStatus {
+
+    /**
+     * The connection is not currently used.
+     */
+    IDLE,
+
+    /**
+     * The client is establishing a connection.
+     */
+    CONNECTING,
+
+    /**
+     * The connection is ready to carry requests.
+     */
+    CONNECTED,
+
+    /**
+     * The connection is temporarily unavailable.
+     */
+    UNAVAILABLE,
+
+    /**
+     * The client is permanently closed and will not try to reconnect.
+     *
+     * This status lets applications distinguish a deliberate client shutdown
+     * from a temporary connection failure and stop showing reconnection UI.
+     */
+    CLOSED
+}
+
+/**
+ * The status of a [DataObservation].
+ */
+public sealed class DataObservationStatus {
+
+    /**
+     * The observation is receiving updates.
+     */
+    public object Active : DataObservationStatus()
+
+    /**
+     * The observation is retaining its last value until the connection is
+     * restored.
+     */
+    public object WaitingForConnection : DataObservationStatus()
+
+    /**
+     * The observation is re-reading its data and creating a new subscription.
+     */
+    public object Refreshing : DataObservationStatus()
+
+    /**
+     * The observation could not read data or create a subscription.
+     *
+     * This status is terminal for automatic connection recovery because the
+     * failure was not classified as a temporary connection loss. After
+     * resolving the cause, call [DataObservation.refresh] explicitly to retry.
+     *
+     * @property error The failure that has occurred.
+     */
+    public data class Failed(
+        public val error: Throwable
+    ) : DataObservationStatus()
+
+    /**
+     * The observation has been cancelled permanently.
+     */
+    public object Cancelled : DataObservationStatus()
+}
+
+/**
+ * Maintains live server data and recovers it after a temporary connection
+ * failure.
+ *
+ * A `DataObservation` is also a Compose [State], so its current [value] can be
+ * read directly or with Kotlin property delegation. An observation in
+ * [DataObservationStatus.WaitingForConnection] automatically re-reads the
+ * complete value and creates a new subscription when the server connection is
+ * restored. An observation in [DataObservationStatus.Failed] is not retried
+ * automatically and requires an explicit [refresh] call.
+ *
+ * The caller owns the observation lifecycle and should call [cancel] when the
+ * observation is no longer needed.
+ *
+ * @param T The type of the observed value.
+ */
+public interface DataObservation<out T> : State<T> {
+
+    /**
+     * The current observation status.
+     */
+    public val status: State<DataObservationStatus>
+
+    /**
+     * Re-reads the complete value and replaces the current subscription.
+     *
+     * Request failures are exposed through [status] instead of being thrown
+     * from this function. Coroutine cancellation is propagated to the caller
+     * without being converted into an observation failure.
+     */
+    public suspend fun refresh()
+
+    /**
+     * Permanently cancels this observation.
+     *
+     * A cancelled observation is excluded from automatic recovery and cannot
+     * be refreshed again.
+     */
+    public fun cancel()
+}
+
+/**
  * A subscription for an event.
  */
 public interface EventSubscription {
@@ -373,14 +528,5 @@ public class ServerCommunicationException(cause: Throwable) : RuntimeException(c
 public class ServerError(public val error: Error) : RuntimeException(error.message) {
     public companion object {
         private const val serialVersionUID: Long = -5438430153458733051L
-    }
-}
-
-/**
- * Signifies a failure to obtain data matching the requested criteria.
- */
-public class NoMatchingDataException(message: String) : RuntimeException(message) {
-    public companion object {
-        private const val serialVersionUID: Long = 2459671723206505789L
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/Client.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/Client.kt
@@ -516,6 +516,9 @@ public interface EventSubscriptions {
  */
 public class ServerCommunicationException(cause: Throwable) : RuntimeException(cause) {
     public companion object {
+        /**
+         * Identifies the serialized form of this exception.
+         */
         private const val serialVersionUID: Long = -5438430153458733051L
     }
 }
@@ -527,6 +530,9 @@ public class ServerCommunicationException(cause: Throwable) : RuntimeException(c
  */
 public class ServerError(public val error: Error) : RuntimeException(error.message) {
     public companion object {
+        /**
+         * Identifies the serialized form of this exception.
+         */
         private const val serialVersionUID: Long = -5438430153458733051L
     }
 }

--- a/client/src/main/kotlin/io/spine/chords/client/ConnectionMonitor.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/ConnectionMonitor.kt
@@ -41,16 +41,36 @@ import kotlinx.coroutines.flow.asStateFlow
  * Observes the connectivity state of a gRPC channel.
  */
 internal class ConnectionMonitor(
+    /**
+     * Obtains the current channel state and optionally requests a connection.
+     */
     private val getState: (requestConnection: Boolean) -> ConnectivityState,
+    /**
+     * Registers a callback to run after the channel leaves the supplied state.
+     */
     private val notifyWhenStateChanged: (
         source: ConnectivityState,
         callback: Runnable
     ) -> Unit,
+    /**
+     * Receives each distinct connection status published by this monitor.
+     */
     private val onStatusChanged: (ConnectionStatus) -> Unit
 ) {
 
+    /**
+     * Prevents callbacks from restarting observation after the monitor is closed.
+     */
     private val closed = AtomicBoolean(false)
+
+    /**
+     * Serializes status updates with the terminal transition to `CLOSED`.
+     */
     private val stateLock = Any()
+
+    /**
+     * Stores the latest public connection status.
+     */
     private val mutableStatus = MutableStateFlow(ConnectionStatus.IDLE)
 
     /**
@@ -74,6 +94,9 @@ internal class ConnectionMonitor(
         }
     }
 
+    /**
+     * Publishes [channelState] and arranges observation of its next transition.
+     */
     private fun observe(channelState: ConnectivityState) {
         if (closed.get()) {
             return
@@ -90,6 +113,9 @@ internal class ConnectionMonitor(
         })
     }
 
+    /**
+     * Publishes [newStatus] unless it duplicates the current or terminal status.
+     */
     private fun updateStatus(newStatus: ConnectionStatus) {
         synchronized(stateLock) {
             if (closed.get() && newStatus != ConnectionStatus.CLOSED) {
@@ -104,6 +130,9 @@ internal class ConnectionMonitor(
     }
 }
 
+/**
+ * Converts a gRPC connectivity state to the corresponding Chords status.
+ */
 private fun ConnectivityState.toConnectionStatus(): ConnectionStatus = when (this) {
     IDLE -> ConnectionStatus.IDLE
     CONNECTING -> ConnectionStatus.CONNECTING

--- a/client/src/main/kotlin/io/spine/chords/client/ConnectionMonitor.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/ConnectionMonitor.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import io.grpc.ConnectivityState
+import io.grpc.ConnectivityState.CONNECTING
+import io.grpc.ConnectivityState.IDLE
+import io.grpc.ConnectivityState.READY
+import io.grpc.ConnectivityState.SHUTDOWN
+import io.grpc.ConnectivityState.TRANSIENT_FAILURE
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Observes the connectivity state of a gRPC channel.
+ */
+internal class ConnectionMonitor(
+    private val getState: (requestConnection: Boolean) -> ConnectivityState,
+    private val notifyWhenStateChanged: (
+        source: ConnectivityState,
+        callback: Runnable
+    ) -> Unit,
+    private val onStatusChanged: (ConnectionStatus) -> Unit
+) {
+
+    private val closed = AtomicBoolean(false)
+    private val stateLock = Any()
+    private val mutableStatus = MutableStateFlow(ConnectionStatus.IDLE)
+
+    /**
+     * The currently observed connection status.
+     */
+    val status: StateFlow<ConnectionStatus> = mutableStatus.asStateFlow()
+
+    /**
+     * Starts observing channel connectivity.
+     */
+    fun start() {
+        observe(getState(true))
+    }
+
+    /**
+     * Stops observing and reports the connection as closed.
+     */
+    fun close() {
+        if (closed.compareAndSet(false, true)) {
+            updateStatus(ConnectionStatus.CLOSED)
+        }
+    }
+
+    private fun observe(channelState: ConnectivityState) {
+        if (closed.get()) {
+            return
+        }
+        updateStatus(channelState.toConnectionStatus())
+        if (channelState == SHUTDOWN) {
+            close()
+            return
+        }
+        notifyWhenStateChanged(channelState, Runnable {
+            if (!closed.get()) {
+                observe(getState(true))
+            }
+        })
+    }
+
+    private fun updateStatus(newStatus: ConnectionStatus) {
+        synchronized(stateLock) {
+            if (closed.get() && newStatus != ConnectionStatus.CLOSED) {
+                return
+            }
+            val previousStatus = mutableStatus.value
+            if (previousStatus != newStatus) {
+                mutableStatus.value = newStatus
+                onStatusChanged(newStatus)
+            }
+        }
+    }
+}
+
+private fun ConnectivityState.toConnectionStatus(): ConnectionStatus = when (this) {
+    IDLE -> ConnectionStatus.IDLE
+    CONNECTING -> ConnectionStatus.CONNECTING
+    READY -> ConnectionStatus.CONNECTED
+    TRANSIENT_FAILURE -> ConnectionStatus.UNAVAILABLE
+    SHUTDOWN -> ConnectionStatus.CLOSED
+}

--- a/client/src/main/kotlin/io/spine/chords/client/DataObservationImpl.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DataObservationImpl.kt
@@ -1,0 +1,514 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
+import io.spine.chords.client.DataObservationStatus.Active
+import io.spine.chords.client.DataObservationStatus.Cancelled
+import io.spine.chords.client.DataObservationStatus.Failed
+import io.spine.chords.client.DataObservationStatus.Refreshing
+import io.spine.chords.client.DataObservationStatus.WaitingForConnection
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * A cancellable handle of an underlying server subscription.
+ */
+internal fun interface ObservationSubscription {
+
+    /**
+     * Cancels the underlying subscription.
+     */
+    fun cancel()
+}
+
+/**
+ * An observation managed by the client's automatic recovery coordinator.
+ */
+internal interface RecoverableDataObservation {
+
+    /**
+     * Tells whether this observation should be refreshed after reconnecting.
+     */
+    val needsRecovery: Boolean
+
+    /**
+     * Suspends this observation until the client reconnects.
+     */
+    fun waitForConnection()
+
+    /**
+     * Re-reads the observation after reconnecting.
+     */
+    suspend fun refresh()
+
+    /**
+     * Cancels this observation.
+     */
+    fun cancel()
+
+    /**
+     * Marks this observation as closed without cancelling its server subscription.
+     *
+     * The owning client terminates the connection, which ends all remaining
+     * subscription streams. Avoiding an individual cancellation here prevents
+     * duplicate cancellation requests during client shutdown.
+     */
+    fun close()
+}
+
+/**
+ * A data observation maintained by [DesktopClient].
+ *
+ * @param T The type of the complete observed value.
+ * @param U The type of an individual update.
+ */
+@Suppress(
+    "TooManyFunctions", /* All functions belong to the observation lifecycle. */
+    "TooGenericExceptionCaught" /* All recoverable request failures become status values. */
+)
+internal class DataObservationImpl<T, U>(
+    initialValue: T,
+    private val read: () -> T,
+    private val subscribe: (
+        onUpdate: (U) -> Unit,
+        onError: (Throwable) -> Unit
+    ) -> ObservationSubscription,
+    private val applyUpdate: (T, U) -> T,
+    private val connectionStatus: () -> ConnectionStatus,
+    private val onCancelled: (RecoverableDataObservation) -> Unit,
+    private val onRecoveryNeeded: (RecoverableDataObservation) -> Unit = {}
+) : DataObservation<T>, RecoverableDataObservation {
+
+    private val mutableValue: MutableState<T> = mutableStateOf(initialValue)
+    private val mutableStatus: MutableState<DataObservationStatus> =
+        mutableStateOf(Refreshing)
+    private val stateLock = Any()
+    private val refreshMutex = Mutex()
+
+    private var generation: Long = 0
+    private var subscription: ObservationSubscription? = null
+    private val abandonedSubscriptionGenerations = mutableSetOf<Long>()
+    private var cancelled: Boolean = false
+
+    override val value: T
+        get() = mutableValue.value
+
+    override val status: State<DataObservationStatus>
+        get() = mutableStatus
+
+    /**
+     * Performs the initial read and subscription synchronously.
+     */
+    internal fun initialize() {
+        runBlocking {
+            refresh()
+        }
+    }
+
+    @Suppress(
+        "ReturnCount" /* Each failed or stale recovery phase must stop immediately. */
+    )
+    override suspend fun refresh() {
+        refreshMutex.withLock {
+            val refreshGeneration = beginRefresh() ?: return
+            val pendingUpdates = PendingUpdates<U>()
+            try {
+                val result = withContext(IO) {
+                    performRefresh(refreshGeneration, pendingUpdates)
+                }
+                when (result) {
+                    is RefreshResult.Success -> {
+                        if (!installSubscription(
+                                refreshGeneration,
+                                result.subscription
+                            )
+                        ) {
+                            return
+                        }
+                        completeRefresh(
+                            refreshGeneration,
+                            result.value,
+                            pendingUpdates
+                        )
+                    }
+                    is RefreshResult.ReadFailed -> {
+                        if (!installSubscription(
+                                refreshGeneration,
+                                result.subscription
+                            )
+                        ) {
+                            return
+                        }
+                        handleFailure(
+                            refreshGeneration,
+                            result.cause,
+                            cancelConnectedSubscription = true
+                        )
+                    }
+                    is RefreshResult.SubscriptionFailed -> {
+                        result.value?.let {
+                            setValue(refreshGeneration, it.value)
+                        }
+                        handleFailure(refreshGeneration, result.cause)
+                    }
+                }
+            } finally {
+                synchronized(stateLock) {
+                    abandonedSubscriptionGenerations.remove(refreshGeneration)
+                }
+            }
+        }
+    }
+
+    @Suppress(
+        "ReturnCount" /* Each failed network phase returns its distinct result immediately. */
+    )
+    private fun performRefresh(
+        refreshGeneration: Long,
+        pendingUpdates: PendingUpdates<U>
+    ): RefreshResult<T> {
+        val newSubscription = try {
+            subscribe(
+                { update ->
+                    bufferOrApplyUpdate(
+                        refreshGeneration,
+                        pendingUpdates,
+                        update
+                    )
+                },
+                { error ->
+                    bufferOrHandleFailure(
+                        refreshGeneration,
+                        pendingUpdates,
+                        error
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            rethrowCancellation(e)
+            return RefreshResult.SubscriptionFailed(
+                e,
+                readAfterSubscriptionFailure(e)
+            )
+        }
+        val refreshedValue = try {
+            read()
+        } catch (e: Exception) {
+            rethrowCancellation(e)
+            return RefreshResult.ReadFailed(newSubscription, e)
+        }
+        return RefreshResult.Success(newSubscription, refreshedValue)
+    }
+
+    override fun cancel() {
+        cancel(cancelSubscription = true)
+    }
+
+    override fun close() {
+        cancel(cancelSubscription = false)
+    }
+
+    private fun cancel(cancelSubscription: Boolean) {
+        val previousSubscription: ObservationSubscription?
+        val notifyCancelled: Boolean
+        synchronized(stateLock) {
+            notifyCancelled = !cancelled
+            if (!notifyCancelled) {
+                return
+            }
+            cancelled = true
+            generation++
+            previousSubscription = subscription
+            subscription = null
+            mutableStatus.value = Cancelled
+        }
+        if (cancelSubscription) {
+            previousSubscription.cancelSafely()
+        }
+        onCancelled(this)
+    }
+
+    /**
+     * Suspends this observation until the client reconnects.
+     */
+    override fun waitForConnection() {
+        synchronized(stateLock) {
+            if (cancelled || mutableStatus.value is Failed) {
+                return
+            }
+            if (subscription == null && mutableStatus.value == Refreshing) {
+                abandonedSubscriptionGenerations.add(generation)
+            }
+            generation++
+            subscription = null
+            mutableStatus.value = WaitingForConnection
+        }
+    }
+
+    /**
+     * Tells whether this observation should be refreshed after reconnecting.
+     */
+    override val needsRecovery: Boolean
+        get() = synchronized(stateLock) {
+            !cancelled && mutableStatus.value == WaitingForConnection
+        }
+
+    private fun beginRefresh(): Long? {
+        val previousSubscription: ObservationSubscription?
+        val refreshGeneration: Long
+        synchronized(stateLock) {
+            if (cancelled) {
+                return null
+            }
+            generation++
+            refreshGeneration = generation
+            previousSubscription = subscription
+            subscription = null
+            mutableStatus.value = Refreshing
+        }
+        previousSubscription.cancelSafely()
+        return refreshGeneration
+    }
+
+    private fun setValue(refreshGeneration: Long, newValue: T): Boolean {
+        synchronized(stateLock) {
+            if (!isCurrent(refreshGeneration)) {
+                return false
+            }
+            mutableValue.value = newValue
+            return true
+        }
+    }
+
+    private fun bufferOrApplyUpdate(
+        refreshGeneration: Long,
+        pendingUpdates: PendingUpdates<U>,
+        update: U
+    ) {
+        synchronized(stateLock) {
+            if (!isCurrent(refreshGeneration)) {
+                return
+            }
+            if (pendingUpdates.buffering) {
+                pendingUpdates.updates.add(update)
+            } else {
+                mutableValue.value = applyUpdate(mutableValue.value, update)
+            }
+        }
+    }
+
+    private fun bufferOrHandleFailure(
+        refreshGeneration: Long,
+        pendingUpdates: PendingUpdates<U>,
+        cause: Throwable
+    ) {
+        val handleImmediately = synchronized(stateLock) {
+            if (!isCurrent(refreshGeneration)) {
+                return
+            }
+            if (pendingUpdates.buffering) {
+                if (pendingUpdates.failure == null) {
+                    pendingUpdates.failure = cause
+                }
+                false
+            } else {
+                true
+            }
+        }
+        if (handleImmediately) {
+            handleFailure(refreshGeneration, cause)
+        }
+    }
+
+    private fun installSubscription(
+        refreshGeneration: Long,
+        newSubscription: ObservationSubscription
+    ): Boolean {
+        val installed: Boolean
+        val shouldCancel: Boolean
+        synchronized(stateLock) {
+            installed = isCurrent(refreshGeneration)
+            shouldCancel = !installed &&
+                    !abandonedSubscriptionGenerations.remove(refreshGeneration)
+            if (installed) {
+                subscription = newSubscription
+            }
+        }
+        if (shouldCancel) {
+            newSubscription.cancelSafely()
+        }
+        return installed
+    }
+
+    private fun completeRefresh(
+        refreshGeneration: Long,
+        refreshedValue: T,
+        pendingUpdates: PendingUpdates<U>
+    ) {
+        val pendingFailure: Throwable?
+        synchronized(stateLock) {
+            if (!isCurrent(refreshGeneration)) {
+                return
+            }
+            var value = refreshedValue
+            pendingUpdates.updates.forEach {
+                value = applyUpdate(value, it)
+            }
+            pendingUpdates.updates.clear()
+            pendingUpdates.buffering = false
+            mutableValue.value = value
+            pendingFailure = pendingUpdates.failure
+            if (pendingFailure == null) {
+                mutableStatus.value = Active
+            }
+        }
+        if (pendingFailure != null) {
+            handleFailure(refreshGeneration, pendingFailure)
+        }
+    }
+
+    private fun readAfterSubscriptionFailure(
+        subscriptionFailure: Exception
+    ): ReadValue<T>? {
+        if (isConnectionFailure(subscriptionFailure)) {
+            return null
+        }
+        return try {
+            ReadValue(read())
+        } catch (e: Exception) {
+            rethrowCancellation(e)
+            null
+        }
+    }
+
+    private fun handleFailure(
+        refreshGeneration: Long,
+        cause: Throwable,
+        cancelConnectedSubscription: Boolean = false
+    ) {
+        val connectionFailure = isConnectionFailure(cause)
+        val connected = connectionStatus() == ConnectionStatus.CONNECTED
+        val previousSubscription: ObservationSubscription?
+        synchronized(stateLock) {
+            if (!isCurrent(refreshGeneration)) {
+                return
+            }
+            generation++
+            previousSubscription = subscription
+            subscription = null
+            mutableStatus.value = if (connectionFailure) {
+                WaitingForConnection
+            } else {
+                Failed(cause)
+            }
+        }
+        if (!connectionFailure ||
+            (cancelConnectedSubscription && connected)
+        ) {
+            previousSubscription.cancelSafely()
+        }
+        if (connectionFailure && connected) {
+            onRecoveryNeeded(this)
+        }
+    }
+
+    private fun isCurrent(refreshGeneration: Long): Boolean =
+        !cancelled && generation == refreshGeneration
+
+    private fun isConnectionFailure(cause: Throwable): Boolean {
+        return when (Status.fromThrowable(cause).code) {
+            Status.Code.CANCELLED,
+            Status.Code.DEADLINE_EXCEEDED,
+            Status.Code.UNAVAILABLE -> true
+            Status.Code.UNKNOWN -> cause.hasGrpcStatus() &&
+                    connectionStatus() != ConnectionStatus.CONNECTED
+            else -> false
+        }
+    }
+}
+
+private fun Throwable.hasGrpcStatus(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is StatusException || current is StatusRuntimeException) {
+            return true
+        }
+        current = current.cause
+    }
+    return false
+}
+
+private class PendingUpdates<U> {
+    val updates: MutableList<U> = mutableListOf()
+    var buffering: Boolean = true
+    var failure: Throwable? = null
+}
+
+private sealed class RefreshResult<out T> {
+
+    data class Success<T>(
+        val subscription: ObservationSubscription,
+        val value: T
+    ) : RefreshResult<T>()
+
+    data class ReadFailed(
+        val subscription: ObservationSubscription,
+        val cause: Exception
+    ) : RefreshResult<Nothing>()
+
+    data class SubscriptionFailed<T>(
+        val cause: Exception,
+        val value: ReadValue<T>?
+    ) : RefreshResult<T>()
+}
+
+private data class ReadValue<out T>(val value: T)
+
+private fun rethrowCancellation(exception: Exception) {
+    if (exception is CancellationException) {
+        throw exception
+    }
+}
+
+private fun ObservationSubscription?.cancelSafely() {
+    try {
+        this?.cancel()
+    } catch (_: Exception) {
+        // Cancellation is best-effort because the stream or channel may already
+        // have failed independently.
+    }
+}

--- a/client/src/main/kotlin/io/spine/chords/client/DataObservationImpl.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DataObservationImpl.kt
@@ -102,26 +102,74 @@ internal interface RecoverableDataObservation {
 )
 internal class DataObservationImpl<T, U>(
     initialValue: T,
+    /**
+     * Reads the complete current value from the server.
+     */
     private val read: () -> T,
+    /**
+     * Creates a server subscription and registers its update and failure callbacks.
+     */
     private val subscribe: (
         onUpdate: (U) -> Unit,
         onError: (Throwable) -> Unit
     ) -> ObservationSubscription,
+    /**
+     * Applies one subscription update to the current complete value.
+     */
     private val applyUpdate: (T, U) -> T,
+    /**
+     * Obtains the latest client connection status.
+     */
     private val connectionStatus: () -> ConnectionStatus,
+    /**
+     * Unregisters this observation after permanent cancellation.
+     */
     private val onCancelled: (RecoverableDataObservation) -> Unit,
+    /**
+     * Requests a delayed retry when a stream fails on a connected channel.
+     */
     private val onRecoveryNeeded: (RecoverableDataObservation) -> Unit = {}
 ) : DataObservation<T>, RecoverableDataObservation {
 
+    /**
+     * Stores the complete value exposed as Compose state.
+     */
     private val mutableValue: MutableState<T> = mutableStateOf(initialValue)
+
+    /**
+     * Stores the observation lifecycle status exposed as Compose state.
+     */
     private val mutableStatus: MutableState<DataObservationStatus> =
         mutableStateOf(Refreshing)
+
+    /**
+     * Guards lifecycle fields shared by request and callback threads.
+     */
     private val stateLock = Any()
+
+    /**
+     * Prevents concurrent refresh operations for this observation.
+     */
     private val refreshMutex = Mutex()
 
+    /**
+     * Identifies the current lifecycle generation so stale callbacks can be ignored.
+     */
     private var generation: Long = 0
+
+    /**
+     * Holds the currently installed server subscription, if any.
+     */
     private var subscription: ObservationSubscription? = null
+
+    /**
+     * Tracks in-flight subscriptions that became obsolete because the connection failed.
+     */
     private val abandonedSubscriptionGenerations = mutableSetOf<Long>()
+
+    /**
+     * Permanently prevents further refreshes after cancellation.
+     */
     private var cancelled: Boolean = false
 
     override val value: T
@@ -194,6 +242,9 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Performs the blocking subscription and read operations for one refresh.
+     */
     @Suppress(
         "ReturnCount" /* Each failed network phase returns its distinct result immediately. */
     )
@@ -242,6 +293,9 @@ internal class DataObservationImpl<T, U>(
         cancel(cancelSubscription = false)
     }
 
+    /**
+     * Permanently stops this observation and optionally cancels its server subscription.
+     */
     private fun cancel(cancelSubscription: Boolean) {
         val previousSubscription: ObservationSubscription?
         val notifyCancelled: Boolean
@@ -287,6 +341,9 @@ internal class DataObservationImpl<T, U>(
             !cancelled && mutableStatus.value == WaitingForConnection
         }
 
+    /**
+     * Starts a new generation and detaches the previous subscription.
+     */
     private fun beginRefresh(): Long? {
         val previousSubscription: ObservationSubscription?
         val refreshGeneration: Long
@@ -304,6 +361,9 @@ internal class DataObservationImpl<T, U>(
         return refreshGeneration
     }
 
+    /**
+     * Replaces the complete value if [refreshGeneration] is still current.
+     */
     private fun setValue(refreshGeneration: Long, newValue: T): Boolean {
         synchronized(stateLock) {
             if (!isCurrent(refreshGeneration)) {
@@ -314,6 +374,9 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Buffers [update] during refresh or applies it to the active value afterward.
+     */
     private fun bufferOrApplyUpdate(
         refreshGeneration: Long,
         pendingUpdates: PendingUpdates<U>,
@@ -331,6 +394,9 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Buffers [cause] during refresh or handles it immediately afterward.
+     */
     private fun bufferOrHandleFailure(
         refreshGeneration: Long,
         pendingUpdates: PendingUpdates<U>,
@@ -354,6 +420,9 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Installs [newSubscription] if its refresh generation is still current.
+     */
     private fun installSubscription(
         refreshGeneration: Long,
         newSubscription: ObservationSubscription
@@ -374,6 +443,9 @@ internal class DataObservationImpl<T, U>(
         return installed
     }
 
+    /**
+     * Publishes the refreshed value together with updates received during its read.
+     */
     private fun completeRefresh(
         refreshGeneration: Long,
         refreshedValue: T,
@@ -401,6 +473,9 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Attempts to preserve readable data after a non-connection subscription failure.
+     */
     private fun readAfterSubscriptionFailure(
         subscriptionFailure: Exception
     ): ReadValue<T>? {
@@ -415,6 +490,9 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Transitions this observation to a waiting or failed state for [cause].
+     */
     private fun handleFailure(
         refreshGeneration: Long,
         cause: Throwable,
@@ -446,9 +524,15 @@ internal class DataObservationImpl<T, U>(
         }
     }
 
+    /**
+     * Tells whether [refreshGeneration] still owns this observation's callbacks.
+     */
     private fun isCurrent(refreshGeneration: Long): Boolean =
         !cancelled && generation == refreshGeneration
 
+    /**
+     * Tells whether [cause] represents a temporary connection failure.
+     */
     private fun isConnectionFailure(cause: Throwable): Boolean {
         return when (Status.fromThrowable(cause).code) {
             Status.Code.CANCELLED,
@@ -461,6 +545,9 @@ internal class DataObservationImpl<T, U>(
     }
 }
 
+/**
+ * Tells whether this throwable or one of its causes carries a gRPC status.
+ */
 private fun Throwable.hasGrpcStatus(): Boolean {
     var current: Throwable? = this
     while (current != null) {
@@ -472,38 +559,74 @@ private fun Throwable.hasGrpcStatus(): Boolean {
     return false
 }
 
+/**
+ * Collects subscription callbacks until the complete refresh value is ready.
+ */
 private class PendingUpdates<U> {
+
+    /**
+     * Updates received before the refreshed value is published.
+     */
     val updates: MutableList<U> = mutableListOf()
+
+    /**
+     * Tells whether callbacks must still be accumulated.
+     */
     var buffering: Boolean = true
+
+    /**
+     * The first stream failure received while buffering, if any.
+     */
     var failure: Throwable? = null
 }
 
+/**
+ * Describes the result of the blocking portion of a refresh.
+ */
 private sealed class RefreshResult<out T> {
 
+    /**
+     * Contains a new subscription and the complete value read after creating it.
+     */
     data class Success<T>(
         val subscription: ObservationSubscription,
         val value: T
     ) : RefreshResult<T>()
 
+    /**
+     * Contains a created subscription whose subsequent complete read failed.
+     */
     data class ReadFailed(
         val subscription: ObservationSubscription,
         val cause: Exception
     ) : RefreshResult<Nothing>()
 
+    /**
+     * Contains a subscription failure and any complete value read afterward.
+     */
     data class SubscriptionFailed<T>(
         val cause: Exception,
         val value: ReadValue<T>?
     ) : RefreshResult<T>()
 }
 
+/**
+ * Wraps a possibly nullable value so it can be distinguished from no read result.
+ */
 private data class ReadValue<out T>(val value: T)
 
+/**
+ * Propagates coroutine cancellation instead of converting it to observation failure.
+ */
 private fun rethrowCancellation(exception: Exception) {
     if (exception is CancellationException) {
         throw exception
     }
 }
 
+/**
+ * Cancels this subscription without propagating a best-effort request failure.
+ */
 private fun ObservationSubscription?.cancelSafely() {
     try {
         this?.cancel()

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -82,15 +82,39 @@ public class DesktopClient(
     port: Int,
     private val user: () -> UserId? = { null }
 ) : Client {
+
+    /**
+     * The gRPC channel used for all requests to the server.
+     */
     private val channel: ManagedChannel = ManagedChannelBuilder
         .forAddress(host, port)
         .usePlaintext()
         .build()
+
+    /**
+     * The underlying Spine client that performs server requests.
+     */
     private val spineClient: io.spine.client.Client =
         io.spine.client.Client.usingChannel(channel).build()
+
+    /**
+     * Coordinates recovery of active data observations after connection loss.
+     */
     private val recoveryCoordinator = ObservationRecoveryCoordinator()
+
+    /**
+     * Runs best-effort subscription cancellation requests.
+     */
     private val cancellationScope = CoroutineScope(IO + SupervisorJob())
+
+    /**
+     * Prevents the client resources from being closed more than once.
+     */
     private val closed = AtomicBoolean(false)
+
+    /**
+     * Observes channel state changes and reports connection status updates.
+     */
     private val connectionMonitor = ConnectionMonitor(
         { requestConnection -> channel.getState(requestConnection) },
         { source, callback -> channel.notifyWhenStateChanged(source, callback) },
@@ -403,6 +427,9 @@ internal open class EventSubscriptionImpl(
     private val cancelSubscriptionRequest: (Subscription) -> Unit
 ) : EventSubscription {
 
+    /**
+     * Guards the mutable subscription state.
+     */
     private val stateLock = Any()
 
     override val active: Boolean
@@ -427,7 +454,14 @@ internal open class EventSubscriptionImpl(
             isCancelled
         }
 
+    /**
+     * Indicates whether this subscription handle has reached a terminal state.
+     */
     private var isCancelled = false
+
+    /**
+     * Requests cancellation when an asynchronously created subscription is installed.
+     */
     private var cancelWhenInstalled = false
 
     /**
@@ -436,6 +470,9 @@ internal open class EventSubscriptionImpl(
      */
     private var subscription: Subscription? = null
 
+    /**
+     * The currently scheduled subscription timeout, if any.
+     */
     private var timeoutJob: Job? = null
 
     @OptIn(
@@ -523,6 +560,9 @@ internal open class EventSubscriptionImpl(
         cancelTimeout()
     }
 
+    /**
+     * Marks this handle as cancelled and cancels an installed subscription.
+     */
     private fun cancelSubscription() {
         val previousSubscription = synchronized(stateLock) {
             if (isCancelled) {
@@ -539,6 +579,9 @@ internal open class EventSubscriptionImpl(
         }
     }
 
+    /**
+     * Sends a best-effort cancellation request for the given [subscription].
+     */
     private fun sendCancellationSafely(subscription: Subscription) {
         try {
             cancelSubscriptionRequest(subscription)
@@ -547,6 +590,9 @@ internal open class EventSubscriptionImpl(
         }
     }
 
+    /**
+     * Cancels and clears the currently scheduled timeout.
+     */
     private fun cancelTimeout() {
         if (timeoutJob != null) {
             timeoutJob?.cancel()

--- a/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/DesktopClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,8 @@
 
 package io.spine.chords.client
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import com.google.protobuf.Message
+import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.grpc.Status.Code.UNAVAILABLE
 import io.grpc.StatusRuntimeException
@@ -45,15 +43,24 @@ import io.spine.client.EventFilter.eq
 import io.spine.client.Subscription
 import io.spine.core.UserId
 import java.lang.Runtime.getRuntime
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.TimeUnit.SECONDS
 import kotlin.time.Duration
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+
+/**
+ * Allows active gRPC streams time to finish after the client channel is closed.
+ */
+private const val ChannelShutdownTimeoutSeconds = 5L
 
 /**
  * Provides API to interact with the application server via gRPC.
@@ -67,21 +74,37 @@ import kotlinx.coroutines.runBlocking
  *   If the callback return `null` the client will send requests
  *   to the server on behalf of the guest user.
  */
+@Suppress(
+    "TooManyFunctions" /* The functions implement the public Client contract. */
+)
 public class DesktopClient(
     host: String,
     port: Int,
     private val user: () -> UserId? = { null }
 ) : Client {
-    private val spineClient: io.spine.client.Client
+    private val channel: ManagedChannel = ManagedChannelBuilder
+        .forAddress(host, port)
+        .usePlaintext()
+        .build()
+    private val spineClient: io.spine.client.Client =
+        io.spine.client.Client.usingChannel(channel).build()
+    private val recoveryCoordinator = ObservationRecoveryCoordinator()
+    private val cancellationScope = CoroutineScope(IO + SupervisorJob())
+    private val closed = AtomicBoolean(false)
+    private val connectionMonitor = ConnectionMonitor(
+        { requestConnection -> channel.getState(requestConnection) },
+        { source, callback -> channel.notifyWhenStateChanged(source, callback) },
+        recoveryCoordinator::onConnectionStatusChanged
+    )
+
     override val isOpen: Boolean get() = spineClient.isOpen
+    override val connectionStatus: StateFlow<ConnectionStatus>
+        get() = connectionMonitor.status
     override val userId: UserId? get() = user()
 
     init {
-        val channel = ManagedChannelBuilder
-            .forAddress(host, port)
-            .usePlaintext()
-            .build()
-        spineClient = io.spine.client.Client.usingChannel(channel).build()
+        recoveryCoordinator.start()
+        connectionMonitor.start()
 
         getRuntime().addShutdownHook(Thread {
             close()
@@ -89,81 +112,92 @@ public class DesktopClient(
     }
 
     override fun close() {
-        spineClient.close()
+        if (!closed.compareAndSet(false, true)) {
+            return
+        }
+        recoveryCoordinator.close()
+        connectionMonitor.close()
+        cancellationScope.cancel()
+        closeChannel()
     }
 
     override fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any
-    ): State<List<E>> {
-        val listState = mutableStateOf(listOf<E>())
-        listState.value = clientRequest().select(entityClass).run()
-        clientRequest()
-            .subscribeTo(entityClass)
-            .observe { entity ->
-                runBlocking(Main) {
-                    updateList(listState, entity, extractId)
-                }
-            }
-            .post()
-        return listState
-    }
+    ): DataObservation<List<E>> = createObservation(
+        initialValue = emptyList(),
+        read = {
+            clientRequest()
+                .select(entityClass)
+                .run()
+        },
+        subscribe = { onUpdate, onError ->
+            subscribeTo(entityClass, onUpdate, onError)
+        },
+        applyUpdate = { entities, entity ->
+            updateList(entities, entity, extractId)
+        }
+    )
 
     override fun <E : EntityState> readAndObserve(
         entityClass: Class<E>,
         extractId: (E) -> Any,
         queryFilter: CompositeQueryFilter,
-        observeFilter: CompositeEntityStateFilter,
-        onNext: (List<E>) -> Unit
-    ) {
-        val initialResult: List<E> = clientRequest()
-            .select(entityClass)
-            .where(queryFilter)
-            .run()
-        onNext(initialResult)
-        val observedEntities = mutableStateOf(initialResult)
-        clientRequest()
-            .subscribeTo(entityClass)
-            .observe { updatedEntity ->
-                updateList(observedEntities, updatedEntity, extractId)
-                runBlocking(Main) {
-                    onNext(observedEntities.value)
-                }
-            }
-            .where(observeFilter)
-            .post()
-    }
+        observeFilter: CompositeEntityStateFilter
+    ): DataObservation<List<E>> = createObservation(
+        initialValue = emptyList(),
+        read = {
+            clientRequest()
+                .select(entityClass)
+                .where(queryFilter)
+                .run()
+        },
+        subscribe = { onUpdate, onError ->
+            subscribeTo(entityClass, onUpdate, onError, observeFilter)
+        },
+        applyUpdate = { entities, entity ->
+            updateList(entities, entity, extractId)
+        }
+    )
+
+    override fun <E : EntityState> readOneAndObserve(
+        entityClass: Class<E>,
+        queryFilter: CompositeQueryFilter,
+        observeFilter: CompositeEntityStateFilter
+    ): DataObservation<E?> = createObservation(
+        initialValue = null,
+        read = {
+            clientRequest()
+                .select(entityClass)
+                .where(queryFilter)
+                .run()
+                .firstOrNull()
+        },
+        subscribe = { onUpdate, onError ->
+            subscribeTo(entityClass, onUpdate, onError, observeFilter)
+        },
+        applyUpdate = { _, entity -> entity }
+    )
 
     override fun <E : EntityState> readOneAndObserve(
         entityClass: Class<E>,
         queryFilter: CompositeQueryFilter,
         observeFilter: CompositeEntityStateFilter,
-        defaultValue: E?
-    ): State<E> {
-        val initialList = clientRequest()
-            .select(entityClass)
-            .where(queryFilter)
-            .run()
-        val initialValue = initialList.getOrNull(0) ?: defaultValue
-        if (initialValue == null) {
-            throw NoMatchingDataException(
-                "No entity could be found that matches the specified criteria, and no " +
-                        "`defaultValue` has been provided. Entity class: ${entityClass.name}"
-            )
-        }
-        val state = mutableStateOf(initialValue)
-
-        clientRequest()
-            .subscribeTo(entityClass)
-            .observe {
-                runBlocking(Main) {
-                    state.value = it
-                }
-            }
-            .where(observeFilter)
-            .post()
-        return state
-    }
+        defaultValue: E
+    ): DataObservation<E> = createObservation(
+        initialValue = defaultValue,
+        read = {
+            clientRequest()
+                .select(entityClass)
+                .where(queryFilter)
+                .run()
+                .firstOrNull() ?: defaultValue
+        },
+        subscribe = { onUpdate, onError ->
+            subscribeTo(entityClass, onUpdate, onError, observeFilter)
+        },
+        applyUpdate = { _, entity -> entity }
+    )
 
     override fun <E : EntityState, M : Message> read(
         entityClass: Class<E>,
@@ -212,9 +246,9 @@ public class DesktopClient(
         onNetworkError: ((Throwable) -> Unit)?,
         onEvent: (E) -> Unit
     ): EventSubscription {
-        val eventSubscription = EventSubscriptionImpl(spineClient)
+        val eventSubscription = EventSubscriptionImpl(::cancelSubscription)
         try {
-            eventSubscription.subscription = clientRequest()
+            val subscription = clientRequest()
                 .subscribeToEvent(event)
                 .where(eq(field, fieldValue))
                 .observe { evt ->
@@ -222,14 +256,14 @@ public class DesktopClient(
                     onEvent(evt)
                 }
                 .onStreamingError({ err ->
-                    if (!eventSubscription.canceled) {
-                        eventSubscription.cancel()
+                    if (eventSubscription.onStreamingFailure()) {
                         onNetworkError?.invoke(err)
                     }
                 })
                 .post()
+            eventSubscription.install(subscription)
         } catch (e: StatusRuntimeException) {
-            if (!eventSubscription.canceled) {
+            if (eventSubscription.onStreamingFailure()) {
                 onNetworkError?.invoke(e)
             }
         }
@@ -248,7 +282,86 @@ public class DesktopClient(
     }
 
     /**
-     * Updates the content of [targetList] by merging in the given [entity]
+     * Closes the channel without asking Spine Client to cancel all subscriptions.
+     *
+     * Spine Client retains subscriptions whose streams ended because the connection
+     * failed. Its standard `close()` method would try to cancel these stale
+     * subscriptions, which the server has already removed. Immediately shutting
+     * down the channel terminates active streams without sending invalid
+     * cancellation requests.
+     */
+    private fun closeChannel() {
+        try {
+            channel.shutdownNow()
+                .awaitTermination(ChannelShutdownTimeoutSeconds, SECONDS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    /**
+     * Creates, initializes, and registers a recoverable data observation.
+     */
+    private fun <T, U> createObservation(
+        initialValue: T,
+        read: () -> T,
+        subscribe: (
+            onUpdate: (U) -> Unit,
+            onError: (Throwable) -> Unit
+        ) -> ObservationSubscription,
+        applyUpdate: (T, U) -> T
+    ): DataObservation<T> {
+        val observation = DataObservationImpl(
+            initialValue,
+            read,
+            subscribe,
+            applyUpdate,
+            { connectionStatus.value },
+            recoveryCoordinator::unregister,
+            recoveryCoordinator::retryWhileConnected
+        )
+        observation.initialize()
+        recoveryCoordinator.register(observation, connectionStatus.value)
+        return observation
+    }
+
+    /**
+     * Creates an entity subscription with uniform update and failure handling.
+     */
+    private fun <E : EntityState> subscribeTo(
+        entityClass: Class<E>,
+        onUpdate: (E) -> Unit,
+        onError: (Throwable) -> Unit,
+        filter: CompositeEntityStateFilter? = null
+    ): ObservationSubscription {
+        val request = clientRequest()
+            .subscribeTo(entityClass)
+            .observe(onUpdate)
+            .onStreamingError(onError)
+        filter?.let {
+            request.where(it)
+        }
+        val subscription = request.post()
+        return ObservationSubscription {
+            cancelSubscription(subscription)
+        }
+    }
+
+    /**
+     * Sends a best-effort cancellation request without blocking the caller.
+     */
+    private fun cancelSubscription(subscription: Subscription) {
+        cancellationScope.launch {
+            try {
+                spineClient.subscriptions().cancel(subscription)
+            } catch (_: Exception) {
+                // The stream or channel may have failed before cancellation.
+            }
+        }
+    }
+
+    /**
+     * Updates the content of [entities] by merging in the given [entity]
      * into it.
      *
      * The merging here is either an addition of the new item specified by
@@ -256,46 +369,49 @@ public class DesktopClient(
      * ID in the field identified by [extractId], a replacement of
      * the corresponding item with the one passed in [entity].
      *
-     * @param targetList A [MutableState] that contains a list to be updated.
+     * @param entities A list to be updated.
      * @param entity An item that has to be merged into the list.
      * @param extractId A function that, given a list item, or a value of
      *   [entity], retrieves its ID.
      */
     private fun <E : EntityState> updateList(
-        targetList: MutableState<List<E>>,
+        entities: List<E>,
         entity: E,
         extractId: (E) -> Any
-    ) {
-        val prevList = targetList.value
-        val existingItemIndex = prevList.indexOfFirst { e ->
+    ): List<E> {
+        val existingItemIndex = entities.indexOfFirst { e ->
             extractId(e) == extractId(entity)
         }
 
-        val newList = if (existingItemIndex != -1) {
-            prevList.subList(0, existingItemIndex) +
+        return if (existingItemIndex != -1) {
+            entities.subList(0, existingItemIndex) +
                     entity +
-                    prevList.subList(existingItemIndex + 1, prevList.size)
+                    entities.subList(existingItemIndex + 1, entities.size)
         } else {
-            prevList + entity
+            entities + entity
         }
-
-        targetList.value = newList
     }
 }
 
 /**
  * An [EventSubscription] implementation.
  *
- * @param spineClient A Spine Event Engine's [Client][io.spine.client.Client]
- *   instance where the subscription is being registered.
+ * @param cancelSubscriptionRequest Sends an explicit subscription cancellation
+ *   request to the server.
  */
 internal open class EventSubscriptionImpl(
-    private val spineClient: io.spine.client.Client
+    private val cancelSubscriptionRequest: (Subscription) -> Unit
 ) : EventSubscription {
-    override val active: Boolean get() = subscription != null
+
+    private val stateLock = Any()
+
+    override val active: Boolean
+        get() = synchronized(stateLock) {
+            subscription != null
+        }
 
     /**
-     * A flag specifying whether the subscription has been canceled.
+     * A flag specifying whether the subscription has been cancelled or failed.
      *
      * It is the same as ![active] with one difference. Since the subscription
      * activation can take a notable period of time (especially with network
@@ -306,13 +422,19 @@ internal open class EventSubscriptionImpl(
      * It is only needed internally because [Client.onEvent] returns only after
      * the subscription has been activated or after its activation has failed.
      */
-    internal var canceled = false
+    internal val canceled: Boolean
+        get() = synchronized(stateLock) {
+            isCancelled
+        }
+
+    private var isCancelled = false
+    private var cancelWhenInstalled = false
 
     /**
      * A Spine [Subscription], which was made, or `null` if it either hasn't
      * been made yet, or cancelled already.
      */
-    var subscription: Subscription? = null
+    private var subscription: Subscription? = null
 
     private var timeoutJob: Job? = null
 
@@ -351,17 +473,78 @@ internal open class EventSubscriptionImpl(
         cancelTimeout()
     }
 
+    /**
+     * Installs a successfully created subscription unless this handle has
+     * already received a failure or cancellation.
+     */
+    internal fun install(newSubscription: Subscription) {
+        val shouldCancel = synchronized(stateLock) {
+            if (!isCancelled) {
+                subscription = newSubscription
+                false
+            } else {
+                val pendingCancellation = cancelWhenInstalled
+                cancelWhenInstalled = false
+                pendingCancellation
+            }
+        }
+        if (shouldCancel) {
+            sendCancellationSafely(newSubscription)
+        }
+    }
+
+    /**
+     * Marks the subscription as inactive after its stream has failed.
+     *
+     * No cancellation request is sent because the server has already ended
+     * and removed the failed subscription.
+     *
+     * @return `true` if this is the first terminal signal for the subscription.
+     */
+    internal fun onStreamingFailure(): Boolean {
+        val failureAccepted = synchronized(stateLock) {
+            if (isCancelled) {
+                false
+            } else {
+                isCancelled = true
+                cancelWhenInstalled = false
+                subscription = null
+                true
+            }
+        }
+        if (failureAccepted) {
+            cancelTimeout()
+        }
+        return failureAccepted
+    }
+
     override fun cancel() {
         cancelSubscription()
         cancelTimeout()
     }
 
     private fun cancelSubscription() {
-        if (subscription != null) {
-            spineClient.subscriptions().cancel(subscription!!)
+        val previousSubscription = synchronized(stateLock) {
+            if (isCancelled) {
+                return@synchronized null
+            }
+            val current = subscription
             subscription = null
+            isCancelled = true
+            cancelWhenInstalled = current == null
+            current
         }
-        canceled = true
+        if (previousSubscription != null) {
+            sendCancellationSafely(previousSubscription)
+        }
+    }
+
+    private fun sendCancellationSafely(subscription: Subscription) {
+        try {
+            cancelSubscriptionRequest(subscription)
+        } catch (_: Exception) {
+            // The server may already have removed a failed subscription.
+        }
     }
 
     private fun cancelTimeout() {

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -27,6 +27,7 @@
 package io.spine.chords.client
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
@@ -200,6 +201,16 @@ public abstract class EntityChooser<
     override fun itemContent(entityId: I, entityItemText: String) {
         val entityState = entityById(entityId)
         itemContent(entityId, entityState, entityItemText)
+    }
+
+    @Composable
+    override fun content() {
+        DisposableEffect(entityStates) {
+            onDispose {
+                entityStates.cancel()
+            }
+        }
+        super.content()
     }
 
     @Composable

--- a/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/EntityChooser.kt
@@ -91,7 +91,15 @@ public abstract class EntityChooser<
     }
 
     override val items: MutableState<Iterable<I>> = mutableStateOf(listOf())
+
+    /**
+     * The live observation that supplies entity states for this chooser.
+     */
     private val entityStates = app.client.readAndObserve(entityStateClass, ::entityId)
+
+    /**
+     * The latest observed entity states indexed by their IDs.
+     */
     private val entityStatesByIds: HashMap<I, E> = hashMapOf()
 
     /**

--- a/client/src/main/kotlin/io/spine/chords/client/ObservationRecoveryCoordinator.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/ObservationRecoveryCoordinator.kt
@@ -50,19 +50,53 @@ internal class ObservationRecoveryCoordinator(
     coroutineContext: CoroutineContext = IO
 ) {
 
+    /**
+     * Runs connection processing and observation recovery tasks.
+     */
     private val scope =
         CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())
+
+    /**
+     * The observations managed by this coordinator.
+     */
     private val observations =
         ConcurrentHashMap.newKeySet<RecoverableDataObservation>()
+
+    /**
+     * The observations that currently have a connection-aware retry loop.
+     */
     private val retryingObservations =
         ConcurrentHashMap.newKeySet<RecoverableDataObservation>()
+
+    /**
+     * Guards connection status transition state.
+     */
     private val stateLock = Any()
+
+    /**
+     * Serializes connection status changes for ordered processing.
+     */
     private val connectionStatusChanges =
         Channel<ConnectionStatus>(Channel.UNLIMITED)
+
+    /**
+     * Prevents the status-processing coroutine from being started more than once.
+     */
     private val started = AtomicBoolean(false)
+
+    /**
+     * Indicates whether this coordinator has stopped accepting work.
+     */
     private val closed = AtomicBoolean(false)
 
+    /**
+     * Indicates that an unavailable status has not yet been followed by reconnection.
+     */
     private var connectionWasUnavailable = false
+
+    /**
+     * The latest connection status processed by this coordinator.
+     */
     private var connectionStatus = ConnectionStatus.IDLE
 
     /**
@@ -156,6 +190,9 @@ internal class ObservationRecoveryCoordinator(
         scope.cancel()
     }
 
+    /**
+     * Applies a connection [status] transition to all registered observations.
+     */
     private fun processConnectionStatus(status: ConnectionStatus) {
         val connectionLost: Boolean
         synchronized(stateLock) {
@@ -183,12 +220,18 @@ internal class ObservationRecoveryCoordinator(
         }
     }
 
+    /**
+     * Refreshes the given [observation] in the coordinator scope.
+     */
     private fun refresh(observation: RecoverableDataObservation) {
         scope.launch {
             observation.refresh()
         }
     }
 
+    /**
+     * Checks whether the given [observation] still needs a connected retry.
+     */
     private fun shouldRetry(observation: RecoverableDataObservation): Boolean {
         val connected = synchronized(stateLock) {
             connectionStatus == ConnectionStatus.CONNECTED

--- a/client/src/main/kotlin/io/spine/chords/client/ObservationRecoveryCoordinator.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/ObservationRecoveryCoordinator.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Prevents a repeatedly failing subscription stream from causing a tight retry loop.
+ */
+private const val ObservationRetryDelayMillis = 1_000L
+
+/**
+ * Suspends and refreshes data observations as connectivity changes.
+ */
+internal class ObservationRecoveryCoordinator(
+    coroutineContext: CoroutineContext = IO
+) {
+
+    private val scope =
+        CoroutineScope(coroutineContext.minusKey(Job) + SupervisorJob())
+    private val observations =
+        ConcurrentHashMap.newKeySet<RecoverableDataObservation>()
+    private val retryingObservations =
+        ConcurrentHashMap.newKeySet<RecoverableDataObservation>()
+    private val stateLock = Any()
+    private val connectionStatusChanges =
+        Channel<ConnectionStatus>(Channel.UNLIMITED)
+    private val started = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+
+    private var connectionWasUnavailable = false
+    private var connectionStatus = ConnectionStatus.IDLE
+
+    /**
+     * Starts processing connection status changes.
+     */
+    fun start() {
+        if (!closed.get() && started.compareAndSet(false, true)) {
+            scope.launch {
+                for (status in connectionStatusChanges) {
+                    processConnectionStatus(status)
+                }
+            }
+        }
+    }
+
+    /**
+     * Registers the given observation for automatic recovery.
+     */
+    fun register(
+        observation: RecoverableDataObservation,
+        connectionStatus: ConnectionStatus
+    ) {
+        observations.add(observation)
+        val unavailable = synchronized(stateLock) {
+            connectionWasUnavailable || connectionStatus == ConnectionStatus.UNAVAILABLE
+        }
+        if (unavailable) {
+            observation.waitForConnection()
+        } else if (connectionStatus == ConnectionStatus.CONNECTED &&
+            observation.needsRecovery
+        ) {
+            refresh(observation)
+        }
+    }
+
+    /**
+     * Unregisters the given observation.
+     */
+    fun unregister(observation: RecoverableDataObservation) {
+        observations.remove(observation)
+    }
+
+    /**
+     * Retries an observation whose stream failed while the channel remained connected.
+     */
+    fun retryWhileConnected(observation: RecoverableDataObservation) {
+        if (closed.get() ||
+            observation !in observations ||
+            !retryingObservations.add(observation)
+        ) {
+            return
+        }
+        scope.launch {
+            try {
+                while (shouldRetry(observation)) {
+                    delay(ObservationRetryDelayMillis)
+                    if (shouldRetry(observation)) {
+                        observation.refresh()
+                    }
+                }
+            } finally {
+                retryingObservations.remove(observation)
+            }
+        }
+    }
+
+    /**
+     * Schedules an update of all registered observations for the new connection
+     * status.
+     */
+    fun onConnectionStatusChanged(status: ConnectionStatus) {
+        val sent = connectionStatusChanges.trySend(status)
+        check(sent.isSuccess || closed.get()) {
+            "Unable to schedule connection status change: $status."
+        }
+    }
+
+    /**
+     * Cancels all observations and stops automatic recovery.
+     */
+    fun close() {
+        if (!closed.compareAndSet(false, true)) {
+            return
+        }
+        connectionStatusChanges.close()
+        observations.toList().forEach {
+            it.close()
+        }
+        observations.clear()
+        retryingObservations.clear()
+        scope.cancel()
+    }
+
+    private fun processConnectionStatus(status: ConnectionStatus) {
+        val connectionLost: Boolean
+        synchronized(stateLock) {
+            connectionStatus = status
+            connectionLost =
+                status == ConnectionStatus.UNAVAILABLE && !connectionWasUnavailable
+            if (connectionLost) {
+                connectionWasUnavailable = true
+            }
+            if (status == ConnectionStatus.CONNECTED) {
+                connectionWasUnavailable = false
+            }
+        }
+
+        if (connectionLost) {
+            observations.toList().forEach {
+                it.waitForConnection()
+            }
+        } else if (status == ConnectionStatus.CONNECTED) {
+            observations.toList().forEach {
+                if (it.needsRecovery) {
+                    refresh(it)
+                }
+            }
+        }
+    }
+
+    private fun refresh(observation: RecoverableDataObservation) {
+        scope.launch {
+            observation.refresh()
+        }
+    }
+
+    private fun shouldRetry(observation: RecoverableDataObservation): Boolean {
+        val connected = synchronized(stateLock) {
+            connectionStatus == ConnectionStatus.CONNECTED
+        }
+        return !closed.get() &&
+                connected &&
+                observation in observations &&
+                observation.needsRecovery
+    }
+}

--- a/client/src/test/kotlin/io/spine/chords/client/ConnectionMonitorSpec.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/ConnectionMonitorSpec.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import io.grpc.ConnectivityState
+import io.grpc.ConnectivityState.CONNECTING
+import io.grpc.ConnectivityState.IDLE
+import io.grpc.ConnectivityState.READY
+import io.grpc.ConnectivityState.SHUTDOWN
+import io.grpc.ConnectivityState.TRANSIENT_FAILURE
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+import kotlin.concurrent.thread
+import org.junit.jupiter.api.Test
+
+internal class ConnectionMonitorSpec {
+
+    @Test
+    fun `report channel connectivity and request reconnection`() {
+        val channel = FakeConnectivityChannel()
+        val statuses = mutableListOf<ConnectionStatus>()
+        val monitor = ConnectionMonitor(
+            channel::getState,
+            channel::notifyWhenStateChanged
+        ) { status ->
+            statuses += status
+        }
+
+        monitor.start()
+        channel.moveTo(CONNECTING)
+        channel.moveTo(READY)
+        channel.moveTo(TRANSIENT_FAILURE)
+        channel.moveTo(CONNECTING)
+        channel.moveTo(READY)
+
+        channel.requestConnectionCalls shouldBe 6
+        statuses shouldContainExactly listOf(
+            ConnectionStatus.CONNECTING,
+            ConnectionStatus.CONNECTED,
+            ConnectionStatus.UNAVAILABLE,
+            ConnectionStatus.CONNECTING,
+            ConnectionStatus.CONNECTED
+        )
+        monitor.status.value shouldBe ConnectionStatus.CONNECTED
+    }
+
+    @Test
+    fun `stop observing after closing`() {
+        val channel = FakeConnectivityChannel()
+        val monitor = ConnectionMonitor(
+            channel::getState,
+            channel::notifyWhenStateChanged
+        ) { }
+
+        monitor.start()
+        monitor.close()
+        channel.moveTo(READY)
+
+        monitor.status.value shouldBe ConnectionStatus.CLOSED
+        channel.requestConnectionCalls shouldBe 1
+    }
+
+    @Test
+    fun `close when channel shuts down`() {
+        val channel = FakeConnectivityChannel()
+        val monitor = ConnectionMonitor(
+            channel::getState,
+            channel::notifyWhenStateChanged
+        ) { }
+
+        monitor.start()
+        channel.moveTo(SHUTDOWN)
+
+        monitor.status.value shouldBe ConnectionStatus.CLOSED
+    }
+
+    @Test
+    fun `keep closed status when connectivity callback is already running`() {
+        val channel = FakeConnectivityChannel()
+        val stateReadStarted = CountDownLatch(1)
+        val allowStateRead = CountDownLatch(1)
+        val monitor = ConnectionMonitor(
+            channel::getState,
+            channel::notifyWhenStateChanged
+        ) { }
+        monitor.start()
+        channel.beforeGetState = {
+            stateReadStarted.countDown()
+            allowStateRead.await(5, SECONDS)
+        }
+        val transition = thread {
+            channel.moveTo(READY)
+        }
+        stateReadStarted.await(5, SECONDS) shouldBe true
+
+        monitor.close()
+        allowStateRead.countDown()
+        transition.join(5_000)
+
+        transition.isAlive shouldBe false
+        monitor.status.value shouldBe ConnectionStatus.CLOSED
+    }
+}
+
+private class FakeConnectivityChannel {
+
+    var requestConnectionCalls: Int = 0
+        private set
+
+    private var state: ConnectivityState = IDLE
+    private var callback: Runnable? = null
+    var beforeGetState: (() -> Unit)? = null
+
+    fun getState(requestConnection: Boolean): ConnectivityState {
+        beforeGetState?.invoke()
+        if (requestConnection) {
+            requestConnectionCalls++
+        }
+        return state
+    }
+
+    fun notifyWhenStateChanged(source: ConnectivityState, callback: Runnable) {
+        check(source == state)
+        this.callback = callback
+    }
+
+    fun moveTo(newState: ConnectivityState) {
+        state = newState
+        val stateChanged = callback
+        callback = null
+        stateChanged?.run()
+    }
+}

--- a/client/src/test/kotlin/io/spine/chords/client/DataObservationImplSpec.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/DataObservationImplSpec.kt
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import androidx.compose.runtime.snapshots.Snapshot
+import io.grpc.Status
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+internal class DataObservationImplSpec {
+
+    @Test
+    fun `read initial data and apply subscription updates`() {
+        val source = FakeObservationSource("initial")
+        val observation = source.createObservation()
+
+        observation.initialize()
+        source.emit("updated")
+
+        observation.value shouldBe "updated"
+        observation.status.value shouldBe DataObservationStatus.Active
+    }
+
+    @Test
+    fun `read data after subscription is established`() {
+        val source = FakeObservationSource("before subscription")
+        source.onSubscribe = {
+            source.readValue = "after subscription"
+        }
+        val observation = source.createObservation()
+
+        observation.initialize()
+
+        observation.value shouldBe "after subscription"
+        observation.status.value shouldBe DataObservationStatus.Active
+    }
+
+    @Test
+    fun `publish initial data in the snapshot that creates the observation`() {
+        val source = FakeObservationSource("initial")
+        val snapshot = Snapshot.takeMutableSnapshot()
+        try {
+            snapshot.enter {
+                val observation = source.createObservation()
+
+                observation.initialize()
+
+                observation.value shouldBe "initial"
+                observation.status.value shouldBe DataObservationStatus.Active
+            }
+            snapshot.apply().check()
+        } finally {
+            snapshot.dispose()
+        }
+    }
+
+    @Test
+    fun `retain data and wait when initial read cannot connect`() {
+        val source = FakeObservationSource("unused")
+        source.readFailure = Status.UNAVAILABLE.asRuntimeException()
+        val observation = source.createObservation(
+            initialValue = "fallback",
+            connectionStatus = { ConnectionStatus.UNAVAILABLE }
+        )
+
+        observation.initialize()
+
+        observation.value shouldBe "fallback"
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        source.subscribeCalls shouldBe 1
+        source.cancelCalls shouldBe 0
+    }
+
+    @Test
+    fun `cancel live subscription when read times out on connected channel`() {
+        val source = FakeObservationSource("unused")
+        source.readFailure = Status.DEADLINE_EXCEEDED.asRuntimeException()
+        val observation = source.createObservation(initialValue = "fallback")
+
+        observation.initialize()
+
+        observation.value shouldBe "fallback"
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        source.cancelCalls shouldBe 1
+    }
+
+    @Test
+    fun `capture non-connection read failure without throwing`() {
+        val failure = IllegalStateException("Invalid query")
+        val source = FakeObservationSource("unused")
+        source.readFailure = failure
+        val observation = source.createObservation(initialValue = "fallback")
+
+        observation.initialize()
+
+        observation.value shouldBe "fallback"
+        val status = observation.status.value as DataObservationStatus.Failed
+        (status.error === failure) shouldBe true
+        source.subscribeCalls shouldBe 1
+        source.cancelCalls shouldBe 1
+    }
+
+    @Test
+    fun `capture non-connection subscription failure without throwing`() {
+        val failure = IllegalStateException("Invalid subscription")
+        val source = FakeObservationSource("initial")
+        source.subscribeFailure = failure
+        val observation = source.createObservation()
+
+        observation.initialize()
+
+        observation.value shouldBe "initial"
+        val status = observation.status.value as DataObservationStatus.Failed
+        (status.error === failure) shouldBe true
+    }
+
+    @Test
+    fun `propagate cancellation without converting it into failure status`() {
+        val cancellation = CancellationException("Caller cancelled refresh.")
+        val source = FakeObservationSource("unused")
+        source.readFailure = cancellation
+        val observation = source.createObservation()
+
+        shouldThrow<CancellationException> {
+            observation.initialize()
+        }
+
+        observation.status.value shouldBe DataObservationStatus.Refreshing
+        observation.needsRecovery shouldBe false
+    }
+
+    @Test
+    fun `not mistake server rejection for connection failure`() {
+        val failure = Status.PERMISSION_DENIED.asRuntimeException()
+        val source = FakeObservationSource("unused")
+        source.readFailure = failure
+        val observation = source.createObservation(
+            connectionStatus = { ConnectionStatus.UNAVAILABLE }
+        )
+
+        observation.initialize()
+
+        observation.status.value shouldBe DataObservationStatus.Failed(failure)
+    }
+
+    @Test
+    fun `report programming failure while connection is starting`() {
+        val failure = IllegalStateException("Invalid query")
+        val source = FakeObservationSource("unused")
+        source.readFailure = failure
+        val observation = source.createObservation(
+            connectionStatus = { ConnectionStatus.CONNECTING }
+        )
+
+        observation.initialize()
+
+        observation.status.value shouldBe DataObservationStatus.Failed(failure)
+        observation.needsRecovery shouldBe false
+    }
+
+    @Test
+    fun `not overwrite server failure when connection monitor reports loss`() {
+        val failure = Status.PERMISSION_DENIED.asRuntimeException()
+        val source = FakeObservationSource("unused")
+        source.readFailure = failure
+        val observation = source.createObservation()
+        observation.initialize()
+
+        observation.waitForConnection()
+
+        observation.status.value shouldBe DataObservationStatus.Failed(failure)
+        observation.needsRecovery shouldBe false
+    }
+
+    @Test
+    fun `retry failed observation only when explicitly refreshed`() {
+        val source = FakeObservationSource("refreshed")
+        source.readFailure = IllegalStateException("Invalid query")
+        val observation = source.createObservation(initialValue = "fallback")
+        observation.initialize()
+        source.readFailure = null
+
+        runBlocking {
+            observation.refresh()
+        }
+
+        observation.value shouldBe "refreshed"
+        observation.status.value shouldBe DataObservationStatus.Active
+    }
+
+    @Test
+    fun `replace data and subscription when refreshed`() {
+        val source = FakeObservationSource("initial")
+        val observation = source.createObservation()
+        observation.initialize()
+        source.readValue = "refreshed"
+
+        runBlocking {
+            observation.refresh()
+        }
+
+        observation.value shouldBe "refreshed"
+        observation.status.value shouldBe DataObservationStatus.Active
+        source.subscribeCalls shouldBe 2
+        source.cancelCalls shouldBe 1
+    }
+
+    @Test
+    fun `wait for reconnect after streaming failure`() {
+        val source = FakeObservationSource("initial")
+        val observation = source.createObservation()
+        observation.initialize()
+
+        source.fail(Status.UNAVAILABLE.asRuntimeException())
+
+        observation.value shouldBe "initial"
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        observation.needsRecovery shouldBe true
+        source.cancelCalls shouldBe 0
+    }
+
+    @Test
+    fun `request retry when stream fails on connected channel`() {
+        val source = FakeObservationSource("initial")
+        var recoveryRequests = 0
+        val observation = source.createObservation(
+            onRecoveryNeeded = {
+                recoveryRequests++
+            }
+        )
+        observation.initialize()
+
+        source.fail(Status.UNAVAILABLE.asRuntimeException())
+
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        recoveryRequests shouldBe 1
+        source.cancelCalls shouldBe 0
+    }
+
+    @Test
+    fun `not cancel subscription after connection is lost`() {
+        val source = FakeObservationSource("initial")
+        val observation = source.createObservation()
+        observation.initialize()
+
+        observation.waitForConnection()
+
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        observation.needsRecovery shouldBe true
+        source.cancelCalls shouldBe 0
+    }
+
+    @Test
+    fun `exclude cancelled observation from recovery`() {
+        val source = FakeObservationSource("initial")
+        var cancelled = false
+        val observation = source.createObservation {
+            cancelled = true
+        }
+        observation.initialize()
+
+        observation.cancel()
+        runBlocking {
+            observation.refresh()
+        }
+
+        observation.status.value shouldBe DataObservationStatus.Cancelled
+        observation.needsRecovery shouldBe false
+        source.readCalls shouldBe 1
+        source.cancelCalls shouldBe 1
+        cancelled shouldBe true
+    }
+
+    @Test
+    fun `close without cancelling server subscription`() {
+        val source = FakeObservationSource("initial")
+        var closed = false
+        val observation = source.createObservation {
+            closed = true
+        }
+        observation.initialize()
+
+        observation.close()
+
+        observation.status.value shouldBe DataObservationStatus.Cancelled
+        observation.needsRecovery shouldBe false
+        source.cancelCalls shouldBe 0
+        closed shouldBe true
+    }
+
+    @Test
+    fun `cancel subscription created after concurrent cancellation`() = runBlocking {
+        val subscribeStarted = CountDownLatch(1)
+        val allowSubscribe = CountDownLatch(1)
+        val cancelCalls = AtomicInteger()
+        val observation = blockingObservation(
+            subscribeStarted,
+            allowSubscribe,
+            cancelCalls
+        )
+
+        val refresh = launch(IO) {
+            observation.refresh()
+        }
+        subscribeStarted.await(5, SECONDS) shouldBe true
+        observation.cancel()
+        allowSubscribe.countDown()
+        refresh.join()
+
+        observation.status.value shouldBe DataObservationStatus.Cancelled
+        cancelCalls.get() shouldBe 1
+    }
+
+    @Test
+    fun `not cancel subscription created after connection is lost`() = runBlocking {
+        val subscribeStarted = CountDownLatch(1)
+        val allowSubscribe = CountDownLatch(1)
+        val cancelCalls = AtomicInteger()
+        val observation = blockingObservation(
+            subscribeStarted,
+            allowSubscribe,
+            cancelCalls
+        )
+
+        val refresh = launch(IO) {
+            observation.refresh()
+        }
+        subscribeStarted.await(5, SECONDS) shouldBe true
+        observation.waitForConnection()
+        allowSubscribe.countDown()
+        refresh.join()
+
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        observation.needsRecovery shouldBe true
+        cancelCalls.get() shouldBe 0
+    }
+
+    @Test
+    fun `not cancel subscription that reports failure before installation`() {
+        val cancelCalls = AtomicInteger()
+        val observation = DataObservationImpl(
+            "",
+            { "value" },
+            { _, onError ->
+                onError(Status.UNAVAILABLE.asRuntimeException())
+                ObservationSubscription {
+                    cancelCalls.incrementAndGet()
+                }
+            },
+            { _, update: String -> update },
+            { ConnectionStatus.UNAVAILABLE },
+            {}
+        )
+
+        observation.initialize()
+
+        observation.status.value shouldBe DataObservationStatus.WaitingForConnection
+        cancelCalls.get() shouldBe 0
+    }
+}
+
+private fun blockingObservation(
+    subscribeStarted: CountDownLatch,
+    allowSubscribe: CountDownLatch,
+    cancelCalls: AtomicInteger
+): DataObservationImpl<String, String> = DataObservationImpl(
+    "",
+    { "value" },
+    { _, _ ->
+        subscribeStarted.countDown()
+        check(allowSubscribe.await(5, SECONDS)) {
+            "Timed out waiting to finish subscription setup."
+        }
+        ObservationSubscription {
+            cancelCalls.incrementAndGet()
+        }
+    },
+    { _, update -> update },
+    { ConnectionStatus.CONNECTED },
+    {}
+)
+
+private class FakeObservationSource(
+    var readValue: String
+) {
+
+    var readCalls: Int = 0
+        private set
+    var subscribeCalls: Int = 0
+        private set
+    var cancelCalls: Int = 0
+        private set
+    var readFailure: Exception? = null
+    var subscribeFailure: Exception? = null
+    var cancelFailure: io.grpc.StatusRuntimeException? = null
+    var onSubscribe: (() -> Unit)? = null
+
+    private var onUpdate: ((String) -> Unit)? = null
+    private var onError: ((Throwable) -> Unit)? = null
+
+    fun createObservation(
+        initialValue: String = "",
+        connectionStatus: () -> ConnectionStatus = { ConnectionStatus.CONNECTED },
+        onRecoveryNeeded: (RecoverableDataObservation) -> Unit = {},
+        onCancelled: (RecoverableDataObservation) -> Unit = {}
+    ): DataObservationImpl<String, String> = DataObservationImpl(
+        initialValue,
+        {
+            readCalls++
+            readFailure?.let { throw it }
+            readValue
+        },
+        { update, error ->
+            subscribeCalls++
+            subscribeFailure?.let { throw it }
+            onSubscribe?.invoke()
+            onUpdate = update
+            onError = error
+            ObservationSubscription {
+                cancelCalls++
+                cancelFailure?.let { throw it }
+            }
+        },
+        { _, update -> update },
+        connectionStatus,
+        onCancelled,
+        onRecoveryNeeded
+    )
+
+    fun emit(value: String) {
+        onUpdate?.invoke(value)
+    }
+
+    fun fail(error: Throwable) {
+        onError?.invoke(error)
+    }
+}

--- a/client/src/test/kotlin/io/spine/chords/client/EventSubscriptionImplSpec.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/EventSubscriptionImplSpec.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import io.kotest.matchers.shouldBe
+import io.spine.client.Subscription
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Test
+
+internal class EventSubscriptionImplSpec {
+
+    @Test
+    fun `not cancel subscription after its stream fails`() {
+        val cancelCalls = AtomicInteger()
+        val eventSubscription = EventSubscriptionImpl {
+            cancelCalls.incrementAndGet()
+        }
+        eventSubscription.install(Subscription.getDefaultInstance())
+
+        eventSubscription.onStreamingFailure()
+        eventSubscription.cancel()
+
+        eventSubscription.active shouldBe false
+        eventSubscription.canceled shouldBe true
+        cancelCalls.get() shouldBe 0
+    }
+
+    @Test
+    fun `not install subscription after synchronous streaming failure`() {
+        val cancelCalls = AtomicInteger()
+        val eventSubscription = EventSubscriptionImpl {
+            cancelCalls.incrementAndGet()
+        }
+
+        eventSubscription.onStreamingFailure()
+        eventSubscription.install(Subscription.getDefaultInstance())
+        eventSubscription.cancel()
+
+        eventSubscription.active shouldBe false
+        cancelCalls.get() shouldBe 0
+    }
+
+    @Test
+    fun `not cancel late subscription after failure followed by cancellation`() {
+        val cancelCalls = AtomicInteger()
+        val eventSubscription = EventSubscriptionImpl {
+            cancelCalls.incrementAndGet()
+        }
+
+        eventSubscription.onStreamingFailure()
+        eventSubscription.cancel()
+        eventSubscription.install(Subscription.getDefaultInstance())
+
+        eventSubscription.active shouldBe false
+        cancelCalls.get() shouldBe 0
+    }
+
+    @Test
+    fun `cancel active subscription explicitly`() {
+        val cancelCalls = AtomicInteger()
+        val eventSubscription = EventSubscriptionImpl {
+            cancelCalls.incrementAndGet()
+        }
+        eventSubscription.install(Subscription.getDefaultInstance())
+
+        eventSubscription.cancel()
+        eventSubscription.cancel()
+
+        eventSubscription.active shouldBe false
+        eventSubscription.canceled shouldBe true
+        cancelCalls.get() shouldBe 1
+    }
+
+    @Test
+    fun `cancel subscription installed after explicit cancellation`() {
+        val cancelCalls = AtomicInteger()
+        val eventSubscription = EventSubscriptionImpl {
+            cancelCalls.incrementAndGet()
+        }
+
+        eventSubscription.cancel()
+        eventSubscription.install(Subscription.getDefaultInstance())
+
+        eventSubscription.active shouldBe false
+        cancelCalls.get() shouldBe 1
+    }
+
+    @Test
+    fun `ignore cancellation request failure for active subscription`() {
+        val eventSubscription = EventSubscriptionImpl {
+            throw IllegalStateException("Subscription is already gone.")
+        }
+        eventSubscription.install(Subscription.getDefaultInstance())
+
+        eventSubscription.cancel()
+
+        eventSubscription.active shouldBe false
+        eventSubscription.canceled shouldBe true
+    }
+
+    @Test
+    fun `ignore cancellation request failure for late subscription`() {
+        val eventSubscription = EventSubscriptionImpl {
+            throw IllegalStateException("Subscription is already gone.")
+        }
+        eventSubscription.cancel()
+
+        eventSubscription.install(Subscription.getDefaultInstance())
+
+        eventSubscription.active shouldBe false
+        eventSubscription.canceled shouldBe true
+    }
+}

--- a/client/src/test/kotlin/io/spine/chords/client/ObservationRecoveryCoordinatorSpec.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/ObservationRecoveryCoordinatorSpec.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ObservationRecoveryCoordinatorSpec {
+
+    @Test
+    fun `process connection changes outside notifying thread`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        coordinator.register(observation, ConnectionStatus.CONNECTED)
+
+        coordinator.onConnectionStatusChanged(ConnectionStatus.UNAVAILABLE)
+
+        observation.waitCalls shouldBe 0
+        runCurrent()
+        observation.waitCalls shouldBe 1
+        coordinator.close()
+    }
+
+    @Test
+    fun `refresh observations once after connection is restored`() = runTest {
+        val coordinator = createCoordinator()
+        val first = FakeRecoverableObservation()
+        val second = FakeRecoverableObservation()
+        coordinator.register(first, ConnectionStatus.CONNECTED)
+        coordinator.register(second, ConnectionStatus.CONNECTED)
+
+        coordinator.onConnectionStatusChanged(ConnectionStatus.UNAVAILABLE)
+        runCurrent()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTING)
+        runCurrent()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.UNAVAILABLE)
+        runCurrent()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTING)
+        runCurrent()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+
+        first.waitCalls shouldBe 1
+        second.waitCalls shouldBe 1
+        first.refreshCalls shouldBe 1
+        second.refreshCalls shouldBe 1
+        coordinator.close()
+    }
+
+    @Test
+    fun `not refresh on initial connection`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        coordinator.register(observation, ConnectionStatus.CONNECTING)
+
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+
+        observation.refreshCalls shouldBe 0
+        coordinator.close()
+    }
+
+    @Test
+    fun `recover waiting observation on first successful connection`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        observation.waitForConnection()
+        coordinator.register(observation, ConnectionStatus.CONNECTING)
+
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+
+        observation.refreshCalls shouldBe 1
+        coordinator.close()
+    }
+
+    @Test
+    fun `recover observation registered while disconnected`() = runTest {
+        val coordinator = createCoordinator()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.UNAVAILABLE)
+        runCurrent()
+        val observation = FakeRecoverableObservation()
+
+        coordinator.register(observation, ConnectionStatus.UNAVAILABLE)
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+
+        observation.waitCalls shouldBe 1
+        observation.refreshCalls shouldBe 1
+        coordinator.close()
+    }
+
+    @Test
+    fun `retry waiting observation while connection remains available`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        coordinator.register(observation, ConnectionStatus.CONNECTED)
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+        observation.waitForConnection()
+
+        coordinator.retryWhileConnected(observation)
+        coordinator.retryWhileConnected(observation)
+        runCurrent()
+        advanceTimeBy(1_000)
+        runCurrent()
+
+        observation.refreshCalls shouldBe 1
+        observation.needsRecovery shouldBe false
+        coordinator.close()
+    }
+
+    @Test
+    fun `back off between repeated stream recovery attempts`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        observation.remainWaitingAfterRefresh = true
+        coordinator.register(observation, ConnectionStatus.CONNECTED)
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+        observation.waitForConnection()
+
+        coordinator.retryWhileConnected(observation)
+        runCurrent()
+        advanceTimeBy(999)
+        runCurrent()
+        observation.refreshCalls shouldBe 0
+        advanceTimeBy(1)
+        runCurrent()
+        observation.refreshCalls shouldBe 1
+        advanceTimeBy(1_000)
+        runCurrent()
+        observation.refreshCalls shouldBe 2
+        coordinator.close()
+    }
+
+    @Test
+    fun `exclude unregistered observation from recovery`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        coordinator.register(observation, ConnectionStatus.CONNECTED)
+        coordinator.unregister(observation)
+
+        coordinator.onConnectionStatusChanged(ConnectionStatus.UNAVAILABLE)
+        runCurrent()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
+        runCurrent()
+
+        observation.waitCalls shouldBe 0
+        observation.refreshCalls shouldBe 0
+        coordinator.close()
+    }
+
+    @Test
+    fun `not cancel job supplied in coroutine context`() = runTest {
+        val suppliedJob = backgroundScope.coroutineContext[Job]!!
+        val coordinator = ObservationRecoveryCoordinator(
+            backgroundScope.coroutineContext
+        )
+        coordinator.start()
+
+        coordinator.close()
+        coordinator.onConnectionStatusChanged(ConnectionStatus.CLOSED)
+
+        suppliedJob.isActive shouldBe true
+    }
+
+    @Test
+    fun `close observations without cancelling subscriptions individually`() = runTest {
+        val coordinator = createCoordinator()
+        val observation = FakeRecoverableObservation()
+        coordinator.register(observation, ConnectionStatus.CONNECTED)
+
+        coordinator.close()
+
+        observation.closeCalls shouldBe 1
+        observation.cancelCalls shouldBe 0
+    }
+}
+
+private fun TestScope.createCoordinator(): ObservationRecoveryCoordinator =
+    ObservationRecoveryCoordinator(
+        StandardTestDispatcher(testScheduler)
+    ).also {
+        it.start()
+    }
+
+private class FakeRecoverableObservation : RecoverableDataObservation {
+
+    var waitCalls: Int = 0
+        private set
+    var refreshCalls: Int = 0
+        private set
+    var cancelCalls: Int = 0
+        private set
+    var closeCalls: Int = 0
+        private set
+    var remainWaitingAfterRefresh: Boolean = false
+
+    override var needsRecovery: Boolean = false
+        private set
+
+    override fun waitForConnection() {
+        waitCalls++
+        needsRecovery = true
+    }
+
+    override suspend fun refresh() {
+        refreshCalls++
+        needsRecovery = remainWaitingAfterRefresh
+    }
+
+    override fun cancel() {
+        cancelCalls++
+    }
+
+    override fun close() {
+        closeCalls++
+    }
+}

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -200,7 +200,7 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
     }
 
     @Composable
-    override fun content() {
+    override fun content(): Unit = recompositionWorkaround {
         if (!::fieldColors.isInitialized) {
             fieldColors = TextFieldDefaults.colors()
         }

--- a/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/DropdownSelector.kt
@@ -226,6 +226,9 @@ public abstract class DropdownSelector<I> : InputComponent<I>() {
         }
     }
 
+    /**
+     * Renders the editable field that opens and filters the drop-down list.
+     */
     @Composable
     @OptIn(ExperimentalComposeUiApi::class)
     private fun DropdownListBoxScope.SelectorField() {

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -222,6 +222,9 @@ public class AppWindow(
 
 /**
  * A sign-in screen of the application.
+ *
+ * @param content The composable content displayed by the screen.
+ * @param onSuccessAuthentication Invoked after successful authentication.
  */
 private class SignInScreen(
     private val content: @Composable (onSuccessAuthentication: () -> Unit) -> Unit,

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/AppWindow.kt
@@ -28,6 +28,8 @@ package io.spine.chords.core.appshell
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -67,13 +69,16 @@ import java.awt.Dimension
  *   the application starts.
  * @param onCloseRequest An action that should be performed on window closing.
  * @param minWindowSize The minimal size of the application window.
+ * @param windowOverlay Content displayed over the current screen and under
+ *   application dialogs.
  */
 public class AppWindow(
     private val signInScreenContent: @Composable (onSuccessAuthentication: () -> Unit) -> Unit,
     views: List<AppView>,
     initialView: AppView?,
     private val onCloseRequest: () -> Unit,
-    private val minWindowSize: Dimension
+    private val minWindowSize: Dimension,
+    private val windowOverlay: @Composable BoxScope.() -> Unit = {}
 ) {
 
     /**
@@ -130,12 +135,15 @@ public class AppWindow(
                 window.minimumSize = minWindowSize
             }
             Box(
-                modifier = Modifier.background(MaterialTheme.colorScheme.background)
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
             ) {
                 Navigator(signInScreen) {
                     screenNavigator = it
                     CurrentScreen()
                 }
+                windowOverlay()
             }
             bottomDialog?.Content()
         }

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -176,6 +176,9 @@ public open class Application(
      */
     internal val sharedDefaults = SharedDefaults()
 
+    /**
+     * The UI API initialized when the application window is created.
+     */
     private var _ui: ApplicationUI? = null
 
     /**
@@ -251,6 +254,9 @@ public open class Application(
     protected open fun SharedDefaultsScope.sharedDefaults() {
     }
 
+    /**
+     * Creates the main application window with this application's configuration.
+     */
     private fun createAppWindow(onCloseRequest: () -> Unit): AppWindow {
         return AppWindow(
             signInScreenContent = {

--- a/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/appshell/Application.kt
@@ -26,6 +26,7 @@
 
 package io.spine.chords.core.appshell
 
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -252,13 +253,16 @@ public open class Application(
 
     private fun createAppWindow(onCloseRequest: () -> Unit): AppWindow {
         return AppWindow(
-            {
+            signInScreenContent = {
                 this.signInScreenContent(it)
             },
-            views,
-            initialView,
-            onCloseRequest,
-            minWindowSize
+            views = views,
+            initialView = initialView,
+            onCloseRequest = onCloseRequest,
+            minWindowSize = minWindowSize,
+            windowOverlay = {
+                AppWindowOverlay()
+            }
         )
     }
 
@@ -268,6 +272,18 @@ public open class Application(
     @Composable
     protected open fun appWindowContent(appWindow: AppWindow) {
         appWindow.content()
+    }
+
+    /**
+     * Renders content over the current screen inside the main application
+     * window.
+     *
+     * The overlay is displayed under application dialogs. Implementations can
+     * use the receiver's layout facilities to position their content.
+     */
+    @Composable
+    protected open fun BoxScope.AppWindowOverlay() {
+        // Do nothing by default.
     }
 
     /**

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 14:19:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 17:13:39 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Tue Jul 28 14:19:17 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 14:19:18 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 17:13:40 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Tue Jul 28 14:19:18 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 14:19:19 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 17:13:41 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Tue Jul 28 14:19:19 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 14:19:20 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 17:13:42 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Tue Jul 28 14:19:20 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 14:19:21 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 17:13:43 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Tue Jul 28 14:19:21 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 28 14:19:21 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 17:13:44 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.96</version>
+<version>2.0.0-SNAPSHOT.97</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -963,6 +963,10 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
          * a cached value is needed.
          */
         private var _effectivelyDirty: Boolean? = null
+
+        /**
+         * The last effective dirty state reported to the enclosing form.
+         */
         private var lastObservedEffectivelyDirty: Boolean? = null
 
         init {
@@ -1005,6 +1009,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             checkEffectivelyDirtyStateChange()
         }
 
+        /**
+         * Selects this field in its enclosing oneof, if it belongs to one.
+         */
         private fun selectThisOneofField() {
             val oneof = formOneof
             if (oneof != null) {
@@ -1030,6 +1037,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             checkEffectivelyDirtyStateChange()
         }
 
+        /**
+         * Recalculates the effective dirty state and propagates a change to the form.
+         */
         private fun checkEffectivelyDirtyStateChange() {
             _effectivelyDirty = null
             val effectivelyDirty = effectivelyDirty
@@ -1096,6 +1106,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         required = true
     }
 
+    /**
+     * The generated definition of the message edited by this form.
+     */
     private val messageDef by lazy { builder().messageDef() }
 
     /**
@@ -1132,6 +1145,10 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * that has been posted is being handled.
      */
     public val editorsEnabled: State<Boolean> get() = editorsEnabledInternal
+
+    /**
+     * The mutable backing state exposed through [editorsEnabled].
+     */
     private lateinit var editorsEnabledInternal: MutableState<Boolean>
 
     /**
@@ -1233,6 +1250,10 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      * any data.
      */
     public val dirty: Boolean get() = _dirty
+
+    /**
+     * The mutable backing value exposed through [dirty].
+     */
     private var _dirty = false
 
     override fun initialize() {
@@ -1409,6 +1430,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         editorsEnabledInternal.value = shouldEnableEditors
     }
 
+    /**
+     * Determines whether the form starts dirty for the given message value.
+     */
     private fun identifyInitialDirtyState(initialMessageValue: M?): Boolean = when {
         initialMessageValue == null ->
             false
@@ -1425,6 +1449,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
             false
     }
 
+    /**
+     * Determines whether the form should initially produce a non-null message.
+     */
     private fun identifyInitialEnteringNonNullValue(): Boolean = when {
         required || value.value != null ->
             true
@@ -1498,6 +1525,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         FormOneof(oneof, initialSelectedField)
     }
 
+    /**
+     * Recalculates and publishes the form-wide dirty state.
+     */
     private fun updateDirty() {
         val dirty =
             fields.values.any { it.effectivelyDirty } ||
@@ -1647,6 +1677,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
                 "(${super.toString()})"
     }
 
+    /**
+     * Clears all form-wide, field, and oneof validation messages.
+     */
     private fun clearValidationDisplay() {
         formValidationError.value = null
         fields.values.forEach {
@@ -1657,6 +1690,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         }
     }
 
+    /**
+     * Creates a builder populated with the valid values currently entered in the form.
+     */
     private fun builderWithCurrentFields(): ValidatingBuilder<out M> {
         val builder = builder()
         fields.values.forEach { formField ->
@@ -1677,6 +1713,9 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         return builder
     }
 
+    /**
+     * Displays the given constraint violations at their corresponding form locations.
+     */
     private fun showConstraintViolations(
         constraintViolations: List<ConstraintViolation>
     ) {
@@ -1690,9 +1729,15 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
         }
     }
 
+    /**
+     * Finds a registered form field by its Protobuf field name.
+     */
     private fun formFieldByName(fieldName: String): FormField? =
         fields.values.find { it.field.name == fieldName }
 
+    /**
+     * Displays a constraint violation associated with a field or oneof.
+     */
     private fun showFieldConstraintViolation(
         fieldPath: FieldPath,
         constraintViolation: ConstraintViolation

--- a/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/form/MessageForm.kt
@@ -49,7 +49,7 @@ import io.spine.chords.core.FocusableComponent
 import io.spine.chords.core.InputComponent
 import io.spine.chords.core.InputContext
 import io.spine.chords.core.ValidationErrorText
-import io.spine.chords.core.recompositionWorkaroundReadonly
+import io.spine.chords.core.recompositionWorkaround
 import io.spine.chords.proto.form.MessageForm.Companion.Multipart
 import io.spine.chords.proto.form.MessageForm.Companion.create
 import io.spine.chords.proto.form.MessageForm.Companion.invoke
@@ -1354,7 +1354,7 @@ public open class MessageForm<M : Message> : InputComponent<M>(), InputContext {
      */
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
-    override fun content(): Unit = recompositionWorkaroundReadonly {
+    override fun content(): Unit = recompositionWorkaround {
         updateBeforeRendering()
 
         formScope.customMultipartContent()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.96")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.97")


### PR DESCRIPTION
## Summary

Handle initial and streaming data-observation failures uniformly, expose observation and connection status, and allow consumers to cancel observations explicitly.

Fixes #102

## Changes

- Replace the previous observation return values and callbacks with cancellable `DataObservation` handles that retain their latest data and expose lifecycle status.
- Monitor gRPC connectivity and automatically re-read data and recreate subscriptions after reconnection.
- Retry failed subscription streams with backoff when the channel remains connected.
- Make data and event subscription cancellation non-blocking, idempotent, and tolerant of already-removed server subscriptions.
- Add an application-window overlay extension point for connection-status UI and harden affected Compose recomposition paths.
- Document observation lifecycle ownership and add regression coverage for connection, recovery, cancellation, and Compose snapshot races.