### PR TITLE
Expand agent operating policy: Apple Silicon JDK setup and report regeneration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,36 @@ Useful root commands (run from the repository root, JDK 11):
 ./gradlew publishToMavenLocal
 ```
 
+### Apple Silicon Workstations
+
+On Apple Silicon, run the root build with an x86_64 distribution of JDK 11.
+The exact JDK 11 patch version may differ between workstations. Verify the
+active JVM before running Gradle:
+
+```bash
+java -version
+java -XshowSettings:properties -version 2>&1 |
+    rg 'java.home|java.version|os.arch'
+```
+
+Expect Java 11 and `os.arch = x86_64`. Do not set `JAVA_HOME` using
+`/usr/libexec/java_home -v 11` on an affected workstation: when macOS cannot find a
+registered JDK 11, that command may silently select a newer ARM JDK instead.
+If the shell bypasses jEnv, select an installed JDK 11 with jEnv and run Gradle
+as follows:
+
+```bash
+jenv shell 11
+JAVA_HOME="$(jenv prefix)" ./gradlew :<module>:check
+```
+
+This architecture matters because some code generation paths in the pinned
+Spine toolchain resolve `io.grpc:protoc-gen-grpc-java:1.28.1`. That artifact
+provides a macOS x86_64 executable but no `osx-aarch_64` executable. Using an
+ARM JVM makes Protobuf generation fail during dependency resolution.
+
+### Module-Specific Verification
+
 Module names for Gradle paths: `core`, `proto`, `proto-values`, `client`,
 `runtime` (located at `codegen/runtime`), and `codegen-tests` (located at
 `codegen/tests`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ frontmatter matches the task.
 
 ## Commit and History Safety
 
+Before committing changes or opening a pull request, agents must re-read this
+`AGENTS.md` policy in full, even if they read it earlier in the task.
+
 Do not commit, push, tag, rebase, merge, cherry-pick, or otherwise write to Git
 history unless the user's current prompt explicitly asks for it.
 
@@ -50,11 +53,12 @@ The Commit and History Safety rules above apply throughout this procedure.
    - Name new branches after the task, in the repository's kebab-case style
      (for example, `dialog-form-dirty-state`); do not include `codex` or other
      agent-specific identifiers in branches you create.
-3. **Check the version and reports.** Apply "Versioning and Reports" above:
+3. **Check the version and reports.** Apply "Versioning and Reports" below:
    inspect the commits and local state, bump `chordsVersion` in
    `version.gradle.kts` if the changeset has not bumped it yet, and if the
    generated `pom.xml` and `dependencies.md` reports are not updated yet, run
-   `./gradlew build` and include the regenerated reports in the changeset.
+   the focused report-regeneration command in that section and include changed
+   reports in the changeset.
 4. **Commit in logical steps.** Create one or more logical commits; split the
    work only when each commit is independently coherent. Commit the version
    bump together with the regenerated `pom.xml` and `dependencies.md`, using
@@ -77,9 +81,11 @@ step 6), then:
 3. **Omit a trailing period.** Do not end a pull request title with a period
    (`.`).
 4. **Write the description** with a `## Summary` section followed by a
-   `## Changes` section. Optional sections such as `## Important notes` or
-   `## Reviewer notes` may follow when useful. Do not add a "Verifications"
-   section or any agent-attribution section such as `Created by <agent>`.
+   `## Changes` section. Add optional sections such as `## Important notes` or
+   `## Reviewer notes` only when they contain material information that
+   reviewers need; omit routine, empty, or redundant sections. Do not add a
+   "Verifications" section or any agent-attribution section such as
+   `Created by <agent>`.
 5. **Link resolved issues.** For each issue the PR implements or fixes, add a
    GitHub closing keyword in the description (for example, `Fixes #123`) so the
    issue appears under "Successfully merging this pull request may close these
@@ -128,10 +134,35 @@ the `Check version increment` workflow). The version scheme is
 `2.0.0-SNAPSHOT.<N>` where `<N>` grows monotonically.
 
 The `pom.xml` and `dependencies.md` files at the repository root are generated
-reports that must stay in sync with the changeset (enforced by the
-`Ensure license reports updated` workflow). They are regenerated as part of
-`./gradlew build`. When your change affects the version or dependencies, make
-sure regenerated reports are part of the changeset.
+reports that must stay in sync with the changeset. The
+`Ensure license reports updated` workflow requires both files to be modified
+in every pull request. Both embed `chordsVersion`, so a version bump alone
+changes them.
+
+After bumping the version or changing dependencies, regenerate the reports
+from the repository root, without running the full build:
+
+```bash
+find . -path '*/build/reports/dependency-license' -type d -prune \
+    -exec rm -rf {} +
+./gradlew generatePom mergeAllLicenseReports
+```
+
+On Apple Silicon workstations, prefix the Gradle command with
+`JAVA_HOME="$(jenv prefix)"`; see "Apple Silicon Workstations" under
+"Verification and Quality".
+
+The `generatePom` task regenerates `pom.xml`, and `mergeAllLicenseReports`
+merges the per-module license reports into `dependencies.md`. Deleting the
+per-module reports first is required: otherwise Gradle considers
+`generateLicenseReport` up to date, and the merge silently reuses reports
+that still carry the previous version, leaving `dependencies.md` unchanged
+and the workflow failing.
+
+Afterwards, confirm that the `# Dependencies of ...` headings in
+`dependencies.md` carry the new version, and include both regenerated reports
+in the changeset. A full `./gradlew build` regenerates the files as well, but
+is unnecessary solely for this purpose.
 
 Source files carry a copyright header; when modifying a file, keep the header
 year current (files touched in a given year carry that year).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 17:13:39 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 18:16:03 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Wed Jul 29 17:13:39 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 17:13:40 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 18:16:04 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Wed Jul 29 17:13:40 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 17:13:41 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 18:16:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Wed Jul 29 17:13:41 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 17:13:42 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 18:16:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Wed Jul 29 17:13:42 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 17:13:43 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 18:16:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Wed Jul 29 17:13:43 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 17:13:44 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 29 18:16:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.97</version>
+<version>2.0.0-SNAPSHOT.98</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.97")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.98")


### PR DESCRIPTION
## Summary

Document the JDK setup required to run the Chords root build on Apple Silicon
workstations, and refine the agent policy on committing, regenerating the
generated reports, and writing pull request descriptions.

## Changes

Apple Silicon guidance:

- Explain how to verify the active Java version and JVM architecture.
- Show how to select an installed x86_64 JDK 11 with jEnv without depending on
  a specific patch version.
- Explain why the pinned Spine code generation toolchain requires an x86_64
  JVM.
- Delimit the Apple Silicon guidance from module-specific verification
  instructions.

Agent policy:

- Require re-reading `AGENTS.md` before committing or opening a pull request.
- Replace `./gradlew build` with the focused
  `generatePom mergeAllLicenseReports` command for regenerating `pom.xml` and
  `dependencies.md`, and document that the per-module license reports have to
  be deleted first. Otherwise Gradle considers `generateLicenseReport` up to
  date, and the merge silently reuses reports that still carry the previous
  version, leaving `dependencies.md` unchanged and the
  `Ensure license reports updated` workflow failing.
- Restrict optional pull request description sections to material information.
- Correct a cross-reference that pointed to "Versioning and Reports" as being
  above rather than below.

Version and reports:

- Bump Chords to `2.0.0-SNAPSHOT.98`.
- Regenerate `pom.xml` and `dependencies.md`.
