### PR TITLE
Support dirty state and cancellation confirmation in command wizards

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -91,6 +91,34 @@ the server connectivity:
 
 - etc.
 
+#### Confirming cancellation of a command wizard
+
+A `CommandWizard` reports through its `dirty` property whether any data has been
+entered on any of its pages, with the same meaning that `CommandDialog.dirty`
+has. All pages edit the fields of a single command message form, so `dirty`
+stays `true` for the data entered on a page that is not displayed anymore.
+
+The `Wizard.onBeforeCancel` callback is invoked when the user presses "Cancel",
+and returning `false` from it keeps the wizard open. The callback suspends, so
+a confirmation can be awaited inside it, and the wizard keeps the entered data
+while the confirmation is pending:
+
+```kotlin
+val wizard = ImportItemWizard().apply {
+    onCloseRequest = { wizardShown = false }
+    onBeforeCancel = {
+        !dirty || ConfirmationDialog.showConfirmation {
+            message = "Discard the data entered so far?"
+        }
+    }
+}
+```
+
+Successful submission closes the wizard through `close()`, which doesn't consult
+`onBeforeCancel`, so the confirmation above is never displayed after the command
+has been posted successfully. `onCloseRequest` is still invoked on both paths,
+and remains the callback that removes the wizard from the composition.
+
 #### Handling network errors in command modals
 
 When posting from a `CommandDialog` or `CommandWizard` fails because of a

--- a/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/layout/CommandWizard.kt
@@ -119,12 +119,36 @@ public abstract class CommandWizard<C : CommandMessage, B : ValidatingBuilder<ou
 
     private var postingState = mutableStateOf(false)
 
+    /**
+     * Stores the dirty state reported by the [commandMessageForm].
+     *
+     * Its value is exposed to consumers through [dirty].
+     */
+    private val dirtyState = mutableStateOf(false)
+
+    /**
+     * Has a value of `true` when the command form is in the "dirty" state.
+     *
+     * A "dirty" state means that at least one of the form's fields currently
+     * displays some data, either valid or invalid. A value of `false` means
+     * that none of the fields displays any data.
+     *
+     * All of the wizard's pages edit the fields of the same command message
+     * form, and the fields that have been edited remain registered in that form
+     * when the user navigates away from their page. This property therefore
+     * reports the data entered on any of the wizard's pages, and not just on
+     * the one that is currently displayed.
+     */
+    public val dirty: Boolean
+        get() = dirtyState.value
+
     internal val commandMessageForm: CommandMessageForm<C> =
         CommandMessageForm.create(
             { createCommandBuilder() },
             onBeforeBuild = { beforeBuild(it) }
         ) {
             validationDisplayMode = MANUAL
+            onDirtyStateChange = { dirtyState.value = it }
             createCommandConsequences = { consequences ->
                 this@CommandWizard.createCommandConsequences(consequences)
                     .also {

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
@@ -90,8 +90,24 @@ private object WizardContentSize {
  * finished using the wizard, and it needs to be closed. The container where
  * the wizard is placed is responsible for hiding the wizard (excluding it from
  * the composition) upon this event.
+ *
+ * The wizard can be closed along two distinct paths, and they invoke different
+ * callbacks:
+ * - The user presses the "Cancel" button, which invokes [cancel]. It consults
+ *   the [onBeforeCancel] callback, and closes the wizard only if that callback
+ *   permits closing.
+ * - The wizard's submission succeeds, and the wizard's implementation invokes
+ *   [close] directly. This path doesn't consult [onBeforeCancel].
+ *
+ * Both paths end up invoking [onCloseRequest] when the wizard is actually
+ * closed, so a host that only needs to remove the wizard from the composition
+ * can keep handling [onCloseRequest] alone.
  */
 @Stable
+@Suppress(
+    // All functions are apparently appropriate in the class.
+    "TooManyFunctions"
+)
 public abstract class Wizard : Component() {
 
     /**
@@ -106,8 +122,52 @@ public abstract class Wizard : Component() {
      *
      * This callback is triggered when the user closes the wizard or after
      * successful submission.
+     *
+     * It is triggered only when the wizard is actually being closed, so a
+     * cancellation that was rejected by [onBeforeCancel] doesn't trigger it.
+     *
+     * @see onBeforeCancel
      */
     public var onCloseRequest: (() -> Unit)? = null
+
+    /**
+     * A suspending callback, which is invoked upon the wizard's "Cancel" button
+     * click before the wizard is closed.
+     *
+     * The callback should return `true` in order for the wizard to proceed with
+     * closing, and `false` to prevent the wizard from being closed. The wizard
+     * stays in the composition while the callback is suspended, so any data
+     * that has been entered in the wizard's pages is retained, both while the
+     * callback is pending and if it rejects closing.
+     *
+     * The default implementation just returns `true`, and one of the typical
+     * usage scenarios would be to display the confirmation dialog.
+     *
+     * Note that this callback is invoked only when the user cancels the wizard,
+     * and it is not invoked when the wizard is closed after a successful
+     * submission (which happens by invoking [close] directly). A confirmation
+     * displayed in this callback therefore doesn't appear after the wizard's
+     * operation has succeeded.
+     *
+     * For example, in order for the custom `MyWizard` implementation to display
+     * a confirmation before the wizard is closed upon pressing "Cancel", the
+     * following can be done:
+     * ```
+     * public class MyWizard : Wizard() {
+     *
+     *     init {
+     *         onBeforeCancel = {
+     *             ConfirmationDialog.showConfirmation {
+     *                 message = "Are you sure you want to discard the data?"
+     *             }
+     *         }
+     *         ...
+     *     }
+     * ```
+     *
+     * @see cancel
+     */
+    public var onBeforeCancel: suspend () -> Boolean = { true }
 
     public var currentPage: WizardPage
         get() = pages[currentPageIndex]
@@ -157,9 +217,43 @@ public abstract class Wizard : Component() {
 
     /**
      * Closes the wizard.
+     *
+     * This method closes the wizard unconditionally, without consulting the
+     * [onBeforeCancel] callback, and it is the method that the wizard's
+     * implementation is expected to invoke when its submission succeeds.
+     *
+     * Use [cancel] instead to close the wizard on the user's request.
      */
     public open fun close() {
         onCloseRequest?.invoke()
+    }
+
+    /**
+     * Cancels the wizard, which is equivalent to pressing the
+     * "Cancel" button.
+     *
+     * This means invoking the [onBeforeCancel] callback, and closing the wizard
+     * if the callback didn't prevent closing.
+     *
+     * @see onBeforeCancel
+     */
+    public fun cancel(): Unit = launch {
+        requestCancel()
+    }
+
+    /**
+     * Performs the wizard's cancellation, which is the part of [cancel] that
+     * doesn't require a composition-scoped coroutine scope.
+     *
+     * @return `true`, if the wizard was closed, and `false`, if the
+     *   [onBeforeCancel] callback has prevented the wizard from being closed.
+     */
+    internal suspend fun requestCancel(): Boolean {
+        if (!onBeforeCancel()) {
+            return false
+        }
+        close()
+        return true
     }
 
     @Composable
@@ -207,7 +301,7 @@ public abstract class Wizard : Component() {
                     onFinishClick = {
                         handleFinishClick(currentPage)
                     },
-                    onCancelClick = { close() },
+                    onCancelClick = { cancel() },
                     isOnFirstPage = isOnFirstPage(),
                     isOnLastPage = isOnLastPage(),
                     submitting

--- a/core/src/test/kotlin/io/spine/chords/core/layout/WizardSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/WizardSpec.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.runtime.Composable
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+
+internal class WizardSpec {
+
+    @Test
+    fun `close the wizard when the cancellation guard allows it`() {
+        val wizard = TestWizard()
+
+        runBlocking {
+            wizard.requestCancel() shouldBe true
+        }
+
+        wizard.closeRequests shouldBe 1
+    }
+
+    @Test
+    fun `keep the wizard open when the cancellation guard rejects cancellation`() {
+        val wizard = TestWizard().apply {
+            onBeforeCancel = { false }
+        }
+
+        runBlocking {
+            wizard.requestCancel() shouldBe false
+        }
+
+        wizard.closeRequests shouldBe 0
+    }
+
+    @Test
+    fun `keep the wizard open while the cancellation guard is pending`() {
+        val confirmation = CompletableDeferred<Boolean>()
+        val wizard = TestWizard().apply {
+            onBeforeCancel = { confirmation.await() }
+        }
+
+        runBlocking {
+            val cancellation = async { wizard.requestCancel() }
+            yield()
+
+            wizard.closeRequests shouldBe 0
+
+            confirmation.complete(true)
+
+            cancellation.await() shouldBe true
+        }
+
+        wizard.closeRequests shouldBe 1
+    }
+
+    @Test
+    fun `close the wizard without consulting the cancellation guard on submission`() {
+        var guardInvoked = false
+        val wizard = TestWizard().apply {
+            onBeforeCancel = {
+                guardInvoked = true
+                true
+            }
+        }
+
+        wizard.close()
+
+        wizard.closeRequests shouldBe 1
+        guardInvoked shouldBe false
+    }
+
+    /**
+     * A minimal [Wizard] implementation, which counts the close requests it
+     * has made.
+     */
+    private class TestWizard : Wizard() {
+
+        /**
+         * The number of times this wizard has requested its host to close it.
+         */
+        var closeRequests: Int = 0
+            private set
+
+        override val title: String = "Test"
+
+        init {
+            onCloseRequest = { closeRequests += 1 }
+        }
+
+        override fun createPages(): List<WizardPage> = listOf(TestPage(this))
+
+        override suspend fun submit(): Unit = Unit
+    }
+
+    /**
+     * A wizard page with no content, which is valid at all times.
+     */
+    private class TestPage(wizard: Wizard) : AbstractWizardPage(wizard) {
+
+        @Composable
+        override fun content(): Unit = Unit
+
+        override fun validate(): Boolean = true
+    }
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.101`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.102`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 31 19:20:17 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 31 22:25:29 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.101`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.102`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Fri Jul 31 19:20:17 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 31 19:20:18 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 31 22:25:30 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.101`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.102`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Fri Jul 31 19:20:18 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 31 19:20:20 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 31 22:25:31 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.101`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.102`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Fri Jul 31 19:20:20 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 31 19:20:21 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 31 22:25:32 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.101`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.102`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Fri Jul 31 19:20:21 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 31 19:20:22 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 31 22:25:33 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.101`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.102`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Fri Jul 31 19:20:22 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 31 19:20:23 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 31 22:25:34 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.101</version>
+<version>2.0.0-SNAPSHOT.102</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.101")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.102")


### PR DESCRIPTION
## Summary

`CommandDialog` exposes its form's dirty state and can guard cancellation,
but `CommandWizard` had no equivalent. `Wizard.onCloseRequest` also fired
both when the user cancelled and after a successful submission, so a wizard
host could not confirm discarding entered data without also prompting once
the command had posted.

This separates the two close paths rather than having `onCloseRequest` tell
them apart, and exposes the wizard's aggregate dirty state so a host can
implement discard confirmation without inspecting wizard internals.

## Changes

- `Wizard` gains `onBeforeCancel`, a suspending guard returning whether to
  proceed with closing, and `cancel()`, which the "Cancel" button now calls.
  The guard logic sits in `requestCancel()`.
- The submission path continues to call `close()` directly, so it never
  reaches the guard. `close()` and `onCloseRequest` are behaviourally
  unchanged, and existing hosts keep working.
- Entered data survives a pending confirmation: the wizard stays in
  composition until the guard resolves.
- `CommandWizard` gains `dirty`, backed by the single `CommandMessageForm`
  spanning every page, so the value covers pages the user has navigated away
  from.
- `client/README.md` documents the host-side pattern.

Public API additions are additive only: `Wizard.onBeforeCancel`,
`Wizard.cancel()`, and `CommandWizard.dirty`. No existing signature, name, or
visibility changed.

Fixes #148
