### PR TITLE
Add Kotlin language and test-writing skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -3,7 +3,11 @@
 This index is a quick orientation aid. Each skill's frontmatter remains the
 routing source of truth.
 
-- `engineer`: routing skill for mixed or unclear implementation work.
+- `engineer`: routing skill for mixed or unclear implementation work, and
+  the home of the shared design-restraint policy.
+- `kotlin-engineer`: the Kotlin language itself — the 1.8.20 ceiling,
+  null-safety, `lateinit`, coroutine scoping, and public-type rules. Pairs
+  with whichever area skill owns the code being changed.
 - `component-engineer`: class-based Compose UI components across `core`,
   `proto`, and `client` — the component model, input components, message
   forms, and server-connected components.
@@ -20,8 +24,10 @@ routing source of truth.
   guard, validation, and publishing pipelines.
 - `code-reviewer`: implementation review for component, codegen, and build
   changes.
-- `tester`: test authoring and verification strategy for all modules,
+- `tester`: what to cover and how to verify it across all modules,
   including codegen correctness tests.
+- `kotlin-jvm-tester`: how a test suite is written — JUnit Jupiter
+  structure, Kotest assertions, naming, fixtures, and `testlib` bases.
 - `docs-writer`: documentation authoring, editing, restructuring, and claim
   checks.
 - `docs-reviewer`: documentation review for prose, examples, and comments.
@@ -48,8 +54,10 @@ Each skill lives in its own directory:
 The `name` in `SKILL.md` frontmatter must match the directory name.
 
 A skill may add supporting files its own policy body references — for example,
-`pair-workflow/template.md`, the working-document template its driver copies.
-Policy still belongs in `SKILL.md`.
+`pair-workflow/template.md`, the working-document template its driver copies,
+or `kotlin-jvm-tester/references/advanced-test-patterns.md`, loaded only when
+a task reaches the shapes it covers. Core policy still belongs in `SKILL.md`;
+a `references/` file carries detail most tasks do not need.
 
 ## Invocation
 

--- a/.agents/skills/code-reviewer/SKILL.md
+++ b/.agents/skills/code-reviewer/SKILL.md
@@ -79,15 +79,28 @@ duplicate its steps.
   generated `MessageField`/`MessageOneof`/`MessageDef` contract between
   `codegen/plugins` and `codegen/runtime`, and Protobuf compatibility in
   `proto-values`.
-- Toolchain violations: language or library features newer than Kotlin 1.8.20
-  / Compose 1.5.12 in root modules (or mixing the `codegen/plugins` toolchain
-  into root code).
+- Kotlin-language and toolchain violations: apply
+  `.agents/skills/kotlin-engineer/SKILL.md` to the changed Kotlin and report
+  what its rules flag. Read it rather than reviewing from memory — several
+  of its rules turn on repository specifics a general Kotlin reading would
+  get wrong, including which toolchain ceiling governs the file and the
+  sanctioned exceptions to otherwise-standard bans.
 - Missing or weak tests for changed logic, extensions, or codegen behavior.
 - Version-policy misses: `chordsVersion` not incremented, or `pom.xml` /
   `dependencies.md` not regenerated when required.
 - Module-ownership violations, leaked state, unjustified reflection, and
   hidden background work.
 - Workarounds that mask a root cause instead of fixing it.
+- Overengineering, per "Design Restraint" in
+  `.agents/skills/engineer/SKILL.md`: an abstraction with a single
+  implementor, an option nothing sets, or an indirection layer that only
+  forwards. A type parameter is a finding only when it preserves no type
+  relationship *and* every use instantiates it identically — a single call
+  site alone is not evidence. Weigh it against the
+  published-extension-point exception before reporting — a `public`
+  abstraction documented as an extension point for consuming applications
+  is intended. The reverse also counts: duplicated non-trivial logic where
+  the changeset already has two call sites.
 
 ## Handoffs
 

--- a/.agents/skills/component-engineer/SKILL.md
+++ b/.agents/skills/component-engineer/SKILL.md
@@ -38,16 +38,17 @@ build logic, use `.agents/skills/build-engineer/SKILL.md`.
 - Respect module layering: `core` must not depend on `proto` or `client`;
   `proto` must not depend on `client`. Put behavior in the lowest module that
   owns it.
-- All libraries use Kotlin explicit API mode: public declarations need
-  explicit `public` modifiers and public API needs KDoc.
 - Avoid breaking public API: signatures, property names, and visibility of
   published declarations are contracts for external consumers. Prefer additive
   changes; when a member is `protected`, it is part of the API for component
   subclasses.
-- Target the pinned toolchain: Kotlin 1.8.20 and Compose Multiplatform 1.5.12.
-  Do not use newer language features or Compose APIs. Some Compose APIs in use
-  are experimental (`@OptIn(ExperimentalComposeUiApi::class)`); keep such
-  opt-ins localized and documented.
+- Target Compose Multiplatform 1.5.12; do not use newer Compose APIs. Some
+  Compose APIs in use are experimental
+  (`@OptIn(ExperimentalComposeUiApi::class)`); keep such opt-ins localized
+  and documented.
+- For the Kotlin language itself — the 1.8.20 ceiling, explicit API mode,
+  null-safety, `lateinit` in `Props`, and coroutine scoping — follow
+  `.agents/skills/kotlin-engineer/SKILL.md`.
 - Match existing KDoc style: `@param` tags for type parameters and
   constructor-like parameters, backticked identifiers, and wrapped lines
   within 100 characters.

--- a/.agents/skills/engineer/SKILL.md
+++ b/.agents/skills/engineer/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: engineer
 description: >
-  Routes Chords implementation work to the area-specific engineering skill. Use
-  for mixed component/codegen/build changes or when the owning area is unclear;
-  otherwise prefer the narrowest specialist skill directly.
+  Routes Chords implementation work to the area-specific engineering skill and
+  carries the design-restraint policy shared by all of them. Use for mixed
+  component/codegen/build changes or when the owning area is unclear; otherwise
+  prefer the narrowest specialist skill directly, and follow "Design Restraint"
+  below in either case.
 ---
 
 # Engineering Router
 
-Use the narrowest implementation skill that fits the task:
+`.agents/skills/kotlin-engineer/SKILL.md` applies to *all* of the areas
+below — it owns the Kotlin language baseline (the pinned 1.8.20 ceiling,
+null-safety, coroutine scoping, public types under explicit API mode). Pair
+it with the area skill that owns the code being changed:
 
 - `.agents/skills/component-engineer/SKILL.md` for class-based Compose UI
   components in `core`, `proto`, and `client`: the component model,
@@ -38,5 +43,53 @@ For documentation changes alongside implementation, also use
 `.agents/skills/docs-writer/SKILL.md`. For verification work, use
 `.agents/skills/tester/SKILL.md`. To review an implementation diff for
 correctness and regressions, use `.agents/skills/code-reviewer/SKILL.md`.
+
+## Design Restraint
+
+This section applies to every area-specific skill above, whichever one the
+work routes to. It does not replace the API and safety rules in `AGENTS.md`.
+
+Prefer the simplest construct that satisfies the requirement in front of
+you. Reach for a layered, hierarchical, or polymorphic design only when the
+present case needs it — not because a future case might.
+
+- **Abstract only over what exists.** Introduce a base class or an interface
+  once at least two concrete implementors exist, either already in the
+  repository or in the changeset you are writing. One implementor plus an
+  anticipated second is one. When a second is coming, write it first and let
+  the shared shape fall out of the two.
+- **Type parameters answer to a different test.** They have no implementors,
+  so the two-implementation heuristic does not apply. A type parameter earns
+  its place when it preserves a type relationship the signature would
+  otherwise lose — tying an argument to a return type, or a component to the
+  value type it edits — and that can be true at a single call site. What
+  does not earn its place is a parameter that every use instantiates
+  identically, or one that could be replaced by the concrete type with no
+  loss of type-safety at the call site.
+- **The published-extension-point exception.** Chords is a library, and some
+  abstractions are the product rather than speculation:
+  `io.spine.chords.core.Component` and the `Props`-style configuration exist
+  so that consuming applications subclass them. A public extension point can
+  be justified by a single in-repo inheritor when external extension is its
+  stated purpose — state that purpose in its KDoc. This exception covers
+  deliberate API surface, not internal helpers.
+- **Do not add unused capability.** No interface with one implementation and
+  no external implementor, no type parameter every use instantiates the
+  same way, no configuration option nothing sets, no `open` without a
+  subclass, no indirection that only forwards. Explicit API mode makes every
+  `public` declaration a compatibility commitment, and the cheapest
+  abstraction to change is the one not yet published.
+- **Extend the shape already in place** — package structure, module
+  boundaries, and the component patterns named in "Safety Rules" and
+  "Development Conventions" of `AGENTS.md`. A second hierarchy parallel to
+  an existing one needs a reason stated in the final response.
+- **Restraint is not an excuse to under-solve.** It does not license
+  duplicating non-trivial logic, substituting a workaround for a root-cause
+  fix (`AGENTS.md`, "Bug Fixes"), or dropping error handling. The target is
+  the smallest design that fully covers the requirement — not the smallest
+  diff.
+
+When simplicity and generality are genuinely balanced, take the option that
+is cheaper to reverse, and note the trade-off in the final response.
 
 Follow the git-history and safety policy in `AGENTS.md`.

--- a/.agents/skills/kotlin-engineer/SKILL.md
+++ b/.agents/skills/kotlin-engineer/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: kotlin-engineer
+description: >
+  Chords Kotlin implementation policy and the pitfalls that recur in review:
+  the pinned 1.8.20 language ceiling, null-safety and `!!`, `lateinit` in
+  `Props`, coroutine scoping and cancellation in `client`, and read-only
+  public types under explicit API mode. Use whenever writing, changing,
+  refactoring, or reviewing Kotlin in any module: `.kt`/`.kts` edits,
+  turning Java-style Kotlin idiomatic, anything touching coroutines,
+  cancellation, or `Flow` (concentrated in `client`), and designing a public
+  Kotlin signature. Area skills own their own domains — this one covers the
+  language itself.
+---
+
+# Kotlin Engineering
+
+Baseline Kotlin knowledge is assumed — data/sealed classes, scope functions,
+null-safety operators, extension functions, `suspend`, `Flow`, `when`
+exhaustiveness. This skill does not teach the language. It encodes what is
+specific to Chords and the traps that keep surfacing in review.
+
+## Defer, Do Not Restate
+
+Each of these owns its area; this skill stays out of them:
+
+- `.agents/skills/component-engineer/SKILL.md` — the component model,
+  `mutableStateOf`-backed state, `PascalCase` composables, module layering,
+  KDoc style, and the Compose 1.5.12 ceiling.
+- `.agents/skills/codegen-engineer/SKILL.md` — generated contracts and
+  Protobuf declarations.
+- `.agents/skills/build-engineer/SKILL.md` — Gradle Kotlin DSL, `buildSrc`
+  coordinates, and publishing.
+- `.agents/skills/kotlin-jvm-tester/SKILL.md` — how a test suite is
+  written. This skill is the baseline for the Kotlin *inside* a test body.
+- `.agents/skills/engineer/SKILL.md`, "Design Restraint" — *whether* to
+  introduce a sealed hierarchy, base class, or type parameter at all. This
+  skill covers how to write one once that decision is made.
+- `.agents/skills/code-reviewer/SKILL.md` — review output format and
+  verdict. Report Kotlin findings through it; do not invent a second format.
+- `AGENTS.md` — verification commands, versioning, and safety policy.
+
+## Toolchain Ceiling
+
+**Two ceilings, and which one applies depends on the file you are editing.**
+The root build compiles with **Kotlin 1.8.20** — the version of the
+`kotlin("jvm")` plugin declared in `buildSrc/build.gradle.kts` — on JVM
+target 11. It covers every module in
+`settings.gradle.kts`: `core`, `proto`, `proto-values`, `client`, `runtime`
+(at `codegen/runtime`), and `codegen-tests` (at `codegen/tests`) — note that
+both `codegen/` subprojects belong to the *root* build. Only
+`codegen/plugins` is separate, using **Kotlin 2.3.20** on JDK 17 (its own
+`kotlinVersion` in `codegen/plugins/buildSrc/build.gradle.kts`).
+
+Everything below about the 1.8.20 ceiling applies to the root build; in
+`codegen/plugins` the 2.x language is available. Never carry a construct
+from one across to the other because it compiled where you first wrote it.
+Both builds enable explicit API mode.
+
+Within the root modules:
+
+- **The stdlib on the classpath is newer than the compiler.**
+  `forceProductionDependencies()` in
+  `buildSrc/src/main/kotlin/DependencyResolution.kt` pins `kotlin-stdlib` to
+  the `Kotlin.version` coordinate — currently 1.9.23 — while the compiler
+  stays at 1.8.20. A 1.9 stdlib *function* can therefore resolve and compile,
+  even though a 1.9 *language feature* cannot. **"It compiles" is not
+  evidence that a construct is within the baseline** — check when the API
+  was introduced, and prefer one that predates 1.8.20.
+- Not available at 1.8.20: `data object`, `enumEntries`, the stable `..<`
+  operator (use `until`), and stable context receivers.
+- Available and preferred where they fit: sealed interfaces, `@JvmInline
+  value class`, `buildList` / `buildMap`, and `kotlin.time.Duration`.
+- Coroutines are **1.7.3** (`KotlinX.Coroutines.version`), forced across
+  every configuration by the `resolutionStrategy` block in the root
+  `build.gradle.kts`. 1.7 APIs are available. Ignore the unused
+  `Coroutines` object in the same dependency package — nothing imports it,
+  and its version is not what resolves.
+- **Explicit API mode is on in both builds** — each calls `explicitApi()`
+  in its Kotlin block. The compiler enforces exactly two
+  things: an explicit visibility modifier and an explicit return type on
+  every public declaration. It does **not** check documentation — KDoc on
+  every declaration is a separate repository rule from `AGENTS.md`,
+  "Development Conventions". Satisfy both, but do not expect the compiler to
+  catch the second.
+
+## Must Do
+
+- **Null-safety through `?.`, `?:`, `let`, and `requireNotNull`.** Reserve
+  `!!` for a genuine contract violation, and put the reason on the same
+  line. `requireNotNull(x) { "why" }` or `checkNotNull` is almost always the
+  better expression of the same intent, because it fails with a message.
+- **`lateinit var` is sanctioned for `Props`-style configuration** — the
+  established idiom for component properties supplied after construction
+  (`public lateinit var onSelectItem: (I?) -> Unit` in `DropdownListBox`).
+  Outside that pattern, prefer a constructor parameter or a nullable
+  property. Never `lateinit` a primitive or nullable type — that does not
+  compile; use `Delegates.notNull()` for a primitive.
+- **Structured concurrency by default.** Take a `CoroutineScope` from the
+  caller or use `coroutineScope { }`.
+- **The `GlobalScope` exception, in the shape `client` already uses it.**
+  Work that must outlive the composition or call that started it launches on
+  `GlobalScope` only with `@OptIn(DelicateCoroutinesApi::class)` and a
+  comment *inside* that annotation covering the decision. The existing sites
+  state it tersely — "We don't need the posting job to be canceled
+  automatically" — which is the established shape; in new code, also give
+  the reason, so a later reader can tell a deliberate choice from an
+  oversight. Two sanctioned variants, and which one you need follows from
+  whether anything must be able to stop the work:
+  - **Retained job**, when it must be cancellable — assign the `Job` to a
+    property and cancel it explicitly. `DesktopClient.withTimeout` keeps
+    `timeoutJob` and cancels it in `cancelTimeout()`.
+  - **Fire-and-forget**, when the work must run to completion regardless of
+    the caller's lifecycle — do not retain the `Job`.
+    `CommandConsequences.postAndProcessConsequences` posts a command this
+    way deliberately, since abandoning it half-way would leave the command
+    posted but its consequences unobserved.
+
+  What is not acceptable is a `GlobalScope.launch` with neither the opt-in
+  nor a stated reason. Discarding the `Job` is a decision to be justified in
+  that comment, not a defect on its own.
+- **Rethrow `CancellationException`.** A `catch (e: Exception)` that
+  swallows it silently disables cancellation. Cancellation is the caller's
+  decision, not a failure to be converted into an error state.
+- **Confine `runBlocking` to a bridge** from a non-suspend API into suspend
+  code. Inside a `suspend` function it is always a bug.
+- **Expose read-only types from public API** — `List` over `MutableList`,
+  `StateFlow` over `MutableStateFlow`, and never the mutable backing
+  property itself. Explicit API mode makes each of these a published
+  contract.
+- **Immutability first**: `val` over `var`, and `copy()` on a data class
+  rather than mutation.
+- **Named arguments once a Kotlin call takes three or more parameters**,
+  which is what stops a silent argument swap between same-typed parameters.
+  This applies only where parameter names are available to the caller —
+  Kotlin does not permit named arguments for Java methods and constructors,
+  which includes the generated Protobuf builders used throughout `proto` and
+  `proto-values`. There, keep the call readable by other means: one setter
+  per line in a builder chain, or a local variable per value.
+- **`data class` for pure value types only** — not for components,
+  services, or anything with a lifecycle.
+- **Deprecated API only on explicit instruction.** When directed to use one,
+  confine the call to the narrowest scope and suppress right there —
+  `@Suppress("DEPRECATION")` with a comment naming both the instruction and
+  the replacement to migrate to.
+
+## Must Not Do
+
+- **No `catch (e: Throwable)`** — it captures `OutOfMemoryError`,
+  `StackOverflowError`, and cancellation. Catch `Exception` and rethrow
+  cancellation.
+- **No `.first()` on a flow with no guaranteed emission, without a
+  timeout.** The risk is the absence of a value to take, not heat:
+  `StateFlow.first()` returns the current value immediately and is safe,
+  and so is a `SharedFlow` with a non-zero `replay` that has already
+  emitted. A `replay = 0` `SharedFlow`, a channel-backed flow, or any
+  source whose first emission depends on an external event will suspend
+  indefinitely — bound those with `withTimeout`.
+- **`single()` is a stronger claim than `first()`** — it waits for the flow
+  to *complete* and fails if a second value arrives. On any flow that does
+  not terminate on its own it hangs even when values are emitted. Use it
+  only on a finite flow, and use `first()` when you mean "the next value".
+- **No sequential `async { }.await()`** when the point was parallelism;
+  start both, then await both.
+- **No platform-type leak in public API.** A value crossing from Java
+  arrives as `String!`; give the public declaration an explicit nullable or
+  non-null type rather than letting the platform type propagate.
+- **No language feature newer than 1.8.20**, and no stdlib API added after
+  it without a deliberate decision — see "Toolchain Ceiling".
+- **No new deprecated-API call** without that explicit instruction; use the
+  replacement named in the `@Deprecated` or `ReplaceWith` message.
+
+## Verification
+
+Compile the narrowest module first; the full command set and the JDK
+constraints live in `AGENTS.md`, "Verification and Quality".
+
+```bash
+./gradlew :<module>:compileKotlin
+./gradlew :<module>:test
+./gradlew detekt
+```
+
+Detekt runs over these modules — do not introduce new violations, and keep
+lines within 100 characters.
+
+## Report
+
+State what changed, and call out any non-obvious rule above that the change
+depends on — a `!!` you kept, a `GlobalScope` opt-in you added, a stdlib API
+whose version you checked. Findings from reviewing someone else's Kotlin go
+through `code-reviewer`'s output format, not a second verdict here.

--- a/.agents/skills/kotlin-engineer/agents/openai.yaml
+++ b/.agents/skills/kotlin-engineer/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Kotlin Engineer"
+  short_description: "Chords Kotlin language policy and recurring pitfalls"
+  default_prompt: >
+    Use $kotlin-engineer to implement or review this Kotlin change under
+    Chords' language and toolchain rules.

--- a/.agents/skills/kotlin-jvm-tester/SKILL.md
+++ b/.agents/skills/kotlin-jvm-tester/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: kotlin-jvm-tester
+description: >
+  Chords authority on how a JVM test is written: Kotlin, JUnit Jupiter
+  structure, Kotest assertions, `internal` `*Spec` classes, hand-rolled
+  stubs, and a `testlib` base class when the target's shape calls for one.
+  Use when adding, restructuring, or reviewing a test in `core`, `proto`,
+  `proto-values`, `client`, `runtime`, or `codegen/tests` — a fresh suite,
+  more cases, a rewrite, or judging whether an existing suite follows the
+  conventions. `tester` owns which cases are worth writing and how to verify
+  them; `kotlin-engineer` remains the baseline for the Kotlin inside each
+  test body.
+---
+
+# Kotlin JVM tester
+
+This skill is the single source of truth for *how a test is written* in
+Chords. It does not decide *what* to test — that comes from the caller: a
+bug fix dictates its own reproducing case, a feature change its own
+coverage.
+
+Two companions own neighboring concerns; defer to them rather than
+restating:
+
+- `.agents/skills/tester/SKILL.md` — what to cover, where it belongs, and
+  the Gradle verification commands.
+- `.agents/skills/kotlin-engineer/SKILL.md` — the Kotlin baseline. A test
+  body is Kotlin, so its null-safety, coroutine scoping, and language
+  ceiling obey the same rules as production code.
+- `.agents/skills/engineer/SKILL.md` — the router to the area-specific
+  engineering skill (`component-engineer`, `codegen-engineer`,
+  `build-engineer`, …). Use it to find the skill owning the code under
+  test when you need its API constraints.
+
+`AGENTS.md` remains authoritative for Git history, versioning, and
+verification policy.
+
+## Core policy
+
+1. **Every test is Kotlin.** No module currently contains tests under
+   `src/test/java`, and every suite is Kotlin. Do not add a Java test. The
+   published Kotlin declarations are callable from Java like any JVM
+   library, so a Java-interoperability suite is conceivable — treat it as
+   out of scope unless the user asks for that coverage explicitly, and
+   agree on its placement and naming with them first.
+2. **JUnit Jupiter for structure; Kotest for assertions.** Use the
+   class-based Jupiter model — `@Test`, `@Nested`, `@DisplayName`,
+   `@BeforeEach`, `@ParameterizedTest`, `@MethodSource` — and assert with
+   Kotest matchers (`shouldBe`, `shouldNotBe`, `shouldThrow`, `withClue`).
+3. **Kotest spec styles do not run here.** The `setupTests()` function in
+   `buildSrc/src/main/kotlin/jvm-module.gradle.kts` registers only the
+   Jupiter engine:
+
+   ```kotlin
+   useJUnitPlatform {
+       includeEngines("junit-jupiter")
+   }
+   ```
+
+   A `FunSpec`/`StringSpec`/`DescribeSpec` suite compiles and is then
+   silently skipped — it never fails, and it never runs. None exist in the
+   repository; do not add one.
+4. **`@DisplayName` comes from `org.junit.jupiter.api`.** Kotest ships an
+   annotation of the same name, and an IDE import completion picks it
+   readily. `io.kotest.core.spec.DisplayName` is read by the Kotest engine,
+   which is excluded here, so it has no effect on the report. Check the
+   import whenever you add or edit the annotation — four existing suites
+   (`WallClockSpec`, `DateTimeFieldSpec`, `MoneyFieldSpec`, `MoneyExtsSpec`)
+   carry the Kotest one and are therefore reported by method name only.
+5. **Mark suites `internal`.** Every suite in the repository is
+   `internal class …Spec`. Keep it that way unless the class is an abstract
+   base reused from another module.
+6. **Stubs, not mocks.** No mocking framework is on the classpath by
+   design. Write hand-rolled fakes — see "Fixtures and stubs".
+7. **Kotest assertions only — in the assertions you write.** No suite uses
+   anything else. AssertK is deprecated in favor of Kotest
+   (see the `@Deprecated` annotation on the `AssertK` object in
+   `buildSrc/src/main/kotlin/io/spine/internal/dependency/`).
+   Truth is not declared directly on any test configuration, but it arrives
+   transitively through `spine-testlib` at compile scope, so
+   `com.google.common.truth.Truth` will import and compile. Resolving is not
+   permission: use Kotest. If a subject genuinely cannot be expressed with
+   Kotest matchers, raise it rather than quietly importing a second
+   assertion library.
+
+   This rule governs the assertions in your suite, not the internals of the
+   helpers it inherits. The `testlib` base classes assert with JUnit and
+   Truth inside their own inherited tests; that is theirs, and it is not a
+   precedent for the cases you write.
+
+## Workflow
+
+1. **Read first.** Read the class under test in full — public API,
+   constructors, branches, `when`/sealed exhaustiveness, error paths. Then
+   read the nearest existing suite in the same module and match its
+   structure, fixtures, and imports.
+2. **Name the suite** per "Naming": `<ClassUnderTest>Spec.kt`.
+3. **Classify the target, then pick a base or a helper**, per "Pick a base or
+   helper". Most Chords targets are Kotlin `object`s, Compose component
+   classes, or ordinary classes, for which a bare `internal class …Spec` is
+   correct. A base class is required only when the target's shape matches a
+   row in the *base class* table — never hand-roll a check a base already
+   provides. The standalone helpers are independent of that choice: reach
+   for them from any suite, with or without a base.
+4. **Write the test** following "Structure and formatting". Place it under
+   `<module>/src/test/kotlin/…`, mirroring the package of the code under
+   test. Reuse the surrounding files' copyright header.
+5. **Verify** by running the narrowest Gradle test task for the module,
+   unless the user forbids verification or it is unavailable in this
+   environment — in which case report why it was not run instead of running
+   it anyway. Follow the verification policy in
+   `.agents/skills/tester/SKILL.md`, including its warning about
+   `UP-TO-DATE` tasks standing in as evidence.
+
+## Naming
+
+**A suite is `<subject>Spec.kt`** — the single naming form in this
+repository, and the one `AGENTS.md` states. There is no `*Test` suffix for
+a suite, and no separate suffix for an integration test; `Spec` covers
+every suite until a source set exists that needs otherwise, at which point
+the convention is settled with the user and recorded in both `AGENTS.md`
+and this skill.
+
+- **A file of extensions takes the file's name**, not a class name —
+  `MoneyExts.kt` → `MoneyExtsSpec.kt` in `proto-values`.
+- **Give every new suite a `@DisplayName`** with a "should" lead-in and the
+  subject in backticks: ``@DisplayName("`WallClock` should")``. For an
+  extension file the subject reads naturally:
+  ``@DisplayName("Extensions for `Money` should")``. Older suites in
+  `client` and `core` predate this rule; leave them unless you are already
+  editing them.
+- **Test method names read as sentences, backticked only when they must
+  be.** A multi-word name is a backticked sentence:
+  `` fun `read initial data and apply subscription updates`() ``. A name
+  that is a single legal Kotlin identifier is written plainly —
+  `fun initialize()` — unless it is a hard keyword (`is`, `in`, `object`,
+  `fun`, …), which still needs backticks: `` fun `is`() ``. The same rule
+  governs `@Nested` class names.
+
+## Structure and formatting
+
+A canonical suite, following
+`client/src/test/kotlin/io/spine/chords/client/DataObservationImplSpec.kt`
+for body shape and
+`codegen/tests/src/test/kotlin/io/spine/chords/codegen/CodegenPluginsSpec.kt`
+for the `@DisplayName` import:
+
+```kotlin
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests how [DataObservationImpl] publishes initial data and reacts to
+ * failures reported by its subscription source.
+ */
+@DisplayName("`DataObservationImpl` should")
+internal class DataObservationImplSpec {
+
+    /**
+     * A subscription update must overwrite the value read initially.
+     */
+    @Test
+    fun `read initial data and apply subscription updates`() {
+        val source = FakeObservationSource("initial")
+        val observation = source.createObservation()
+
+        observation.initialize()
+        source.emit("updated")
+
+        observation.value shouldBe "updated"
+        observation.status.value shouldBe DataObservationStatus.Active
+    }
+
+    /**
+     * Cancellation is a caller's decision rather than an observation
+     * failure, so it propagates instead of becoming a failure status.
+     */
+    @Test
+    fun `propagate cancellation without converting it into failure status`() {
+        val source = FakeObservationSource("unused")
+        source.readFailure = CancellationException("Caller cancelled refresh.")
+        val observation = source.createObservation()
+
+        shouldThrow<CancellationException> {
+            observation.initialize()
+        }
+
+        observation.status.value shouldBe DataObservationStatus.Refreshing
+    }
+}
+```
+
+Arrange, act, and assert are separated by blank lines, as above. Both cases
+exercise the same subject; a suite does not mix unrelated subjects.
+
+**KDoc is required, on the suite and on every test method**, per the
+repository convention in `AGENTS.md`. A sentence-like method name states
+*what* the case does and does not waive the requirement — use the KDoc for
+what the name cannot carry: why the behavior matters, the bug a regression
+test pins down, or a fixture's contract. Existing suites are inconsistent
+here; new ones are not.
+
+**Throwing.** Use Kotest's `shouldThrow<E> { … }`
+(`io.kotest.assertions.throwables.shouldThrow`), not JUnit's
+`assertThrows`, as in the second case above. `shouldThrow` returns the
+thrown exception, so bind it when the exception itself carries something
+worth asserting. Assert a typed property, not the message — the standing
+repository rule is that tests do not assert text-message content unless the
+user explicitly asks for it. The shape, in the abstract:
+
+```kotlin
+val failure = shouldThrow<StatusRuntimeException> {
+    source.readValue()
+}
+failure.status.code shouldBe UNAVAILABLE
+```
+
+**Loop assertions carry a clue.** When a single test walks a sample table,
+wrap each iteration in `withClue` so a failure names the offending input —
+see `proto-values/src/test/kotlin/io/spine/money/MoneyExtsSpec.kt`.
+Prefer `@ParameterizedTest` for a fixed, enumerable set of cases.
+
+**Nested groups and parameterized tests** have their own layout rules —
+the one-line `@Nested` declaration with the name on the next line, and the
+`@TestInstance(PER_CLASS)` + private-instance-method `@MethodSource` shape
+Chords uses. See `references/advanced-test-patterns.md` when you reach for
+either.
+
+## Fixtures and stubs
+
+- **Shared test data goes in a `Given.kt`** next to the suites that use it,
+  as an `object Given` of factory functions named for the data they
+  produce — see
+  `codegen/tests/src/test/kotlin/io/spine/chords/codegen/Given.kt`.
+- **A stub used by one suite is a `private class Fake…` at the bottom of
+  that suite's file**, below the test methods — see `FakeObservationSource`
+  in `DataObservationImplSpec.kt` and `FakeConnectivityChannel` in
+  `ConnectionMonitorSpec.kt`, both in `client`. Give it mutable knobs the
+  test sets before acting (`readFailure`, `onSubscribe`, call counters)
+  rather than constructor-only configuration.
+- **A stub used by several suites gets its own file** in the same package.
+  No such stub exists yet — every stub in the repository is `private` to one
+  suite — so there is no local example to copy. Move one out only when a
+  second suite actually needs it, and keep it `internal`.
+- **A helper that sets up the test *environment*** — installing JVM-wide
+  state the code under test reads — is a separate concern from a stub, and
+  does get its own file. See `references/advanced-test-patterns.md`.
+- Chords does **not** use Gradle's `java-test-fixtures` plugin. Do not
+  introduce a `testFixtures` source set to share a stub; a plain class in
+  `src/test/kotlin` is the local pattern.
+- **Protobuf stubs follow the neighboring file.** Existing fixtures build
+  messages with Java builder chains (`Timestamp.newBuilder().setSeconds(1)
+  .build()`). Never wrap a proto builder in `.apply { }`.
+- Avoid fixtures that depend on a real Spine server, network resources, or
+  local absolute paths.
+
+## Pick a base or helper
+
+`spine-testlib` and Guava's test library are added to every module by
+`addDependencies()` in `buildSrc/src/main/kotlin/jvm-module.gradle.kts`
+(`Spine.testlib` and `Guava.testLib`), so these are available without a
+build change. All but `EqualsTester` live in `io.spine.testing`:
+
+**Base classes.** A suite extends at most one, and only when the target's
+shape matches:
+
+| Target shape | Extend |
+|---|---|
+| Utility class (final, private ctor, statics) | `UtilityClassTest<T>` |
+| A class's static/class-level concerns | `ClassTest<T>` |
+| A singleton class | `SingletonTest<T>` |
+
+**Standalone helpers.** Not base classes — call them from any suite,
+whether or not it extends a base:
+
+| Need | Use |
+|---|---|
+| `equals()`/`hashCode()` contract | `EqualsTester` (Guava) |
+| Random/sample test values | `TestValues` |
+
+`io.spine.testing.Assertions` (`assertNpe`, `assertIllegalArgument`, …) is
+deliberately **not** listed. It implements those checks with JUnit's
+`assertThrows` and Truth, which is the assertion style rule 7 rules out —
+and Kotest already covers it: `shouldThrow<NullPointerException> { … }` is
+the direct equivalent. `EqualsTester` stays because it is a contract tester
+with no Kotest counterpart, not an assertion style.
+
+These bases contribute *different* tests — `ClassTest` alone does far less
+than its name suggests, and picking it for a utility class silently drops
+two checks. Before extending one, read "What each `testlib` base
+contributes" in `references/advanced-test-patterns.md`.
+
+**A base is the default only when a base-class row fits.** A Kotlin
+`object` takes no `testlib` base — no row covers it, and a bare
+`internal class …Spec` is correct. That is the common case in Chords, which
+is why no suite currently extends one; it is not a reason to skip a base
+when the shape does match.
+
+## Repo notes
+
+- **Bump the version even for a tests-only change.** Every PR must
+  increment `chordsVersion` in `version.gradle.kts`, and `pom.xml` plus
+  `dependencies.md` must be regenerated with it. See "Versioning and
+  Reports" in `AGENTS.md`.
+- **KDoc every declaration**, including private ones and every test method,
+  per the repository convention in `AGENTS.md`. See "Structure and
+  formatting" for what the KDoc should add beyond the method name.
+- **Keep lines within 100 characters** (Detekt `MaxLineLength`), which
+  applies to test sources too.
+- **Rendering and interaction are not covered by automated tests** in this
+  repository. Test the logic behind a component, and report the
+  manual-verification remainder explicitly.
+
+## Report
+
+Return: **Files** (test files added or edited), **Naming** (the suite name
+chosen), **Helpers** (base classes, fixtures, or stubs used or added), and
+**Verification** — the Gradle test task run and its result, or, when it was
+not run, which task would have covered the change and why it was skipped.

--- a/.agents/skills/kotlin-jvm-tester/agents/openai.yaml
+++ b/.agents/skills/kotlin-jvm-tester/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Kotlin JVM Tester"
+  short_description: "Write a Chords test the way this repository writes them"
+  default_prompt: >
+    Use $kotlin-jvm-tester to write or review this test suite under Chords'
+    JUnit Jupiter and Kotest conventions.

--- a/.agents/skills/kotlin-jvm-tester/references/advanced-test-patterns.md
+++ b/.agents/skills/kotlin-jvm-tester/references/advanced-test-patterns.md
@@ -1,0 +1,98 @@
+# Advanced test patterns
+
+Supporting reference for `.agents/skills/kotlin-jvm-tester/SKILL.md`. Read
+the section that matches the shape in front of you; none of this is needed
+for an ordinary suite of flat `@Test` methods.
+
+## Nested case groups
+
+Keep `@Nested` (with any visibility and `inner class`) on **one line** and
+put the name on the **next** line, for backticked and plain names alike. The
+backtick rule is the same as for a test method: backtick a multi-word
+sentence or a Kotlin hard keyword, and write a single legal identifier
+plainly. A `@Nested` class is a declaration, so it carries KDoc like any
+other.
+
+```kotlin
+// Correct — multi-word name, so backticked and wrapped to the next line
+/**
+ * Groups the cases covering the extension-based factories.
+ */
+@Nested inner class
+`create instances by extension which` {
+    // ...
+}
+
+// Correct — single valid identifier, no backticks, still on its own line
+/**
+ * Groups the constructor-argument validation cases.
+ */
+@Nested inner class
+Construction {
+    // ...
+}
+```
+
+```kotlin
+// Avoid — name on the same line as the declaration
+@Nested
+internal inner class `check that a value is positive` {
+}
+```
+
+No suite uses `@Nested` today; the rule applies to the first one that does.
+
+## Parameterized tests
+
+Use `@ParameterizedTest` with `@MethodSource`. Chords supplies the data from
+a **private instance method** on a suite annotated
+`@TestInstance(TestInstance.Lifecycle.PER_CLASS)`, rather than from a
+`companion object` with `@JvmStatic` — `CodegenPluginsSpec` in
+`codegen/tests` is the reference. Follow the neighboring file.
+
+Prefer a parameterized test over a loop when the cases are a fixed,
+enumerable set: a failure then names the case instead of failing the whole
+method. When a loop is the better fit, wrap each iteration in `withClue` so
+the failure still identifies the offending input.
+
+## Test-environment helpers
+
+A helper that sets up the test *environment* is a separate concern from a
+stub of a collaborator, and it gets its own file.
+
+`TestApplication.kt` in `client/src/test` is the example. It installs the
+JVM-wide `app` property with a minimal **real** `Application` — not a mock —
+because types under test read application-wide defaults on construction, and
+reading an unassigned `app` throws.
+
+The part worth copying is its `install()`: idempotent and synchronized,
+because all test classes share one JVM and their execution order is not
+fixed. Every suite that needs the environment calls `install()` itself
+rather than assuming another suite already ran. Follow that shape for any
+future environment helper.
+
+## What each `testlib` base contributes
+
+The three bases contribute *different* tests. Know which ones you inherit,
+so you neither duplicate them nor assume coverage you did not get.
+
+- **`ClassTest<T>`** adds exactly **one** test: `NullPointerTester` over the
+  subject's static methods (public by default; pass a `Visibility` to the
+  constructor to widen it, and override `configure(NullPointerTester)` to
+  supply default instances). It does **not** check that the class is final
+  or that its constructor is private — it only exposes `assertFinal()` and
+  `assertHasPrivateParameterlessCtor()` as protected helpers for you to call
+  from your own test.
+- **`UtilityClassTest<T>`** extends `ClassTest<T>` and adds the two tests
+  that invoke those helpers: the class is `final`, and it has a private
+  parameterless constructor. Inheriting it covers all three concerns.
+- **`SingletonTest<T>`** extends `ClassTest<T>` and adds that the accessor
+  returns the same instance, plus a nested pair asserting that no non-private
+  constructor exists and at least one private one does. Its constructor takes
+  the accessor as a `Supplier<T>` alongside the subject class.
+
+So `ClassTest` is the narrow choice: pick it for a class whose static methods
+you want null-checked, and add the final/private-constructor assertions
+yourself if they matter. Where the target is a genuine utility class,
+`UtilityClassTest` is the right base — choosing `ClassTest` there silently
+drops two checks.

--- a/.agents/skills/tester/SKILL.md
+++ b/.agents/skills/tester/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: tester
 description: >
-  Chords test and verification policy. Use for test authoring and verification
-  strategy across core, proto, proto-values, client, the codegen runtime, and
+  Chords test and verification policy. Use to decide what to cover and how to
+  verify it across core, proto, proto-values, client, the codegen runtime, and
   codegen correctness tests, including Gradle verification commands.
+  `kotlin-jvm-tester` owns how a suite is written.
 ---
 
 # Testing
 
 ## Core Policy
 
-- Follow existing local style. Tests are named `*Spec.kt` and use JUnit
-  Jupiter with Truth, AssertK, or Kotest matchers depending on the owning
-  module; check neighboring tests before introducing a new dependency.
+- How a suite is written — naming, JUnit Jupiter structure, Kotest
+  assertions, fixtures, stubs, and `testlib` bases — is owned by
+  `.agents/skills/kotlin-jvm-tester/SKILL.md`. Follow it once the cases are
+  known.
 - Put focused regression tests in the module that owns the behavior, under
   `src/test/kotlin` mirroring the production package.
-- Keep fixtures small and near the tests (`Given.kt`-style files), named after
-  the behavior they represent.
 - Prefer public APIs, generated messages, and observable component state over
   private implementation details.
 - Cover both success and failure paths for validation, value parsing,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,13 @@ verification rule in that section.
   deliberately in a few places, such as resolving component type parameters).
 - Preserve existing package structure, module boundaries, naming conventions,
   and Gradle patterns.
+- Do not overengineer. Use the simplest construct that satisfies the current
+  requirement, and introduce a base class or interface only once at least two
+  concrete implementors exist. A type parameter is judged instead by whether
+  it preserves a type relationship the signature would otherwise lose.
+  Deliberate public extension points, such as
+  `io.spine.chords.core.Component`, are the exception. See "Design Restraint"
+  in `.agents/skills/engineer/SKILL.md`.
 - Do not manually edit generated sources or build outputs: `generated/`
   folders, codegen workspace outputs (`_out/`), Gradle wrapper files, or the
   generated `pom.xml` / `dependencies.md` reports (regenerate them with Gradle
@@ -270,11 +277,10 @@ If verification cannot be run, state the reason clearly in the final response.
   `content()`, pre-composition updates in `beforeComposeContent()`, and
   instance configuration via the `Props`-style lambdas. Composable functions
   and composable-emitting methods are named in `PascalCase`.
-- Tests are named `*Spec.kt`, use JUnit Jupiter with Truth/AssertK/Kotest
-  matchers depending on the owning module, and keep fixtures in `Given.kt`-style
-  files near the test.
-- Test methods may use Kotlin backtick names to match the style of the
-  surrounding test class.
+- Tests are named `*Spec.kt` and use JUnit Jupiter structure with Kotest
+  matchers. The full convention — engine constraints, naming, fixtures, and
+  `testlib` bases — is `.agents/skills/kotlin-jvm-tester/SKILL.md`; consult
+  it before adding or restructuring a suite.
 - Dependency coordinates live in `buildSrc/src/main/kotlin/io/spine/internal/dependency/`;
   add or change them there, following the existing object-per-library pattern.
 - Get the `config` submodule content with

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 23:31:44 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 04 13:22:49 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Mon Aug 03 23:31:44 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 23:31:46 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 04 13:22:51 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Mon Aug 03 23:31:46 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 23:31:47 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 04 13:22:52 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Mon Aug 03 23:31:47 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 23:31:48 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 04 13:22:53 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Mon Aug 03 23:31:48 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 23:31:49 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 04 13:22:54 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Mon Aug 03 23:31:49 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 23:31:50 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 04 13:22:55 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1104,7 +1104,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 13:05:53 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Aug 03 23:31:44 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,7 +1899,7 @@ This report was generated on **Mon Aug 03 13:05:53 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 13:05:55 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Aug 03 23:31:46 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2938,7 +2938,7 @@ This report was generated on **Mon Aug 03 13:05:55 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 13:05:56 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Aug 03 23:31:47 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3976,7 +3976,7 @@ This report was generated on **Mon Aug 03 13:05:56 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 13:05:57 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Aug 03 23:31:48 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4775,7 +4775,7 @@ This report was generated on **Mon Aug 03 13:05:57 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 13:05:57 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Aug 03 23:31:49 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5544,4 +5544,4 @@ This report was generated on **Mon Aug 03 13:05:57 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 03 13:05:58 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Aug 03 23:31:50 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.103</version>
+<version>2.0.0-SNAPSHOT.104</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.103")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.104")


### PR DESCRIPTION
## Summary

Adds two local agent skills that carry policy previously spread across the
area skills: `kotlin-engineer` for the Kotlin language itself, and
`kotlin-jvm-tester` for how a test suite is written. Also records a shared
design-restraint policy in the `engineer` router and `AGENTS.md`.

## Changes

- Add `.agents/skills/kotlin-engineer/`: the pinned 1.8.20 language ceiling,
  null-safety and `!!`, `lateinit` in `Props`, coroutine scoping and
  cancellation, and read-only public types under explicit API mode.
- Add `.agents/skills/kotlin-jvm-tester/`: JUnit Jupiter structure, Kotest
  assertions, `internal` `*Spec` naming, fixtures, hand-rolled stubs, and
  `testlib` bases, with `references/advanced-test-patterns.md` for shapes
  most tasks do not reach.
- Trim `component-engineer` to Compose-specific rules and `tester` to what
  to cover, deferring the language and suite mechanics to the new skills.
- Add a "Design Restraint" section to `engineer` and a matching rule to the
  Safety Rules in `AGENTS.md`; give `code-reviewer` findings for
  overengineering and for Kotlin-language violations.
- Document the `references/` convention in the skill index.

## Reviewer notes

This branch was cut from `init-data-without-blicking-ui`, so it also
contains the three commits of #154. Only the skills commit is new here;
review #154 separately, and merge it first.
