### PR TITLE
Keep command modals open by default on network errors

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -80,10 +80,62 @@ the server connectivity:
   a variant of the `MessageForm` component (introduced in the Chords Proto 
   module), which allows creating custom per-field editors of command messages,
   and has built in means of posting the resulting command to the server.
- 
-- [CommandWizard](src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt) —
+
+- [CommandDialog](src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt) —
+  a modal form for constructing and posting a command message.
+
+- [CommandWizard](src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt) —
   a variant of the `Wizard` component introduced in the Chords Core module,
   which represents a multipage editor for a command message, and allows posting
   the resulting command to the application server.
 
 - etc.
+
+#### Handling network errors in command modals
+
+When posting from a `CommandDialog` or `CommandWizard` fails because of a
+network communication error, Chords clears the posting state and keeps the
+component open by default. The entered form data remains available, and the
+user can retry manually after checking whether repeating the command is safe.
+Chords does not retry commands automatically.
+
+The default message asks the user to retry after the connection is restored.
+Before retrying, the application should account for an uncertain operation
+status: a missing acknowledgement does not prove that the server never
+accepted the command.
+
+Use `commandConsequencesProps` to customize one component:
+
+```kotlin
+commandConsequencesProps = Props {
+    closeOnNetworkError = true
+    networkErrorMessage = "Connection lost. Please check the operation status."
+}
+```
+
+Setting `closeOnNetworkError` to `true` requests the previous close-on-error
+behavior after the error presentation finishes. A `CommandWizard` closes only
+when its host handles `onCloseRequest`.
+
+Use shared defaults to customize all command dialogs and wizards:
+
+```kotlin
+override fun SharedDefaultsScope.sharedDefaults() {
+    ModalCommandConsequences::class defaultsTo {
+        networkErrorMessage = "The server is temporarily unavailable."
+        networkErrorPresentation = { error ->
+            showMessage(
+                if (error.acknowledgementReceived) {
+                    "Connection lost while waiting for the operation result."
+                } else {
+                    networkErrorMessage
+                }
+            )
+        }
+    }
+}
+```
+
+The custom presentation receives `ModalCommandNetworkError`, which contains
+the communication exception and whether Chords received an acknowledgement.
+Chords still resets the posting state and applies `closeOnNetworkError`.

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandDialog.kt
@@ -37,6 +37,8 @@ import io.spine.base.CommandMessage
 import io.spine.chords.client.CommandConsequencesScope
 import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.client.layout.ModalCommandConsequences.Companion.consequences
+import io.spine.chords.core.appshell.Application
+import io.spine.chords.core.appshell.Props
 import io.spine.chords.core.layout.Dialog
 import io.spine.chords.core.layout.SubmitOrCancelDialog
 import io.spine.chords.core.writeOnce
@@ -69,16 +71,34 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      *    customize this on an application level using the
      *    ["shared defaults"][Application.sharedDefaults] feature.
      *
-     *  In cases when the above cases are not enough, and you need to customize
-     *  how `ModelCommandConsequences` is instantiated or configured on a
-     *  per-dialog basis, you can do this by specifying a respective lambda in
-     *  this property. The lambda accepts a consequences configuration function
-     *  and returns the respective [ModalCommandConsequences] created from that
-     *  configuration function.
+     *  Use [commandConsequencesProps] for per-dialog property configuration.
+     *  In cases when a custom `ModalCommandConsequences` subclass or different
+     *  construction is needed, specify a factory in this property. The lambda
+     *  accepts a consequences configuration function and returns the
+     *  respective [ModalCommandConsequences].
      */
     public var createCommandConsequences:
                 (ModalCommandConsequencesScope<C>.() -> Unit) -> ModalCommandConsequences<C> =
         { consequences(postingState, { close() }, it) }
+
+    /**
+     * Configures each [ModalCommandConsequences] created for this dialog.
+     *
+     * These properties are applied after [createCommandConsequences] returns,
+     * including when a consumer replaces that factory. They therefore override
+     * values supplied through application shared defaults.
+     *
+     * By default, a network communication error clears the posting state,
+     * informs the user, and keeps this dialog open without changing its form
+     * data. Use this property to customize that behavior for one dialog:
+     * ```
+     *     commandConsequencesProps = Props {
+     *         closeOnNetworkError = true
+     *         networkErrorMessage = "Connection lost. Please try again."
+     *     }
+     * ```
+     */
+    public var commandConsequencesProps: Props<ModalCommandConsequences<C>> = Props {}
 
     private var postingState = mutableStateOf(false)
 
@@ -122,7 +142,14 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
             props = {
                 validationDisplayMode = MANUAL
                 onDirtyStateChange = { dirtyState.value = it }
-                createCommandConsequences = this@CommandDialog.createCommandConsequences
+                createCommandConsequences = { consequences ->
+                    this@CommandDialog.createCommandConsequences(consequences)
+                        .also {
+                            this@CommandDialog.commandConsequencesProps.run {
+                                it.configure()
+                            }
+                        }
+                }
                 commandConsequences = {
                     (this as ModalCommandConsequencesScope<C>).run {
                         commandConsequences()
@@ -195,14 +222,15 @@ public abstract class CommandDialog<C : CommandMessage, B : ValidatingBuilder<C>
      * [predefinedConsequences][ModalCommandConsequences.predefinedConsequences]
      * property of [ModalCommandConsequences] instance provided by the
      * [createCommandConsequences] lambda. You can customize this behavior on
-     * a per-instance or application-wide level. See [ModalCommandConsequences]
-     * and [createCommandConsequences].
+     * a per-instance or application-wide level. See [ModalCommandConsequences],
+     * [commandConsequencesProps], and [createCommandConsequences].
      *
      * @receiver [ModalCommandConsequencesScope], which provides an API for
      *   registering command's consequences.
      * @see submitContent
      * @see cancelActiveSubscriptions
      * @see ModalCommandConsequences
+     * @see commandConsequencesProps
      * @see createCommandConsequences
      */
     protected abstract fun ModalCommandConsequencesScope<C>.commandConsequences()

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -34,6 +34,8 @@ import io.spine.base.CommandMessage
 import io.spine.chords.client.CommandConsequencesScope
 import io.spine.chords.client.form.CommandMessageForm
 import io.spine.chords.client.layout.ModalCommandConsequences.Companion.consequences
+import io.spine.chords.core.appshell.Application
+import io.spine.chords.core.appshell.Props
 import io.spine.chords.core.layout.AbstractWizardPage
 import io.spine.chords.core.layout.Wizard
 import io.spine.chords.proto.form.FormFieldsScope
@@ -83,16 +85,37 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
      *    customize this on an application level using the
      *    ["shared defaults"][Application.sharedDefaults] feature.
      *
-     *  In cases when the above cases are not enough, and you need to customize
-     *  how `ModelCommandConsequences` is instantiated or configured on a
-     *  per-wizard basis, you can do this by specifying a respective lambda in
-     *  this property. The lambda accepts a consequences configuration function
-     *  and returns the respective [ModalCommandConsequences] created from that
-     *  configuration function.
+     *  Use [commandConsequencesProps] for per-wizard property configuration.
+     *  In cases when a custom `ModalCommandConsequences` subclass or different
+     *  construction is needed, specify a factory in this property. The lambda
+     *  accepts a consequences configuration function and returns the
+     *  respective [ModalCommandConsequences].
      */
     public var createCommandConsequences:
                 (ModalCommandConsequencesScope<C>.() -> Unit) -> ModalCommandConsequences<C> =
         { consequences(postingState, { close() }, it) }
+
+    /**
+     * Configures each [ModalCommandConsequences] created for this wizard.
+     *
+     * These properties are applied after [createCommandConsequences] returns,
+     * including when a consumer replaces that factory. They therefore override
+     * values supplied through application shared defaults.
+     *
+     * By default, a network communication error clears the posting state,
+     * informs the user, and keeps this wizard open without changing its form
+     * data. Use this property to customize that behavior for one wizard:
+     * ```
+     *     commandConsequencesProps = Props {
+     *         closeOnNetworkError = true
+     *         networkErrorMessage = "Connection lost. Please try again."
+     *     }
+     * ```
+     *
+     * When `closeOnNetworkError` is `true`, the wizard's host must handle
+     * [onCloseRequest] to remove the wizard from composition.
+     */
+    public var commandConsequencesProps: Props<ModalCommandConsequences<C>> = Props {}
 
     private var postingState = mutableStateOf(false)
 
@@ -102,7 +125,14 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
             onBeforeBuild = { beforeBuild(it) }
         ) {
             validationDisplayMode = MANUAL
-            createCommandConsequences = this@CommandWizard.createCommandConsequences
+            createCommandConsequences = { consequences ->
+                this@CommandWizard.createCommandConsequences(consequences)
+                    .also {
+                        this@CommandWizard.commandConsequencesProps.run {
+                            it.configure()
+                        }
+                    }
+            }
             commandConsequences = {
                 (this as ModalCommandConsequencesScope<C>).run {
                     commandConsequences()
@@ -169,14 +199,15 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
      * [predefinedConsequences][ModalCommandConsequences.predefinedConsequences]
      * property of [ModalCommandConsequences] instance provided by the
      * [createCommandConsequences] lambda. You can customize this behavior on
-     * a per-instance or application-wide level. See [ModalCommandConsequences]
-     * and [createCommandConsequences].
+     * a per-instance or application-wide level. See [ModalCommandConsequences],
+     * [commandConsequencesProps], and [createCommandConsequences].
      *
      * @receiver [ModalCommandConsequencesScope], which provides an API for
      *   registering command's consequences.
      * @see submit
      * @see cancelActiveSubscriptions
      * @see ModalCommandConsequences
+     * @see commandConsequencesProps
      * @see createCommandConsequences
      */
     protected abstract fun ModalCommandConsequencesScope<C>.commandConsequences()

--- a/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/ModalCommandConsequences.kt
@@ -38,8 +38,10 @@ import io.spine.chords.client.CommandConsequences
 import io.spine.chords.client.CommandConsequencesScope
 import io.spine.chords.client.CommandConsequencesScopeImpl
 import io.spine.chords.client.EventSubscription
+import io.spine.chords.client.ServerCommunicationException
 import io.spine.chords.core.appshell.Application
 import io.spine.chords.core.layout.MessageDialog.Companion.showMessage
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
 
 /**
@@ -89,44 +91,40 @@ import kotlin.time.Duration
  * consist of first invoking [predefinedConsequences] followed by
  * invoking the [consequences] lambda.
  *
- * If you need to change [predefinedConsequences] for all
- * [ModalCommandConsequences] instances in the application (and thus change the
- * way how errors and posting progress display is implemented in all modal UIs),
- * you can do this using the [Application]'s
- * [shared defaults][Application.sharedDefaults] feature like this:
+ * By default, a network communication error clears the posting state, displays
+ * [networkErrorMessage], and keeps the modal UI open. Chords does not retry the
+ * command automatically because the server may have accepted it before the
+ * connection failed. Applications should verify the operation status before
+ * allowing a manual retry.
+ *
+ * Network error handling can be customized for all
+ * `ModalCommandConsequences` instances using the [Application]'s
+ * [shared defaults][Application.sharedDefaults] feature:
  *
  * ```
  *     override fun SharedDefaultsScope.sharedDefaults() {
  *         ModalCommandConsequences::class defaultsTo {
- *             predefinedConsequences = {
- *                 onBeforePost {
- *                     // Custom `onBeforePost` handler.
- *                     posting = true
- *                 }
- *                 onServerError {
- *                     // Custom `onServerError` handler.
- *                     showMessage("Unexpected server error has occurred.")
- *                     close()
- *                 }
- *                 onNetworkError {
- *                     // Custom `onNetworkError` handler.
- *                     showMessage("Server connection failed.")
- *                     close()
- *                 }
- *                 onDefaultTimeout {
- *                     // Custom `onDefaultTimeout` handler.
- *                     showMessage("The operation takes unexpectedly long to process. " +
- *                             "Please check the status of its execution later.")
- *                     close()
- *                 }
+ *             networkErrorMessage = "The server is temporarily unavailable."
+ *             networkErrorPresentation = { error ->
+ *                 showMessage(
+ *                     if (error.acknowledgementReceived) {
+ *                         "Connection lost while waiting for the operation result."
+ *                     } else {
+ *                         networkErrorMessage
+ *                     }
+ *                 )
  *             }
  *         }
  *     }
  * ```
- * Note that this way you replace the whole [predefinedConsequences] handler for
- * predefined consequences for all [ModalCommandConsequences] in the
- * application, so a new set of consequences should be sufficient to replace the
- * default one.
+ *
+ * The same properties can be supplied for one [CommandDialog] or
+ * [CommandWizard] through its `commandConsequencesProps`.
+ *
+ * Replacing [predefinedConsequences] remains available for broader
+ * customization. Doing so opts out of the focused network error properties,
+ * acknowledgement tracking, and Chords' duplicate presentation guard because
+ * the replacement defines the complete predefined behavior.
  *
  * @param C A type of commands whose consequences are specified.
  *
@@ -147,17 +145,78 @@ public open class ModalCommandConsequences<C : CommandMessage>(
     override fun createConsequencesScope(command: C): ModalCommandConsequencesScope<C> =
         ModalCommandConsequencesScope(command, postingState, close, defaultTimeout)
 
+    /**
+     * Specifies whether a network communication error closes the modal UI
+     * after [networkErrorPresentation] finishes.
+     *
+     * The default is `false`, so the UI remains open and preserves its form
+     * data. Setting this property to `true` restores the previous close
+     * request. A [CommandWizard] closes only when its host handles
+     * [onCloseRequest][io.spine.chords.core.layout.Wizard.onCloseRequest].
+     *
+     * When a custom [networkErrorPresentation] opens nested modal UI, it must
+     * not return until that UI is dismissed. Otherwise, closing a
+     * [CommandDialog] while its nested dialog is open can fail.
+     */
+    public var closeOnNetworkError: Boolean = false
+
+    /**
+     * The text displayed by the default [networkErrorPresentation].
+     *
+     * The message warns against immediately repeating a command because a
+     * communication failure can leave the operation status unknown.
+     */
+    public var networkErrorMessage: String =
+        "Server connection failed. Please try again when the connection is restored."
+
+    /**
+     * Presents a network communication error to the user.
+     *
+     * Chords resets the posting state before invoking this callback and applies
+     * [closeOnNetworkError] after it returns. The callback customizes
+     * presentation only and cannot bypass either lifecycle operation.
+     *
+     * If this callback opens nested modal UI while [closeOnNetworkError] is
+     * `true`, it must suspend until that UI is dismissed.
+     */
+    public var networkErrorPresentation: suspend (ModalCommandNetworkError) -> Unit = {
+        showMessage(networkErrorMessage)
+    }
+
+    /**
+     * Defines the common consequences registered before component-specific
+     * consequences.
+     *
+     * Replacing this property defines the complete predefined behavior and
+     * therefore opts out of [closeOnNetworkError], [networkErrorMessage],
+     * [networkErrorPresentation], acknowledgement tracking, and duplicate
+     * presentation and close handling by Chords.
+     */
     public var predefinedConsequences: ModalCommandConsequencesScope<C>.() -> Unit = {
+        val acknowledgementReceived = AtomicBoolean(false)
+        val networkErrorHandled = AtomicBoolean(false)
+
         onBeforePost {
             posting = true
+        }
+        onAcknowledge {
+            acknowledgementReceived.set(true)
         }
         onServerError {
             showMessage("Unexpected server error has occurred.")
             close()
         }
-        onNetworkError {
-            showMessage("Server connection failed.")
-            close()
+        onNetworkError { error ->
+            if (!networkErrorHandled.compareAndSet(false, true)) {
+                return@onNetworkError
+            }
+            posting = false
+            networkErrorPresentation(
+                ModalCommandNetworkError(error, acknowledgementReceived.get())
+            )
+            if (closeOnNetworkError) {
+                close()
+            }
         }
         onDefaultTimeout {
             showMessage("The operation takes unexpectedly long to process. " +
@@ -216,6 +275,20 @@ public open class ModalCommandConsequences<C : CommandMessage>(
         }
     }
 }
+
+/**
+ * Describes a network communication error encountered while processing a
+ * command posted by a modal UI.
+ *
+ * @property exception The exception that reported the communication failure.
+ * @property acknowledgementReceived Whether Chords received the server
+ *   acknowledgement before the failure. A value of `false` does not prove that
+ *   the server rejected or never accepted the command.
+ */
+public class ModalCommandNetworkError(
+    public val exception: ServerCommunicationException,
+    public val acknowledgementReceived: Boolean
+)
 
 /**
  * A [CommandConsequencesScope] variant, which provides an extended API to

--- a/client/src/test/kotlin/io/spine/chords/client/TestApplication.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/TestApplication.kt
@@ -31,12 +31,51 @@ import io.spine.chords.core.appshell.app
 import java.awt.Dimension
 
 /**
- * Installs the application required by tests in this module.
+ * Assigns the JVM-wide [app] property so that the code under test in this
+ * module can be exercised outside a running application.
+ *
+ * Some types tested in this module read application-wide state upon
+ * construction. In particular,
+ * [ModalCommandConsequences][io.spine.chords.client.layout.ModalCommandConsequences]
+ * inherits from
+ * [DefaultPropsOwnerBase][io.spine.chords.core.DefaultPropsOwnerBase], which
+ * obtains default property values from the application's
+ * [shared defaults][Application.sharedDefaults].
+ *
+ * In a running application, [app] is assigned by [Application.run]. Tests do
+ * not run an application, and reading an unassigned [app] throws
+ * [IllegalStateException]. Such types would therefore fail to be constructed
+ * in tests, regardless of what a test actually verifies.
+ *
+ * To prevent this, this object assigns [app] a real, but deliberately minimal
+ * [Application] instance rather than a mock. The instance serves no purpose
+ * other than satisfying the dependency described above: it declares no views,
+ * and its window is never created or shown, as [run][Application.run] is
+ * never invoked on it. It also customizes no
+ * [shared defaults][Application.sharedDefaults], so the types under test keep
+ * the default property values declared by their own implementations.
  */
 internal object TestApplication {
 
+    /**
+     * Tells whether [install] has already assigned the [app] property.
+     */
     private var installed: Boolean = false
 
+    /**
+     * Assigns the [app] property, doing nothing if a previous call has
+     * already assigned it.
+     *
+     * [app] is a [write-once][io.spine.chords.core.writeOnce] property, so
+     * assigning it twice fails. At the same time, all test classes that need
+     * an application share a single JVM, and each of them has to ensure that
+     * [app] is assigned before its own test cases run, since the order in
+     * which test classes are executed is not fixed.
+     *
+     * This method is therefore idempotent, and is synchronized to stay so if
+     * tests are executed in parallel. Any test class can safely call it, e.g.
+     * from a [BeforeAll][org.junit.jupiter.api.BeforeAll] method.
+     */
     @Synchronized
     fun install() {
         if (!installed) {

--- a/client/src/test/kotlin/io/spine/chords/client/TestApplication.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/TestApplication.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client
+
+import io.spine.chords.core.appshell.Application
+import io.spine.chords.core.appshell.app
+import java.awt.Dimension
+
+/**
+ * Installs the application required by tests in this module.
+ */
+internal object TestApplication {
+
+    private var installed: Boolean = false
+
+    @Synchronized
+    fun install() {
+        if (!installed) {
+            app = Application(
+                name = "Chords client tests",
+                views = emptyList(),
+                minWindowSize = Dimension(1, 1)
+            )
+            installed = true
+        }
+    }
+}

--- a/client/src/test/kotlin/io/spine/chords/client/layout/ModalCommandConsequencesSpec.kt
+++ b/client/src/test/kotlin/io/spine/chords/client/layout/ModalCommandConsequencesSpec.kt
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.client.layout
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import io.kotest.matchers.shouldBe
+import io.spine.base.CommandMessage
+import io.spine.chords.client.ServerCommunicationException
+import io.spine.chords.client.ServerError
+import io.spine.chords.client.TestApplication
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+internal class ModalCommandConsequencesSpec {
+
+    @Test
+    fun `clear posting and keep modal open by default`() {
+        runBlocking {
+            val scenario = scenario()
+            var presentedError: ModalCommandNetworkError? = null
+            var postingDuringPresentation: Boolean? = null
+            scenario.consequences.networkErrorPresentation = {
+                postingDuringPresentation = scenario.posting.value
+                presentedError = it
+            }
+            scenario.registerPredefinedConsequences()
+            val exception = networkError()
+
+            scenario.scope.failWith(exception)
+
+            postingDuringPresentation shouldBe false
+            scenario.posting.value shouldBe false
+            scenario.closeCalls.get() shouldBe 0
+            presentedError!!.exception shouldBe exception
+            presentedError!!.acknowledgementReceived shouldBe false
+        }
+    }
+
+    @Test
+    fun `report acknowledgement received before network error`() {
+        runBlocking {
+            val scenario = scenario()
+            var presentedError: ModalCommandNetworkError? = null
+            scenario.consequences.networkErrorPresentation = {
+                presentedError = it
+            }
+            scenario.registerPredefinedConsequences()
+
+            scenario.scope.acknowledge()
+            scenario.scope.failWith(networkError())
+
+            presentedError!!.acknowledgementReceived shouldBe true
+        }
+    }
+
+    @Test
+    fun `close modal after presentation when configured`() {
+        runBlocking {
+            val actions = ArrayList<String>()
+            val scenario = scenario {
+                actions += "close"
+            }
+            scenario.consequences.closeOnNetworkError = true
+            scenario.consequences.networkErrorPresentation = {
+                actions += "present"
+            }
+            scenario.registerPredefinedConsequences()
+
+            scenario.scope.failWith(networkError())
+
+            actions shouldBe listOf("present", "close")
+            scenario.closeCalls.get() shouldBe 1
+        }
+    }
+
+    @Test
+    fun `handle concurrent network errors once per posting`() {
+        runBlocking {
+            val scenario = scenario()
+            val presentationCalls = AtomicInteger()
+            scenario.consequences.closeOnNetworkError = true
+            scenario.consequences.networkErrorPresentation = {
+                presentationCalls.incrementAndGet()
+            }
+            scenario.registerPredefinedConsequences()
+            val exception = networkError()
+
+            coroutineScope {
+                repeat(8) {
+                    launch(Dispatchers.Default) {
+                        scenario.scope.failWith(exception)
+                    }
+                }
+            }
+
+            presentationCalls.get() shouldBe 1
+            scenario.closeCalls.get() shouldBe 1
+        }
+    }
+
+    @Test
+    fun `guard network errors separately for each posting`() {
+        runBlocking {
+            val consequences = consequences(mutableStateOf(true)) {}
+            val presentationCalls = AtomicInteger()
+            consequences.networkErrorPresentation = {
+                presentationCalls.incrementAndGet()
+            }
+
+            repeat(2) {
+                val posting = mutableStateOf(true)
+                val scope = CapturingScope(posting, {})
+                consequences.predefinedConsequences.invoke(scope)
+                scope.failWith(networkError())
+            }
+
+            presentationCalls.get() shouldBe 2
+        }
+    }
+
+    @Test
+    fun `retain server-error registration`() {
+        val scenario = scenario()
+
+        scenario.registerPredefinedConsequences()
+
+        scenario.scope.serverErrorRegistered shouldBe true
+        scenario.posting.value shouldBe true
+        scenario.closeCalls.get() shouldBe 0
+    }
+
+    @Test
+    fun `advise retry after connection is restored in default message`() {
+        val consequences = consequences(mutableStateOf(false)) {}
+
+        consequences.networkErrorMessage shouldBe
+                "Server connection failed. Please try again when the connection is restored."
+    }
+
+    private fun scenario(onClose: () -> Unit = {}): Scenario {
+        val posting = mutableStateOf(true)
+        val closeCalls = AtomicInteger()
+        val close = {
+            closeCalls.incrementAndGet()
+            onClose()
+        }
+        val consequences = consequences(posting, close)
+        consequences.networkErrorPresentation = {}
+        return Scenario(
+            consequences,
+            CapturingScope(posting, close),
+            posting,
+            closeCalls
+        )
+    }
+
+    private companion object {
+
+        @JvmStatic
+        @BeforeAll
+        fun setUpApplication() {
+            TestApplication.install()
+        }
+
+        fun consequences(
+            posting: MutableState<Boolean>,
+            close: () -> Unit
+        ): ModalCommandConsequences<CommandMessage> =
+            ModalCommandConsequences(posting, close) {}
+
+        fun networkError(): ServerCommunicationException =
+            ServerCommunicationException(IllegalStateException("Connection lost."))
+
+        val command: CommandMessage = Proxy.newProxyInstance(
+            CommandMessage::class.java.classLoader,
+            arrayOf(CommandMessage::class.java)
+        ) { proxy, method, arguments ->
+            when (method.name) {
+                "equals" -> proxy === arguments?.firstOrNull()
+                "hashCode" -> System.identityHashCode(proxy)
+                "toString" -> "TestCommand"
+                else -> error("Unexpected command method: ${method.name}.")
+            }
+        } as CommandMessage
+    }
+
+    /**
+     * Captures callbacks without exercising production scope creation.
+     *
+     * A regular scenario passes the same posting state to the consequences
+     * and this scope. The per-posting guard test intentionally supplies a
+     * fresh scope state for every registration.
+     */
+    private class CapturingScope(
+        posting: MutableState<Boolean>,
+        close: () -> Unit
+    ) : ModalCommandConsequencesScope<CommandMessage>(
+        command,
+        posting,
+        close,
+        Duration.ZERO
+    ) {
+        private lateinit var acknowledgeHandler: suspend () -> Unit
+        private lateinit var networkErrorHandler:
+                suspend (ServerCommunicationException) -> Unit
+        var serverErrorRegistered: Boolean = false
+            private set
+
+        override fun onAcknowledge(handler: suspend () -> Unit) {
+            acknowledgeHandler = handler
+        }
+
+        override fun onNetworkError(
+            handler: suspend (ServerCommunicationException) -> Unit
+        ) {
+            networkErrorHandler = handler
+        }
+
+        override fun onServerError(handler: suspend (ServerError) -> Unit) {
+            serverErrorRegistered = true
+        }
+
+        suspend fun acknowledge() {
+            acknowledgeHandler()
+        }
+
+        suspend fun failWith(exception: ServerCommunicationException) {
+            networkErrorHandler(exception)
+        }
+    }
+
+    private data class Scenario(
+        val consequences: ModalCommandConsequences<CommandMessage>,
+        val scope: CapturingScope,
+        val posting: MutableState<Boolean>,
+        val closeCalls: AtomicInteger
+    ) {
+        fun registerPredefinedConsequences() {
+            consequences.predefinedConsequences.invoke(scope)
+        }
+    }
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 18:16:03 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 12:51:42 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Wed Jul 29 18:16:03 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 18:16:04 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 12:51:44 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Wed Jul 29 18:16:04 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 18:16:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 12:51:45 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Wed Jul 29 18:16:06 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 18:16:06 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 12:51:46 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Wed Jul 29 18:16:06 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 18:16:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 12:51:47 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Wed Jul 29 18:16:07 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 29 18:16:08 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 12:51:48 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.98</version>
+<version>2.0.0-SNAPSHOT.99</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.98")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.99")


### PR DESCRIPTION
## Summary

Keep command dialogs and wizards open by default after network communication failures so entered form data remains available.

Fixes #144

## Changes

- Reset the modal posting state and present network errors without closing by default.
- Add acknowledgement-aware network error context, one-shot presentation handling, and configurable close, message, and presentation properties.
- Support application shared defaults and per-component properties, including consumer-supplied consequences factories.
- Document the behavior and add focused regression coverage.
- Bump Chords to `2.0.0-SNAPSHOT.99` and regenerate the required reports.