### PR TITLE
Adjust dialog sizing to prevent truncated content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,9 +244,17 @@ If verification cannot be run, state the reason clearly in the final response.
   Compose Multiplatform 1.5.12, Spine Event Engine 1.9.0, Gradle 6.9.4 for the
   root project. Do not assume newer language or library features are available.
 - Kotlin explicit API mode is enabled: public declarations require explicit
-  `public` modifiers and public API should have KDoc.
+  `public` modifiers.
+- Every declaration in project-owned source, including declarations explicitly
+  marked `private`, must have a documentation comment in the language's
+  standard format, such as KDoc or Javadoc. Explain its purpose, behavior, or
+  constraints; do not merely restate its name.
 - Configure IntelliJ IDEA Detekt with `quality/detekt-config.yml`.
 - Keep lines within 100 characters (Detekt `MaxLineLength`).
+- Do not introduce constants for text messages unless the user explicitly
+  requests them.
+- Do not add tests that assert text-message content unless the user explicitly
+  requests such tests.
 - UI components follow the class-based component pattern from `core` (see
   `io.spine.chords.core.Component` and its inheritors): composition happens in
   `content()`, pre-composition updates in `beforeComposeContent()`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ When moving or renaming tracked files, use `git mv` so file history is preserved
 
 The Commit and History Safety rules above apply throughout this procedure.
 
+Do not repeat tests, checks, builds, or other verification solely because the
+user asks to commit or push. Rely on verification already performed for the
+change unless the current prompt explicitly requests additional verification.
+Required report regeneration under "Versioning and Reports" remains part of
+this procedure.
+
 1. **Confirm authorization.** Commit or push only when the current prompt
    explicitly asks for it, per "Commit and History Safety" above.
 2. **Choose the branch.**
@@ -73,7 +79,8 @@ The Commit and History Safety rules above apply throughout this procedure.
 ## Creating a Pull Request
 
 Open the PR only once it is authorized (see "Committing and Pushing",
-step 6), then:
+step 6). Creating a PR does not authorize additional verification; follow the
+verification rule in that section.
 
 1. **Create it as a draft** (`gh pr create --draft`), targeting `master` as the
    base branch unless the task specifies otherwise.
@@ -83,8 +90,9 @@ step 6), then:
 4. **Write the description** with a `## Summary` section followed by a
    `## Changes` section. Add optional sections such as `## Important notes` or
    `## Reviewer notes` only when they contain material information that
-   reviewers need; omit routine, empty, or redundant sections. Do not add a
-   "Verifications" section or any agent-attribution section such as
+   reviewers need; omit routine, empty, or redundant sections. Do not include
+   verification, testing, build, or check information anywhere in the PR
+   description. Do not add any agent-attribution section such as
    `Created by <agent>`.
 5. **Link resolved issues.** For each issue the PR implements or fixes, add a
    GitHub closing keyword in the description (for example, `Fixes #123`) so the
@@ -107,7 +115,9 @@ step 6), then:
   repository, and changes belong upstream.
 - Do not publish artifacts or trigger publishing tasks (`publish`,
   `publishCodegenPlugins`) unless the user's current prompt explicitly asks for
-  it. Publishing is normally performed by CI on pushes to `master`.
+  it. Publishing is normally performed by CI on pushes to `master`. This does
+  not restrict `publishToMavenLocal` or `publishCodegenPluginsToMavenLocal`,
+  which stay on the workstation and are part of routine verification.
 - Do not edit the encrypted key files under `.github/keys/` or the decryption
   scripts' credential wiring.
 - Do not auto-update external dependencies outside dedicated update tasks. The
@@ -263,6 +273,8 @@ If verification cannot be run, state the reason clearly in the final response.
 - Tests are named `*Spec.kt`, use JUnit Jupiter with Truth/AssertK/Kotest
   matchers depending on the owning module, and keep fixtures in `Given.kt`-style
   files near the test.
+- Test methods may use Kotlin backtick names to match the style of the
+  surrounding test class.
 - Dependency coordinates live in `buildSrc/src/main/kotlin/io/spine/internal/dependency/`;
   add or change them there, following the existing object-per-library pattern.
 - Get the `config` submodule content with
@@ -280,8 +292,8 @@ a test cannot be added, state this in the final response and explain why.
 ## Code Review
 
 For reviews, lead with findings ordered by severity and include file/line
-references. Focus on bugs, regressions, public API breaks, missing tests, and
-convention violations.
+references. Focus on bugs, regressions, public API breaks, missing tests,
+security risks, release hazards, and convention violations.
 
 Skip routine review of generated or vendored files, including:
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ConfirmationDialog.kt
@@ -153,7 +153,9 @@ public class ConfirmationDialog : Dialog() {
     protected override fun contentSection() {
         val textStyle = typography.bodyLarge
 
-        Column {
+        Column(
+            modifier = Modifier.preferUnwrappedWidth()
+        ) {
             Row {
                 Text(
                     text = message,

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -249,9 +249,11 @@ public abstract class Dialog : Component() {
      * content. Assign a specified [Dp] value to use a fixed width instead.
      *
      * Automatic width detection uses intrinsic measurement to keep text-based
-     * dialogs compact. Content implemented with `SubcomposeLayout`, such as a
-     * lazy list, does not support intrinsic measurement in Compose 1.5.12 and
-     * therefore requires an explicitly specified width.
+     * dialogs compact. The detected width fits the dialog's buttons section,
+     * and is capped with the space that is available on the screen. Content
+     * implemented with `SubcomposeLayout`, such as a lazy list, does not
+     * support intrinsic measurement in Compose 1.5.12 and therefore requires
+     * an explicitly specified width.
      */
     public var width: Dp by mutableStateOf(Dp.Unspecified)
 

--- a/core/src/main/kotlin/io/spine/chords/core/layout/DialogText.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/DialogText.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+
+/**
+ * The maximum width that a dialog's text can request for being displayed
+ * without wrapping.
+ *
+ * The value follows the maximum width of a basic dialog in Material Design 3.
+ * It prevents a long text from stretching the dialog across the screen, while
+ * still allowing the typical single-sentence texts to be displayed on
+ * a single line.
+ */
+private val MaxUnwrappedTextWidth = 560.dp
+
+/**
+ * Makes the content request the width that displays it without wrapping, but
+ * no more than [maxWidth].
+ *
+ * A dialog, whose width is detected automatically, is as wide as the minimum
+ * intrinsic width of its content (see [Dialog.width]). A text reports the width
+ * of its longest word as such a width, which makes a dialog wrap the text that
+ * it could have displayed on a single line.
+ *
+ * Applying this modifier to a dialog's text makes the dialog wide enough for
+ * displaying that text without wrapping, as long as it is not wider than
+ * [maxWidth]. A text that is longer than that is still wrapped.
+ *
+ * Note that this modifier doesn't constrain the content in any way. It only
+ * affects the width that the content requests from the layout that measures it.
+ *
+ * @param maxWidth The maximum width that can be requested for displaying
+ *   the content without wrapping.
+ */
+internal fun Modifier.preferUnwrappedWidth(
+    maxWidth: Dp = MaxUnwrappedTextWidth
+): Modifier = then(UnwrappedWidthModifier(maxWidth))
+
+/**
+ * A [LayoutModifier], which reports the content's maximum intrinsic width
+ * (the width that displays the content without wrapping) as the content's
+ * minimum intrinsic width, limiting it with [maxWidth].
+ *
+ * @property maxWidth The maximum width that can be reported as the content's
+ *   minimum intrinsic width.
+ */
+private data class UnwrappedWidthModifier(
+    private val maxWidth: Dp
+) : LayoutModifier {
+
+    /**
+     * Measures the content the way it would have been measured without this
+     * modifier, which only affects the intrinsic widths reported below.
+     */
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.placeRelative(IntOffset.Zero)
+        }
+    }
+
+    /**
+     * Reports the width that displays the content without wrapping, so that
+     * the layout, which sizes itself to the minimum intrinsic width of its
+     * content, is wide enough for that.
+     */
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int
+    ): Int = minOf(measurable.maxIntrinsicWidth(height), maxWidth.roundToPx())
+
+    /**
+     * Reports the content's maximum intrinsic width as is, since this modifier
+     * doesn't limit the width that the content can occupy.
+     */
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int
+    ): Int = measurable.maxIntrinsicWidth(height)
+
+    /**
+     * Reports the content's minimum intrinsic height as is, since this modifier
+     * affects the width only.
+     */
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurable: IntrinsicMeasurable,
+        width: Int
+    ): Int = measurable.minIntrinsicHeight(width)
+
+    /**
+     * Reports the content's maximum intrinsic height as is, since this modifier
+     * affects the width only.
+     */
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurable: IntrinsicMeasurable,
+        width: Int
+    ): Int = measurable.maxIntrinsicHeight(width)
+}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/InputTextDialog.kt
@@ -192,7 +192,9 @@ public class InputTextDialog : Dialog() {
         val textStyle = typography.bodyLarge
         Column {
             DialogHeading {
-                Column {
+                Column(
+                    modifier = Modifier.preferUnwrappedWidth()
+                ) {
                     Text(
                         text = message,
                         style = textStyle

--- a/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/MessageDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import io.spine.chords.core.AbstractComponentSetup
 import io.spine.chords.core.appshell.Props
 import kotlinx.coroutines.CompletableDeferred
@@ -117,7 +118,9 @@ public class MessageDialog : Dialog() {
     protected override fun contentSection() {
         val textStyle = typography.bodyLarge
 
-        Column {
+        Column(
+            modifier = Modifier.preferUnwrappedWidth()
+        ) {
             Row {
                 Text(
                     text = message,

--- a/core/src/main/kotlin/io/spine/chords/core/layout/WindowType.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/WindowType.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -59,6 +58,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
@@ -66,6 +73,7 @@ import androidx.compose.ui.unit.IntOffset.Companion.Zero
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.constrain
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.DialogState
@@ -74,6 +82,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import io.spine.chords.core.keyboard.matches
+import kotlin.math.ceil
 
 /**
  * Defines the way that a dialog is displayed on the screen (e.g. as a separate
@@ -347,16 +356,18 @@ public sealed class WindowType {
  * This prevents short text from producing impractically narrow windows while
  * still allowing wider form layouts to determine their preferred width.
  */
-private val DefaultDialogMinWidth = 400.dp
+internal val DefaultDialogMinWidth = 400.dp
 
 /**
  * Measures unspecified dimensions from the content and caps them at the
  * available window size.
  *
  * Minimum intrinsic width is intentional: it keeps text-based dialogs compact
- * instead of expanding them to the width of an unwrapped paragraph.
+ * instead of expanding them to the width of an unwrapped paragraph. A text that
+ * should still be displayed on a single line requests such a width explicitly
+ * (see [preferUnwrappedWidth]).
  */
-private fun Modifier.dialogSize(
+internal fun Modifier.dialogSize(
     width: Dp,
     height: Dp,
     maxWidth: Dp,
@@ -372,7 +383,7 @@ private fun Modifier.dialogSize(
             }
         } else {
             Modifier
-                .width(IntrinsicSize.Min)
+                .then(WindowSafeMinIntrinsicWidth)
                 .widthIn(
                     min = minOf(DefaultDialogMinWidth, maxWidth),
                     max = maxWidth
@@ -389,6 +400,74 @@ private fun Modifier.dialogSize(
             Modifier.heightIn(max = maxHeight)
         }
     )
+
+/**
+ * Sizes the content to its minimum intrinsic width, rounded up so that
+ * the window that displays this content is guaranteed to be wide enough
+ * for it.
+ *
+ * This modifier is an analog of `Modifier.width(IntrinsicSize.Min)`, which
+ * additionally accounts for the fact that a window's size is measured in whole
+ * [Dp] units, while its content is measured in pixels. The conversion of the
+ * content's width into the window's width discards the fractional part of
+ * a [Dp] value, so a window whose size is derived from the content can end up
+ * narrower than the content that it was measured from.
+ *
+ * Such a window makes its content squeeze into the space that is smaller than
+ * the one that the content has reported as needed, which, e.g., renders
+ * the dialog's button labels with an ellipsis (see [Dialog]).
+ */
+private object WindowSafeMinIntrinsicWidth : LayoutModifier {
+
+    /**
+     * Measures the content with the width that it reports as its minimum
+     * intrinsic one, extended up to the window-safe width, and limited with
+     * the incoming constraints.
+     */
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val width = windowSafeWidth(measurable.minIntrinsicWidth(constraints.maxHeight))
+        val placeable = measurable.measure(
+            constraints.constrain(Constraints.fixedWidth(width))
+        )
+        return layout(placeable.width, placeable.height) {
+            placeable.placeRelative(IntOffset.Zero)
+        }
+    }
+
+    /**
+     * Reports the width that this modifier makes the content occupy.
+     */
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int
+    ): Int = windowSafeWidth(measurable.minIntrinsicWidth(height))
+
+    /**
+     * Reports the same width as [minIntrinsicWidth] does, since this modifier
+     * makes the content occupy that width in either case.
+     */
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int
+    ): Int = windowSafeWidth(measurable.minIntrinsicWidth(height))
+
+    /**
+     * Extends the given width, which is expressed in pixels, up to the width
+     * that survives being converted into the whole [Dp] units of a window's
+     * size and then back into the pixels of that window's content.
+     *
+     * @receiver The density that converts between pixels and [Dp] units.
+     * @param width The width in pixels that the content needs.
+     * @return The width in pixels, which is not less than [width].
+     */
+    private fun Density.windowSafeWidth(width: Int): Int {
+        val windowWidth = ceil(width / density)
+        return ceil(windowWidth * density).toInt()
+    }
+}
 
 /**
  * A [PopupPositionProvider], which makes a lightweight popup to appear at
@@ -417,7 +496,9 @@ private fun DialogTitle(
     padding: PaddingValues
 ) {
     Text(
-        modifier = Modifier.padding(padding),
+        modifier = Modifier
+            .padding(padding)
+            .preferUnwrappedWidth(),
         text = text,
         style = typography.headlineLarge
     )

--- a/core/src/test/kotlin/io/spine/chords/core/layout/DialogSizingSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/DialogSizingSpec.kt
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ComposeScene
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the way that a dialog, whose size is detected automatically,
+ * measures its width.
+ */
+internal class DialogSizingSpec {
+
+    /**
+     * A window's size is expressed in whole [Dp] units, while its content is
+     * measured in pixels, and the conversion between the two discards the
+     * fractional part. A width that doesn't survive that conversion makes
+     * the window squeeze its content, which, e.g., truncates the labels of
+     * the dialog's buttons.
+     */
+    @Test
+    fun `provide the width that a dialog's window is able to reproduce`() {
+        val contentWidth = 400.5.dp
+
+        val width = dialogWidth {
+            ContentStub(contentWidth, contentWidth)
+        }
+
+        val requiredWidth = with(density) { contentWidth.roundToPx() }
+        width shouldBeGreaterThanOrEqual requiredWidth
+        windowContentWidth(width) shouldBeGreaterThanOrEqual requiredWidth
+    }
+
+    /**
+     * The buttons section is a part of the dialog's content, so the width
+     * detected for the dialog has to display the buttons the way they need,
+     * instead of making them squeeze their labels.
+     */
+    @Test
+    fun `provide the width that the dialog's buttons need`() {
+        val dialog = dialogWithLongButtonLabels()
+
+        val buttonsWidth = measureWidth {
+            MaterialTheme {
+                Box(modifier = Modifier.width(IntrinsicSize.Max)) {
+                    dialog.buttonsSectionInternal()
+                }
+            }
+        }
+        val width = dialogWidth {
+            DialogContent(dialog)
+        }
+
+        // Makes sure that it is the buttons, and not the minimum dialog width,
+        // that the detected width comes from.
+        buttonsWidth shouldBeGreaterThan with(density) { DefaultDialogMinWidth.roundToPx() }
+        width shouldBeGreaterThanOrEqual buttonsWidth
+    }
+
+    /**
+     * A dialog has to remain usable on the display that it is shown on, so
+     * the space available for the dialog wins over the width that the dialog's
+     * buttons ask for.
+     */
+    @Test
+    fun `cap the width that the dialog's buttons need with the available space`() {
+        val dialog = dialogWithLongButtonLabels()
+        val availableWidth = 300.dp
+
+        val width = dialogWidth(availableWidth) {
+            DialogContent(dialog)
+        }
+
+        width shouldBe with(density) { availableWidth.roundToPx() }
+    }
+
+    /**
+     * A text that fits on a single line shouldn't be wrapped only because
+     * the dialog is as narrow as the longest word of that text.
+     */
+    @Test
+    fun `provide the width that displays the dialog's text without wrapping`() {
+        val unwrappedWidth = 500.dp
+
+        val width = dialogWidth {
+            ContentStub(
+                minIntrinsicWidth = 100.dp,
+                maxIntrinsicWidth = unwrappedWidth,
+                modifier = Modifier.preferUnwrappedWidth()
+            )
+        }
+
+        width shouldBe with(density) { unwrappedWidth.roundToPx() }
+    }
+
+    /**
+     * A long text is wrapped rather than stretching the dialog, so the width
+     * that such a text asks for is limited.
+     */
+    @Test
+    fun `limit the width that a long text requests`() {
+        val maxTextWidth = 480.dp
+
+        val width = dialogWidth {
+            ContentStub(
+                minIntrinsicWidth = 100.dp,
+                maxIntrinsicWidth = 900.dp,
+                modifier = Modifier.preferUnwrappedWidth(maxTextWidth)
+            )
+        }
+
+        width shouldBe with(density) { maxTextWidth.roundToPx() }
+    }
+
+    /**
+     * Content that is wider than the space available for the dialog cannot
+     * make the dialog overflow the display that it is shown on.
+     */
+    @Test
+    fun `cap the width with the space that is available for the dialog`() {
+        val width = dialogWidth {
+            ContentStub(AvailableWidth * 2, AvailableWidth * 2)
+        }
+
+        width shouldBe with(density) { AvailableWidth.roundToPx() }
+    }
+
+    /**
+     * Creates a [ConfirmationDialog], whose buttons are wider than
+     * the minimum width of an automatically sized dialog.
+     */
+    private fun dialogWithLongButtonLabels() = ConfirmationDialog().apply {
+        message = "Proceed?"
+        noButtonText = "Continue editing the command"
+        yesButtonText = "Discard all the changes made so far"
+    }
+
+    /**
+     * Displays the content of the given dialog's window the way that
+     * a [WindowType] implementation does.
+     *
+     * @param dialog The dialog whose content is to be displayed.
+     */
+    @Composable
+    private fun DialogContent(dialog: Dialog) {
+        MaterialTheme {
+            Column {
+                dialog.windowContentInternal(DialogContentHeightMode.Natural)
+            }
+        }
+    }
+
+    /**
+     * Measures the width, in pixels, of an automatically sized dialog with
+     * the given content.
+     *
+     * @param availableWidth The width available for the dialog.
+     * @param content The content of the dialog to measure.
+     * @return The measured width of the dialog.
+     */
+    private fun dialogWidth(
+        availableWidth: Dp = AvailableWidth,
+        content: @Composable () -> Unit
+    ): Int = measureWidth(availableWidth) {
+        Box(
+            modifier = Modifier.dialogSize(
+                width = Dp.Unspecified,
+                height = Dp.Unspecified,
+                maxWidth = availableWidth,
+                maxHeight = AvailableHeight,
+                fillSpecifiedDimensions = false
+            )
+        ) {
+            content()
+        }
+    }
+
+    /**
+     * Measures the width, in pixels, that the given content occupies within
+     * the specified available width.
+     *
+     * @param availableWidth The width available for the content.
+     * @param content The content to measure.
+     * @return The measured width of the content.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun measureWidth(
+        availableWidth: Dp = AvailableWidth,
+        content: @Composable () -> Unit
+    ): Int {
+        val scene = ComposeScene(density = density)
+        try {
+            scene.constraints = with(density) {
+                Constraints(
+                    maxWidth = availableWidth.roundToPx(),
+                    maxHeight = AvailableHeight.roundToPx()
+                )
+            }
+            scene.setContent(content)
+            return scene.contentSize.width
+        } finally {
+            scene.close()
+        }
+    }
+
+    /**
+     * Emulates the way that Compose Desktop sizes a window from the size that
+     * was measured for its content: the measured size is converted into
+     * the whole [Dp] units of the window's size, and the content of that window
+     * is then measured against those units again.
+     *
+     * @param width The width, in pixels, measured for the window's content.
+     * @return The width, in pixels, that the window makes available
+     *   to its content.
+     */
+    private fun windowContentWidth(width: Int): Int {
+        val scale = density.density
+        val windowWidth = (width / scale).toInt()
+        return (windowWidth * scale).toInt()
+    }
+
+    /**
+     * Displays no content, and reports the specified intrinsic widths.
+     *
+     * It stands for a text, whose minimum intrinsic width is the width of its
+     * longest word, and whose maximum intrinsic width is the width that
+     * displays it without wrapping.
+     *
+     * @param minIntrinsicWidth The minimum intrinsic width to report.
+     * @param maxIntrinsicWidth The maximum intrinsic width to report.
+     * @param modifier The modifier to apply to this content.
+     */
+    @Composable
+    private fun ContentStub(
+        minIntrinsicWidth: Dp,
+        maxIntrinsicWidth: Dp,
+        modifier: Modifier = Modifier
+    ) {
+        Layout(
+            content = {},
+            modifier = modifier,
+            measurePolicy = object : MeasurePolicy {
+
+                /**
+                 * Occupies the space that the content is measured against.
+                 */
+                override fun MeasureScope.measure(
+                    measurables: List<Measurable>,
+                    constraints: Constraints
+                ): MeasureResult = layout(constraints.minWidth, constraints.minHeight) {}
+
+                /**
+                 * Reports the width of the content's longest "word".
+                 */
+                override fun IntrinsicMeasureScope.minIntrinsicWidth(
+                    measurables: List<IntrinsicMeasurable>,
+                    height: Int
+                ): Int = minIntrinsicWidth.roundToPx()
+
+                /**
+                 * Reports the width that displays the content without wrapping.
+                 */
+                override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+                    measurables: List<IntrinsicMeasurable>,
+                    height: Int
+                ): Int = maxIntrinsicWidth.roundToPx()
+
+                /**
+                 * Reports no height, as this content is measured by width only.
+                 */
+                override fun IntrinsicMeasureScope.minIntrinsicHeight(
+                    measurables: List<IntrinsicMeasurable>,
+                    width: Int
+                ): Int = 0
+
+                /**
+                 * Reports no height, as this content is measured by width only.
+                 */
+                override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+                    measurables: List<IntrinsicMeasurable>,
+                    width: Int
+                ): Int = 0
+            }
+        )
+    }
+
+    private companion object {
+
+        /**
+         * The density that makes a whole [Dp] unit occupy more than one pixel,
+         * like the one of a high-resolution display.
+         */
+        val density = Density(2f)
+
+        /**
+         * The width that is available to the dialog being measured.
+         */
+        val AvailableWidth = 1200.dp
+
+        /**
+         * The height that is available to the dialog being measured.
+         */
+        val AvailableHeight = 800.dp
+    }
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 30 12:51:42 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 20:56:07 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Thu Jul 30 12:51:42 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 30 12:51:44 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 20:56:09 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Thu Jul 30 12:51:44 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 30 12:51:45 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 20:56:10 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Thu Jul 30 12:51:45 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 30 12:51:46 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 20:56:11 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Thu Jul 30 12:51:46 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 30 12:51:47 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 20:56:12 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Thu Jul 30 12:51:47 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 30 12:51:48 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 30 20:56:13 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.99</version>
+<version>2.0.0-SNAPSHOT.100</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.99")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.100")


### PR DESCRIPTION
## Summary

An automatically sized dialog was measured to fit its content exactly, in pixels, while
a window's size is expressed in whole `Dp` units. Deriving the window's size from that
measurement discarded the fractional part, so the window could end up a pixel narrower
than its content. The buttons section then squeezed the button labels, which
`DialogButton` renders with `TextOverflow.Ellipsis`, turning `Discard changes` into
`Discard chang...`.

The detected width is now rounded up to a width that such a conversion preserves.
Besides that, the texts of the built-in dialogs request the width that displays them
without wrapping, up to the maximum width of a basic dialog in Material Design 3. Both
widths remain capped with the space available on the screen.

Fixes #149

## Changes

- `WindowType`: the `WindowSafeMinIntrinsicWidth` modifier replaces
  `Modifier.width(IntrinsicSize.Min)` in the shared dialog sizing. It extends the measured
  minimum intrinsic width up to a width that a window, sized in whole `Dp` units, is able
  to reproduce for its content.
- `DialogText` (new): the `Modifier.preferUnwrappedWidth()` modifier, which makes a text
  request the width that displays it on a single line, up to `560.dp`.
- `ConfirmationDialog`, `MessageDialog`, `InputTextDialog`, and the lightweight window's
  title apply that modifier to their texts.
- `Dialog.width`: documents that the detected width fits the buttons section and is capped
  with the available space.
- `DialogSizingSpec` (new): measures dialogs with `ComposeScene`, covering the window-safe
  rounding, the width required by the real buttons section of a `ConfirmationDialog`,
  the unwrapped text width and its limit, and the available-width cap.

## Reviewer notes

`dialogSize()` and `DefaultDialogMinWidth` are relaxed from `private` to `internal`, so
that `DialogSizingSpec` measures the shared sizing itself rather than a copy of it.