### PR TITLE
Add blocking progress overlays for submitting dialogs and wizards

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -106,6 +106,46 @@ the server connectivity:
 
 - etc.
 
+#### Indicating that a command is being posted
+
+`CommandDialog` and `CommandWizard` maintain the `submitting` property that
+they inherit from `Dialog` and `Wizard` while a command is being posted and its
+consequences are pending. Those base components cover their content with
+`ProgressOverlay` while that property is `true`, so both display a progress
+indicator and block the covered content without any changes at their usage
+sites.
+
+A standalone `CommandMessageForm` has no posting-state property, so it stays
+caller-controlled. Wrap it with `ProgressOverlay`, and drive the overlay from
+the state that the form's own consequence handlers maintain:
+
+```kotlin
+var posting by remember { mutableStateOf(false) }
+
+ProgressOverlay(posting) {
+    CommandMessageForm(
+        { AuthorizeUser.newBuilder() },
+        props = {
+            enabled = !posting
+            commandConsequences = {
+                onBeforePost { posting = true }
+                onServerError { posting = false }
+                onNetworkError { posting = false }
+                onEvent(
+                    UserAuthorized::class.java,
+                    UserAuthorized.Field.userName(),
+                    command.userName
+                ) {
+                    posting = false
+                }
+            }
+        }
+    ) {
+        // The form's field editors.
+    }
+}
+```
+
 #### Confirming cancellation of a command wizard
 
 A `CommandWizard` reports through its `dirty` property whether any data has been

--- a/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
+++ b/client/src/main/kotlin/io/spine/chords/client/form/CommandMessageForm.kt
@@ -152,6 +152,47 @@ import io.spine.protobuf.ValidatingBuilder
  * }
  * ```
  *
+ * ## Indicating that the command is being posted
+ *
+ * Unlike [CommandDialog][io.spine.chords.client.layout.CommandDialog] and
+ * [CommandWizard][io.spine.chords.client.layout.CommandWizard], which cover
+ * their content with a progress overlay while they are posting a command, this
+ * form has no posting-state property, so the code that declares it owns and
+ * maintains that state.
+ *
+ * A standalone `CommandMessageForm` therefore remains caller-controlled: wrap
+ * it with
+ * [ProgressOverlay][io.spine.chords.core.layout.ProgressOverlay], and drive
+ * that overlay from the state that the form's own consequence handlers
+ * maintain, like this:
+ *
+ * ```
+ * var posting by remember { mutableStateOf(false) }
+ *
+ * ProgressOverlay(posting) {
+ *     CommandMessageForm(
+ *         { AuthorizeUser.newBuilder() },
+ *         props = {
+ *             enabled = !posting
+ *             commandConsequences = {
+ *                 onBeforePost { posting = true }
+ *                 onServerError { posting = false }
+ *                 onNetworkError { posting = false }
+ *                 onEvent(
+ *                     UserAuthorized::class.java,
+ *                     UserAuthorized.Field.userName(),
+ *                     command.userName
+ *                 ) {
+ *                     posting = false
+ *                 }
+ *             }
+ *         }
+ *     ) {
+ *         // The form's field editors.
+ *     }
+ * }
+ * ```
+ *
  * @param C A type of the command message being edited with the form.
  */
 public class CommandMessageForm<C : CommandMessage> : MessageForm<C>() {

--- a/core/README.md
+++ b/core/README.md
@@ -106,5 +106,31 @@ In addition to components, the library includes such facilities:
   [RadioButtonWithText](src/main/kotlin/io/spine/chords/core/primitive/RadioButtonWithText.kt),
   or [WithTooltip](src/main/kotlin/io/spine/chords/core/layout/WithTooltip.kt).
 
+- **A blocking progress overlay** for content that is busy with an
+  asynchronous process
+  ([ProgressOverlay](src/main/kotlin/io/spine/chords/core/layout/ProgressOverlay.kt)).
+  It wraps arbitrary content, and, while it is active, covers that content with
+  a semitransparent layer that displays a progress indicator and prevents the
+  covered content from being operated with a pointing device:
+  ```kotlin
+  ProgressOverlay(saving) {
+      // The content that cannot be operated while it is being saved.
+  }
+  ```
+  The overlay doesn't change the way that the covered content is measured.
+  While it is inactive, no overlay or interaction-intercepting layer is
+  composed, and the wrapped content is composed and behaves exactly as it does
+  without the wrapper. Its background and indicator can be customized with the
+  respective parameters.
+
 - **More complex components** like
     [Wizard](src/main/kotlin/io/spine/chords/core/layout/Wizard.kt). 
+
+- **Automatic submission progress** in
+  [Dialog](src/main/kotlin/io/spine/chords/core/layout/Dialog.kt) and
+  [Wizard](src/main/kotlin/io/spine/chords/core/layout/Wizard.kt). Both apply
+  `ProgressOverlay` to their content whenever their `submitting` property is
+  `true`, which requires no changes at their usage sites. Such content
+  additionally stops receiving key events, so it cannot be edited, navigated,
+  or submitted again while the submission is in progress, while the dialog's
+  Cancel button and the wizard's "Cancel" button keep working.

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Dialog.kt
@@ -207,6 +207,18 @@ private val LocalDialogContentHeightMode = staticCompositionLocalOf {
  * original ones, make sure that they invoke the dialog's [submit] and [cancel]
  * methods respectively.
  *
+ * ## Submission progress
+ *
+ * A dialog whose submission is an asynchronous process can report that this
+ * process is in progress by setting the [submitting] property to `true`, and
+ * back to `false` when it completes.
+ *
+ * While [submitting] is `true`, the dialog covers its content section with
+ * a [ProgressOverlay], which displays a progress indicator and prevents the
+ * content from being edited or submitted again, both with a pointing device
+ * and with the keyboard. The buttons section is not covered, and the Cancel
+ * button, along with the Escape key, keeps cancelling the dialog.
+ *
  * ## Display modes
  *
  * The way that the dialog is displayed can be customized using the
@@ -387,9 +399,15 @@ public abstract class Dialog : Component() {
      * (an asynchronous process upon pressing the "Submit" button has been
      * initiated but not completed yet).
      *
-     * Depending on the dialog's implementation, this property can affect
-     * whether the Submit button and dialog's controls should be disabled
-     * or not. This property is not changed by the [Dialog] component
+     * While this property is `true`, the dialog's content section is covered
+     * with a [ProgressOverlay], and cannot be edited or submitted, neither
+     * with a pointing device, nor with the keyboard (see the "Submission
+     * progress" section in this class's description). The Submit button is
+     * disabled as well, and the dialog's cancellation remains available.
+     *
+     * Besides that, and depending on the dialog's implementation, this
+     * property can affect whether any other dialog's controls should be
+     * disabled or not. This property is not changed by the [Dialog] component
      * automatically, and it should be maintained by the actual dialog's
      * implementation as needed.
      */
@@ -417,9 +435,18 @@ public abstract class Dialog : Component() {
      * Specifies whether the "Submit" button should be displayed.
      */
     protected var submitAvailable: Boolean = false
-    internal var submitAvailableInternal: Boolean
-        get() = submitAvailable
-        set(value) { submitAvailable = value }
+
+    /**
+     * Specifies whether the dialog can currently be submitted with
+     * the submission shortcut (see [submitShortcutKey]).
+     *
+     * The shortcut is available whenever the Submit button is, and, just like
+     * that button, it is unavailable while the dialog is [submitting], so that
+     * the dialog cannot be submitted again while its submission is
+     * in progress.
+     */
+    internal val submitShortcutEnabled: Boolean
+        get() = submitAvailable && !submitting
 
     /**
      * Specifies whether the "Cancel" button should be displayed.
@@ -469,10 +496,23 @@ public abstract class Dialog : Component() {
      * Note that this method does not perform enabling/disabling of dialog's
      * controls and doesn't close the dialog. Any such effects should be a part
      * of the actual dialog's implementation in its [submitContent] method.
+     *
+     * This is a no-op while the dialog is [submitting], so that a submission
+     * cannot be started while another one is in progress. The live property is
+     * checked here rather than being relied upon through the disabled Submit
+     * button, because disabling a button takes effect only in the next
+     * composition, and because a custom [buttonsSection] can invoke this method
+     * from a button of its own, which stays outside the overlay and can remain
+     * enabled for the whole submission.
      */
-    public fun submit(): Unit = launch {
-        if (onBeforeSubmit()) {
-            submitContent()
+    public fun submit() {
+        if (submitting) {
+            return
+        }
+        launch {
+            if (onBeforeSubmit()) {
+                submitContent()
+            }
         }
     }
 
@@ -521,23 +561,36 @@ public abstract class Dialog : Component() {
      * By default, this renders the content section (see [contentSection]),
      * and the buttons section below it (see [buttonsSection]).
      *
+     * The content section is covered with a [ProgressOverlay] while the dialog
+     * is [submitting], and the buttons section is not, so that the dialog can
+     * still be cancelled while its submission is in progress.
+     *
      * @see contentSection
      * @see buttonsSection
      */
     @Composable
     protected open fun ColumnScope.windowContent() {
         val heightMode = LocalDialogContentHeightMode.current
-        val contentModifier = when (heightMode) {
+        val sizeModifier = when (heightMode) {
             DialogContentHeightMode.Natural -> Modifier
-            DialogContentHeightMode.AtMost -> Modifier
-                .weight(1F, fill = false)
-                .verticalScroll(rememberScrollState())
-            DialogContentHeightMode.Exact -> Modifier
-                .weight(1F)
-                .verticalScroll(rememberScrollState())
+            DialogContentHeightMode.AtMost -> Modifier.weight(1F, fill = false)
+            DialogContentHeightMode.Exact -> Modifier.weight(1F)
         }
-        Column(contentModifier) {
-            contentSection()
+        val scrollModifier = if (heightMode == DialogContentHeightMode.Natural) {
+            Modifier
+        } else {
+            Modifier.verticalScroll(rememberScrollState())
+        }
+        ProgressOverlay(submitting, sizeModifier) {
+            Column(
+                scrollModifier.blockKeyEvents(submitting) {
+                    if (cancelAvailable) {
+                        cancel()
+                    }
+                }
+            ) {
+                contentSection()
+            }
         }
         buttonsSection()
     }

--- a/core/src/main/kotlin/io/spine/chords/core/layout/ProgressOverlay.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/ProgressOverlay.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.pointer.PointerEventPass.Initial
+import androidx.compose.ui.input.pointer.pointerInput
+import io.spine.chords.core.keyboard.matches
+
+/**
+ * The opacity of the [ProgressOverlay]'s default background.
+ *
+ * The background dims the covered content enough for it to read as
+ * unavailable, while keeping it recognizable.
+ */
+private const val DefaultOverlayAlpha = 0.6f
+
+/**
+ * Displays the given [content], and covers it with a progress overlay while
+ * [active] is `true`.
+ *
+ * The overlay is a layer that is displayed above the content, occupies the
+ * content's full bounds, and prevents the content from being operated with
+ * a pointing device. It displays a progress indicator to signify that some
+ * process, which involves the content, is currently in progress.
+ *
+ * Wrapping the content with this function doesn't change the way that
+ * the content is measured or placed, and, while [active] is `false`, the
+ * content behaves exactly like it does without this wrapper (in particular,
+ * no interaction-intercepting layer is introduced).
+ *
+ * Here's an example of using it for a form whose data is being saved:
+ * ```kotlin
+ *     ProgressOverlay(saving) {
+ *         Column {
+ *             // The content that cannot be edited while it is being saved.
+ *         }
+ *     }
+ * ```
+ *
+ * Note that the overlay blocks the pointer input only, and the content that
+ * is covered by it can still be reached with the keyboard. A container that
+ * displays such content is expected to prevent the keyboard interaction on
+ * its own, like [Dialog] and [Wizard] do while they are submitting (see the
+ * "Submission progress" section in [Dialog]).
+ *
+ * @param active Specifies whether the progress overlay should be displayed
+ *   above the [content] currently.
+ * @param modifier The [Modifier] to be applied to the layout that contains
+ *   the [content] along with the overlay.
+ * @param background The color, which fills the overlay's bounds. It is
+ *   semitransparent by default, so that the covered content remains visible.
+ * @param indicator The content, which is displayed in the center of the
+ *   overlay, and is expected to indicate that some process is in progress.
+ * @param content The content, which the overlay is displayed above.
+ */
+@Composable
+public fun ProgressOverlay(
+    active: Boolean,
+    modifier: Modifier = Modifier,
+    background: Color = colorScheme.background.copy(alpha = DefaultOverlayAlpha),
+    indicator: @Composable () -> Unit = { CircularProgressIndicator() },
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier,
+
+        // Makes this wrapper transparent for the layout constraints that it
+        // receives, so that wrapping the content doesn't change the way that
+        // the content is measured.
+        propagateMinConstraints = true
+    ) {
+        content()
+        if (active) {
+            Box(
+                modifier = Modifier
+
+                    // Takes the content's size without participating in
+                    // the measurement of this layout.
+                    .matchParentSize()
+                    .background(background)
+                    .consumePointerInput(),
+                contentAlignment = Center
+            ) {
+                indicator()
+            }
+        }
+    }
+}
+
+/**
+ * Makes the modified layout consume all the pointer events that occur within
+ * its bounds, which prevents any content below that layout from receiving
+ * those events.
+ *
+ * The events are consumed on the [Initial] pass, which is the stage that
+ * precedes the one where the gesture detectors of the content below this
+ * layout would otherwise recognize them.
+ *
+ * @receiver The [Modifier] to which the pointer input handler is attached.
+ * @return the [Modifier] that consumes the pointer input.
+ */
+private fun Modifier.consumePointerInput(): Modifier =
+    pointerInput(Unit) {
+        awaitPointerEventScope {
+            while (true) {
+                awaitPointerEvent(Initial).changes.forEach { it.consume() }
+            }
+        }
+    }
+
+/**
+ * Makes the modified layout consume all the key events that are addressed to
+ * its content while [blocking] is `true`, which prevents the content from
+ * being operated with the keyboard.
+ *
+ * The events are consumed before the content has a chance to handle them, so
+ * neither the focused content itself, nor any keyboard shortcut declared
+ * within the modified layout is triggered while the content is blocked.
+ *
+ * The cancellation shortcut is consumed as well, and the [onCancelShortcut]
+ * callback is what makes it remain functional in the modified layout. Letting
+ * the event propagate instead would expose it to the blocked content, which
+ * could handle it in place of the layout's own cancellation.
+ *
+ * @receiver The [Modifier] to which the key event handler is attached.
+ * @param blocking Specifies whether the content's key events have to be
+ *   consumed currently.
+ * @param onCancelShortcut The callback invoked when the cancellation shortcut
+ *   (see [cancelShortcutKey]) is pressed while the content is blocked.
+ * @return the [Modifier] that consumes the content's key events.
+ */
+internal fun Modifier.blockKeyEvents(
+    blocking: Boolean,
+    onCancelShortcut: () -> Unit = {}
+): Modifier =
+    if (blocking) {
+        onPreviewKeyEvent { handleBlockedKeyEvent(it, onCancelShortcut) }
+    } else {
+        this
+    }
+
+/**
+ * Handles a key event that is addressed to the content that is currently
+ * blocked (see [blockKeyEvents]).
+ *
+ * @param event The key event that the blocked content would receive.
+ * @param onCancelShortcut The callback invoked when [event] is the
+ *   cancellation shortcut being pressed.
+ * @return `true` always, since no key event can reach the blocked content.
+ */
+internal fun handleBlockedKeyEvent(
+    event: KeyEvent,
+    onCancelShortcut: () -> Unit
+): Boolean {
+    if (event matches cancelShortcutKey.down) {
+        onCancelShortcut()
+    }
+    return true
+}

--- a/core/src/main/kotlin/io/spine/chords/core/layout/WindowType.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/WindowType.kt
@@ -140,7 +140,7 @@ public sealed class WindowType {
                     if (dialog.cancelAvailableInternal && event matches cancelShortcutKey.down) {
                         dialog.cancel()
                     }
-                    if (dialog.submitAvailableInternal && event matches submitShortcutKey.up) {
+                    if (dialog.submitShortcutEnabled && event matches submitShortcutKey.up) {
                         dialog.submit()
                     }
                     false

--- a/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
+++ b/core/src/main/kotlin/io/spine/chords/core/layout/Wizard.kt
@@ -102,6 +102,11 @@ private object WizardContentSize {
  * Both paths end up invoking [onCloseRequest] when the wizard is actually
  * closed, so a host that only needs to remove the wizard from the composition
  * can keep handling [onCloseRequest] alone.
+ *
+ * A wizard whose submission is asynchronous reports that this process is in
+ * progress with the [submitting] property, which makes the wizard cover its
+ * page with a [ProgressOverlay] and block the page's editing, navigation, and
+ * repeated submission until the process completes.
  */
 @Stable
 @Suppress(
@@ -180,6 +185,12 @@ public abstract class Wizard : Component() {
     /**
      * Specifies whether the wizard is in the submission state, which means
      * that an asynchronous form submission has started, but not completed yet.
+     *
+     * While this property is `true`, the wizard covers its page area with
+     * a [ProgressOverlay], and the page cannot be edited, navigated, or
+     * submitted again, neither with a pointing device, nor with the keyboard.
+     * The navigation panel is not covered, and its "Cancel" button keeps
+     * cancelling the wizard, while its other buttons are disabled.
      */
     protected var submitting: Boolean by mutableStateOf(false)
 
@@ -273,26 +284,28 @@ public abstract class Wizard : Component() {
                 if (title != null) {
                     Title(title!!)
                 }
-                Column(
-                    Modifier
-                        .weight(1F, fill = false)
-                        .on(Ctrl(Enter.key).up) {
-                            submitPage(currentPage)
-                        }
-                        .on(Alt(DirectionLeft.key).up) {
-                            handlePreviousClick()
-                        }
-                        .on(Alt(DirectionRight.key).up) {
-                            if (!isOnLastPage()) {
+                ProgressOverlay(submitting, Modifier.weight(1F, fill = false)) {
+                    Column(
+                        Modifier
+                            .blockKeyEvents(submitting)
+                            .on(Ctrl(Enter.key).up) {
                                 submitPage(currentPage)
                             }
+                            .on(Alt(DirectionLeft.key).up) {
+                                handlePreviousClick()
+                            }
+                            .on(Alt(DirectionRight.key).up) {
+                                if (!isOnLastPage()) {
+                                    submitPage(currentPage)
+                                }
+                            }
+                    ) {
+                        key(currentPage) {
+                            PageContainer(currentPage)
                         }
-                ) {
-                    key(currentPage) {
-                        PageContainer(currentPage)
-                    }
-                    LaunchedEffect(currentPage) {
-                        currentPage.show()
+                        LaunchedEffect(currentPage) {
+                            currentPage.show()
+                        }
                     }
                 }
                 NavigationPanel(
@@ -310,23 +323,70 @@ public abstract class Wizard : Component() {
         }
     }
 
-    private fun Wizard.submitPage(currentPage: WizardPage) {
+    /**
+     * Completes the given page, which either navigates the wizard to the next
+     * page, or submits the wizard, if [currentPage] is the last one.
+     *
+     * This is a no-op while the wizard is [submitting], so that the page that
+     * has already been submitted cannot be submitted or left again.
+     *
+     * @param currentPage The page that is displayed currently.
+     */
+    private fun submitPage(currentPage: WizardPage) {
+        if (submitting) {
+            return
+        }
         if (isOnLastPage()) {
-            launch {
-                handleFinishClick(currentPage)
-            }
+            handleFinishClick(currentPage)
         } else {
             handleNextClick(currentPage)
         }
     }
 
-    private fun Wizard.handleFinishClick(currentPage: WizardPage) = launch {
-        if (currentPage.validate()) {
-            submit()
+    /**
+     * Submits the wizard, if the given page is valid.
+     *
+     * This is a no-op while the wizard is [submitting], so that the wizard
+     * whose submission is in progress cannot be submitted again. The live
+     * property is checked here rather than being relied upon through the
+     * disabled "Finish" button, because disabling a button takes effect only
+     * in the next composition, and this method is also invoked by the
+     * navigation panel directly.
+     *
+     * @param currentPage The page that is displayed currently.
+     */
+    private fun handleFinishClick(currentPage: WizardPage) {
+        if (submitting) {
+            return
+        }
+        launch {
+            if (currentPage.validate()) {
+                submit()
+            }
         }
     }
 
+    /**
+     * Exposes [handleFinishClick] within the `internal` visibility scope, so
+     * that a test can exercise the navigation panel's submission path without
+     * locating the "Finish" button on the screen.
+     */
+    internal fun handleFinishClickInternal() {
+        handleFinishClick(currentPage)
+    }
+
+    /**
+     * Navigates the wizard to the next page, if the given page is valid.
+     *
+     * This is a no-op while the wizard is [submitting], so that the page whose
+     * submission is in progress cannot be left.
+     *
+     * @param currentPage The page that is displayed currently.
+     */
     private fun handleNextClick(currentPage: WizardPage) {
+        if (submitting) {
+            return
+        }
         if (currentPage.validate()) {
             if (!isOnLastPage()) {
                 currentPageIndex += 1
@@ -336,8 +396,14 @@ public abstract class Wizard : Component() {
 
     /**
      * Navigates the wizard to the previous page.
+     *
+     * This is a no-op while the wizard is [submitting], so that the page whose
+     * submission is in progress cannot be left.
      */
     private fun handlePreviousClick() {
+        if (submitting) {
+            return
+        }
         if (!isOnFirstPage()) {
             currentPageIndex -= 1
         }
@@ -422,7 +488,7 @@ private fun NavigationPanel(
                     Text("Finish")
                 }
             } else {
-                TextButton(onClick = onNextClick) {
+                TextButton(onClick = onNextClick, enabled = !submitting) {
                     Text("Next")
                 }
             }

--- a/core/src/test/kotlin/io/spine/chords/core/TestApplication.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/TestApplication.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core
+
+import io.spine.chords.core.appshell.Application
+import io.spine.chords.core.appshell.app
+import java.awt.Dimension
+
+/**
+ * Assigns the JVM-wide [app] property so that the components tested in this
+ * module can be composed outside a running application.
+ *
+ * [Component.Content] reads the application's
+ * [shared defaults][Application.sharedDefaults] before rendering a component,
+ * so composing any component requires [app] to be assigned. In a running
+ * application, [app] is assigned by [Application.run], which tests don't
+ * invoke, and reading an unassigned [app] throws [IllegalStateException].
+ *
+ * To prevent this, this object assigns [app] a real, but deliberately minimal
+ * [Application] instance rather than a mock. The instance serves no purpose
+ * other than satisfying the dependency described above: it declares no views,
+ * and its window is never created or shown, as [run][Application.run] is
+ * never invoked on it. It also customizes no
+ * [shared defaults][Application.sharedDefaults], so the components under test
+ * keep the default property values declared by their own implementations.
+ */
+internal object TestApplication {
+
+    /**
+     * Tells whether [install] has already assigned the [app] property.
+     */
+    private var installed: Boolean = false
+
+    /**
+     * Assigns the [app] property, doing nothing if a previous call has
+     * already assigned it.
+     *
+     * [app] is a [write-once][writeOnce] property, so assigning it twice
+     * fails. At the same time, all test classes that need an application share
+     * a single JVM, and each of them has to ensure that [app] is assigned
+     * before its own test cases run, since the order in which test classes are
+     * executed is not fixed.
+     *
+     * This method is therefore idempotent, and is synchronized to stay so if
+     * tests are executed in parallel. Any test class can safely call it, e.g.
+     * from a [BeforeAll][org.junit.jupiter.api.BeforeAll] method.
+     */
+    @Synchronized
+    fun install() {
+        if (!installed) {
+            app = Application(
+                name = "Chords core tests",
+                views = emptyList(),
+                minWindowSize = Dimension(1, 1)
+            )
+            installed = true
+        }
+    }
+}

--- a/core/src/test/kotlin/io/spine/chords/core/layout/DialogSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/DialogSpec.kt
@@ -26,14 +26,44 @@
 
 package io.spine.chords.core.layout
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.kotest.matchers.shouldBe
+import io.spine.chords.core.TestApplication
+import io.spine.chords.core.layout.WindowType.LightweightWindow
+import java.awt.event.KeyEvent.CTRL_DOWN_MASK
+import java.awt.event.KeyEvent.KEY_PRESSED
+import java.awt.event.KeyEvent.KEY_RELEASED
+import java.awt.event.KeyEvent.VK_A
+import java.awt.event.KeyEvent.VK_ENTER
+import java.awt.event.KeyEvent.VK_ESCAPE
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
+/**
+ * Tests the dialog's sizing properties, and the way that a dialog blocks its
+ * content while its submission is in progress.
+ */
+@DisplayName("`Dialog` should")
 internal class DialogSpec {
 
+    /**
+     * A dialog that was not given a size detects it from its content.
+     */
     @Test
     fun `determine dimensions from content by default`() {
         val dialog = TestDialog()
@@ -42,6 +72,10 @@ internal class DialogSpec {
         dialog.height shouldBe Dp.Unspecified
     }
 
+    /**
+     * The dialogs that the library provides are sized from their content as
+     * well, since their content is what defines how big they have to be.
+     */
     @Test
     fun `determine dimensions of built-in dialogs from content`() {
         val dialogs = listOf(
@@ -56,6 +90,9 @@ internal class DialogSpec {
         }
     }
 
+    /**
+     * A size that a dialog was given explicitly is the one that it keeps.
+     */
     @Test
     fun `allow specifying dimensions explicitly`() {
         val dialog = TestDialog().apply {
@@ -67,13 +104,280 @@ internal class DialogSpec {
         dialog.height shouldBe 400.dp
     }
 
-    private class TestDialog : Dialog() {
+    /**
+     * The content of a dialog that is not submitting anything is operated
+     * as usual, which is what the cases below observe the absence of while
+     * the dialog is submitting.
+     */
+    @Test
+    fun `let its content be operated when it is not submitting`() {
+        val dialog = TestDialog(submitAvailable = true)
+
+        dialogScene(dialog).use { scene ->
+            // The key event is sent before the click, since clicking moves
+            // the focus onto the control that has been clicked.
+            scene.pressKey(VK_A)
+            scene.click(ContentWidth / 2, ControlHeight / 2)
+
+            dialog.contentKeyEvents shouldBe 1
+            dialog.contentClicks shouldBe 1
+        }
+    }
+
+    /**
+     * The overlay that a submitting dialog displays above its content has to
+     * prevent that content from being edited with a pointing device, and the
+     * content has to become operable again once the submission completes.
+     */
+    @Test
+    fun `prevent its content from being clicked while it is submitting`() {
+        val dialog = TestDialog(submitAvailable = true)
+
+        dialogScene(dialog).use { scene ->
+            dialog.submitting = true
+            scene.render()
+            scene.click(ContentWidth / 2, ControlHeight / 2)
+
+            dialog.contentClicks shouldBe 0
+
+            dialog.submitting = false
+            scene.render()
+            scene.click(ContentWidth / 2, ControlHeight / 2)
+
+            dialog.contentClicks shouldBe 1
+        }
+    }
+
+    /**
+     * A key event must not reach the covered content while the dialog is
+     * submitting, so that neither the focused editor, nor a keyboard shortcut
+     * declared within the content can bypass the overlay.
+     */
+    @Test
+    fun `prevent its content from receiving key events while it is submitting`() {
+        val dialog = TestDialog(submitAvailable = true)
+
+        dialogScene(dialog).use { scene ->
+            dialog.submitting = true
+            scene.render()
+            scene.pressKey(VK_A)
+            scene.releaseKey(VK_ENTER, CTRL_DOWN_MASK)
+            scene.pressKey(VK_ESCAPE)
+
+            dialog.contentKeyEvents shouldBe 0
+
+            dialog.submitting = false
+            scene.render()
+            scene.pressKey(VK_A)
+
+            dialog.contentKeyEvents shouldBe 1
+        }
+    }
+
+    /**
+     * The submission shortcut is what could otherwise submit a dialog that is
+     * already being submitted, while its cancellation has to remain available
+     * at any time.
+     */
+    @Test
+    fun `disable the submission shortcut while it is submitting`() {
+        val dialog = TestDialog(submitAvailable = true, cancelAvailable = true)
+
+        dialog.submitShortcutEnabled shouldBe true
+
+        dialog.submitting = true
+
+        dialog.submitShortcutEnabled shouldBe false
+        dialog.cancelAvailableInternal shouldBe true
+    }
+
+    /**
+     * The Submit button is disabled while the dialog is submitting, but that
+     * only takes effect in the next composition, so the button that the
+     * previous frame rendered can still invoke [Dialog.submit]. A custom
+     * buttons section can call that method from a control of its own as well,
+     * which stays outside the overlay and can remain enabled for the whole
+     * submission. The method therefore has to check the live submission state
+     * itself.
+     */
+    @Test
+    fun `not submit its content again while it is submitting`() {
+        val dialog = TestDialog(submitAvailable = true, cancelAvailable = true)
+
+        submittableDialogScene(dialog).use { scene ->
+            dialog.submit()
+            scene.render()
+
+            dialog.submissions shouldBe 1
+
+            // The state is changed without an intervening frame, so the Submit
+            // button is still the enabled one that was rendered before the
+            // submission started.
+            dialog.submitting = true
+            dialog.submit()
+            scene.render()
+
+            dialog.submissions shouldBe 1
+        }
+    }
+
+    /**
+     * Displays the given dialog the way that a real one is displayed, through
+     * [Dialog.Content] rather than through its window content alone.
+     *
+     * This is what gives the dialog the coroutine scope that its submission
+     * runs on, which [dialogScene] does not, since that one composes the
+     * window content directly to keep the other cases free of a window.
+     *
+     * @param dialog The dialog to be displayed.
+     * @return The scene that displays the dialog.
+     */
+    private fun submittableDialogScene(dialog: TestDialog): TestScene = TestScene {
+        dialog.Content()
+    }
+
+    /**
+     * The consumed cancellation shortcut is what the dialog cancels itself
+     * upon, since letting that event propagate would expose it to the blocked
+     * content, which could handle it instead of the dialog.
+     */
+    @Test
+    fun `cancel itself on the cancellation shortcut consumed for the blocked content`() {
+        var cancellations = 0
+
+        val escapeConsumed = handleBlockedKeyEvent(
+            keyEvent(KEY_PRESSED, VK_ESCAPE)
+        ) { cancellations += 1 }
+
+        escapeConsumed shouldBe true
+        cancellations shouldBe 1
+    }
+
+    /**
+     * Every key event other than the cancellation shortcut is consumed as
+     * well, and none of them cancels the dialog.
+     */
+    @Test
+    fun `consume the other key events addressed to the blocked content`() {
+        var cancellations = 0
+        fun consume(event: KeyEvent) = handleBlockedKeyEvent(event) { cancellations += 1 }
+
+        consume(keyEvent(KEY_RELEASED, VK_ENTER, CTRL_DOWN_MASK)) shouldBe true
+        consume(keyEvent(KEY_PRESSED, VK_A)) shouldBe true
+
+        cancellations shouldBe 0
+    }
+
+    /**
+     * Displays the window content of the given dialog the way that
+     * a [WindowType] implementation does.
+     *
+     * @param dialog The dialog whose content is to be displayed.
+     * @return The scene that displays the dialog's content.
+     */
+    private fun dialogScene(dialog: TestDialog): TestScene = TestScene {
+        Column {
+            dialog.windowContentInternal(DialogContentHeightMode.Natural)
+        }
+    }
+
+    /**
+     * A minimal [Dialog] implementation, whose content counts the interactions
+     * that reach it.
+     *
+     * @param submitAvailable Whether the dialog has to display the Submit
+     *   button, and support the submission shortcut.
+     * @param cancelAvailable Whether the dialog has to display the Cancel
+     *   button, and support the cancellation shortcut.
+     */
+    private class TestDialog(
+        submitAvailable: Boolean = false,
+        cancelAvailable: Boolean = false
+    ) : Dialog() {
+
+        /**
+         * The number of clicks that the dialog's content has received.
+         */
+        var contentClicks: Int = 0
+            private set
+
+        /**
+         * The number of key events that the dialog's content has received.
+         */
+        var contentKeyEvents: Int = 0
+            private set
+
+        /**
+         * The number of times this dialog's content has been submitted.
+         */
+        var submissions: Int = 0
+            private set
 
         override val title: String = "Test"
 
-        @Composable
-        override fun contentSection(): Unit = Unit
+        init {
+            this.submitAvailable = submitAvailable
+            this.cancelAvailable = cancelAvailable
 
-        override suspend fun submitContent(): Unit = Unit
+            // Renders within the test scene, unlike the default desktop
+            // window, which would require a display.
+            windowType = LightweightWindow()
+        }
+
+        @Composable
+        override fun contentSection() {
+            val focusRequester = remember { FocusRequester() }
+            Column {
+                Box(
+                    Modifier
+                        .size(ContentWidth, ControlHeight)
+                        .clickable { contentClicks += 1 }
+                )
+                Box(
+                    Modifier
+                        .size(ContentWidth, ControlHeight)
+                        .focusRequester(focusRequester)
+                        .focusable()
+                        .onKeyEvent {
+                            contentKeyEvents += 1
+                            false
+                        }
+                )
+            }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        override suspend fun submitContent() {
+            submissions += 1
+        }
+    }
+
+    /**
+     * The dimensions of the content section of the dialog under test, and the
+     * environment that composing that dialog requires.
+     */
+    private companion object {
+
+        /**
+         * The width of the content section of the dialog under test.
+         */
+        val ContentWidth: Dp = 300.dp
+
+        /**
+         * The height of each of the two controls that the content section of
+         * the dialog under test consists of.
+         */
+        val ControlHeight: Dp = 100.dp
+
+        /**
+         * Assigns the application instance that a composed component requires.
+         */
+        @JvmStatic
+        @BeforeAll
+        fun setUpApplication() {
+            TestApplication.install()
+        }
     }
 }

--- a/core/src/test/kotlin/io/spine/chords/core/layout/ProgressOverlaySpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/ProgressOverlaySpec.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.Blue
+import androidx.compose.ui.graphics.Color.Companion.Green
+import androidx.compose.ui.graphics.Color.Companion.Red
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the way that [ProgressOverlay] displays its content, and the way that
+ * the overlay prevents that content from being operated while it is active.
+ */
+@DisplayName("`ProgressOverlay` should")
+internal class ProgressOverlaySpec {
+
+    /**
+     * An inactive overlay is not composed at all, so it neither displays
+     * anything, nor intercepts the interaction with the content.
+     */
+    @Test
+    fun `not display the overlay when it is inactive`() {
+        var indicatorDisplayed = false
+
+        overlayScene(active = false, indicator = { indicatorDisplayed = true }).use { scene ->
+            indicatorDisplayed shouldBe false
+            scene.pixelAt(ContentWidth / 2, ContentHeight / 2) shouldBe Blue.toArgb()
+        }
+    }
+
+    /**
+     * An active overlay displays its indicator above the content, and covers
+     * the content's bounds with its background.
+     */
+    @Test
+    fun `display the indicator above the content when it is active`() {
+        var indicatorDisplayed = false
+
+        overlayScene(active = true, indicator = { indicatorDisplayed = true }).use { scene ->
+            indicatorDisplayed shouldBe true
+            scene.pixelAt(ContentWidth / 2, ContentHeight / 2) shouldNotBe Blue.toArgb()
+            scene.pixelAt(1.dp, 1.dp) shouldNotBe Blue.toArgb()
+            scene.pixelAt(ContentWidth - 1.dp, ContentHeight - 1.dp) shouldNotBe Blue.toArgb()
+        }
+    }
+
+    /**
+     * The indicator is placed in the center of the covered content, rather
+     * than in an arbitrary position within it.
+     *
+     * A custom indicator stands in for the default one here, because the
+     * default [androidx.compose.material3.CircularProgressIndicator] is
+     * animated, and its indeterminate animation does not advance in the
+     * headless scene that this suite renders into — it draws nothing at all,
+     * no matter how many frames are rendered. What the default indicator looks
+     * like is therefore left to the manual test plan for this feature.
+     */
+    @Test
+    fun `display the indicator in the center of the content`() {
+        overlayScene(active = true, indicator = { CenterMarker() }).use { scene ->
+            scene.pixelAt(ContentWidth / 2, ContentHeight / 2) shouldBe Green.toArgb()
+
+            scene.pixelAt(MarkerSize, MarkerSize) shouldNotBe Green.toArgb()
+            scene.pixelAt(
+                ContentWidth - MarkerSize,
+                ContentHeight - MarkerSize
+            ) shouldNotBe Green.toArgb()
+        }
+    }
+
+    /**
+     * The default background dims the covered content instead of hiding it.
+     *
+     * An opaque background would produce the same pixel no matter what it
+     * covers, so covering two different contents and comparing the result is
+     * what tells a semitransparent background from an opaque one, without
+     * depending on the theme's colors.
+     */
+    @Test
+    fun `dim the content with a semitransparent background by default`() {
+        overlayScene(active = true, contentColor = Blue).use { overBlue ->
+            overlayScene(active = true, contentColor = Red).use { overRed ->
+                overBlue.pixelAt(1.dp, 1.dp) shouldNotBe overRed.pixelAt(1.dp, 1.dp)
+            }
+        }
+    }
+
+    /**
+     * The overlay is not measured along with the content that it covers, so
+     * the content is laid out the same way as it is without the overlay, even
+     * if the overlay's indicator is bigger than the content.
+     */
+    @Test
+    fun `preserve the content's size when it is active`() {
+        val contentSize = IntSize(ContentWidth.value.toInt(), ContentHeight.value.toInt())
+
+        overlayScene(active = false).use { scene ->
+            scene.contentSize shouldBe contentSize
+        }
+        overlayScene(active = true, indicator = { OversizedIndicator() }).use { scene ->
+            scene.contentSize shouldBe contentSize
+        }
+    }
+
+    /**
+     * The content that the active overlay covers cannot be operated with
+     * a pointing device, and it becomes operable again once the overlay
+     * is deactivated.
+     */
+    @Test
+    fun `prevent the covered content from receiving pointer input`() {
+        var active by mutableStateOf(false)
+        var clicks = 0
+
+        TestScene {
+            ProgressOverlay(active) {
+                Box(Modifier.size(ContentWidth, ContentHeight).clickable { clicks += 1 })
+            }
+        }.use { scene ->
+            scene.click(ContentWidth / 2, ContentHeight / 2)
+            clicks shouldBe 1
+
+            active = true
+            scene.render()
+            scene.click(ContentWidth / 2, ContentHeight / 2)
+            clicks shouldBe 1
+
+            active = false
+            scene.render()
+            scene.click(ContentWidth / 2, ContentHeight / 2)
+            clicks shouldBe 2
+        }
+    }
+
+    /**
+     * A caller that customizes the overlay's appearance gets the background
+     * and the indicator that it has specified, and the overlay keeps blocking
+     * the covered content.
+     */
+    @Test
+    fun `display the custom background and indicator`() {
+        var customIndicatorDisplayed = false
+        var clicks = 0
+
+        TestScene {
+            ProgressOverlay(
+                active = true,
+                background = Red,
+                indicator = { customIndicatorDisplayed = true }
+            ) {
+                Box(
+                    Modifier
+                        .size(ContentWidth, ContentHeight)
+                        .background(Blue)
+                        .clickable { clicks += 1 }
+                )
+            }
+        }.use { scene ->
+            customIndicatorDisplayed shouldBe true
+            scene.pixelAt(ContentWidth / 2, ContentHeight / 2) shouldBe Red.toArgb()
+
+            scene.click(ContentWidth / 2, ContentHeight / 2)
+            clicks shouldBe 0
+        }
+    }
+
+    /**
+     * Displays a fixed-size content of a recognizable color, covered with
+     * an overlay in the given state.
+     *
+     * @param active Whether the overlay has to be active.
+     * @param indicator The content displayed by the overlay.
+     * @return The scene that displays the content.
+     */
+    private fun overlayScene(
+        active: Boolean,
+        indicator: @Composable () -> Unit = {},
+        contentColor: Color = Blue
+    ): TestScene = TestScene {
+        ProgressOverlay(active, indicator = indicator) {
+            Box(Modifier.size(ContentWidth, ContentHeight).background(contentColor))
+        }
+    }
+
+    /**
+     * An indicator that is bigger than the content that this suite covers
+     * with an overlay.
+     */
+    @Composable
+    private fun OversizedIndicator() {
+        Box(Modifier.size(ContentWidth * 2, ContentHeight * 2).background(Color.Green))
+    }
+
+    /**
+     * A small indicator of a recognizable color, which marks the position that
+     * the overlay places its indicator at.
+     */
+    @Composable
+    private fun CenterMarker() {
+        Box(Modifier.size(MarkerSize).background(Green))
+    }
+
+    /**
+     * The dimensions of the content that this suite covers with an overlay.
+     */
+    private companion object {
+
+        /**
+         * The width of the content that this suite covers with an overlay.
+         */
+        val ContentWidth: Dp = 200.dp
+
+        /**
+         * The height of the content that this suite covers with an overlay.
+         */
+        val ContentHeight: Dp = 100.dp
+
+        /**
+         * The size of the indicator that marks its own placement.
+         */
+        val MarkerSize: Dp = 10.dp
+    }
+}

--- a/core/src/test/kotlin/io/spine/chords/core/layout/TestScene.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/TestScene.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.chords.core.layout
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ComposeScene
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import java.awt.Panel
+import java.awt.event.KeyEvent.CHAR_UNDEFINED
+import java.awt.event.KeyEvent.KEY_PRESSED
+import java.awt.event.KeyEvent.KEY_RELEASED
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Surface
+
+/**
+ * Displays the given content off-screen, and allows a test to interact with
+ * that content the way that a user does.
+ *
+ * The content is rendered onto an in-memory surface, so a test can be run
+ * without a display, and it is measured with a density of one pixel per [Dp]
+ * unit, so that the coordinates that a test specifies are the [Dp] values that
+ * the content was laid out with.
+ *
+ * The content is wrapped into a [MaterialTheme], which the components under
+ * test require, and is rendered once before this constructor returns, so it is
+ * ready to be interacted with. Note that a state change made by a test is
+ * applied to the content only upon the subsequent [render] call, just like it
+ * is applied only in the next frame of a running application.
+ *
+ * The scene has to be [closed][close] when a test is done with it, e.g. by
+ * using the [use][kotlin.io.use] function.
+ *
+ * @param width The width available to the content.
+ * @param height The height available to the content.
+ * @param content The content to be displayed in this scene.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+internal class TestScene(
+    private val width: Dp = DefaultSceneWidth,
+    private val height: Dp = DefaultSceneHeight,
+    content: @Composable () -> Unit
+) : AutoCloseable {
+
+    /**
+     * The density that makes a [Dp] unit occupy exactly one pixel.
+     */
+    private val density = Density(1f)
+
+    /**
+     * The scene that composes and lays out the content.
+     */
+    private val scene = ComposeScene(density = density)
+
+    /**
+     * The in-memory surface that the content is rendered onto.
+     */
+    private val surface = Surface.makeRasterN32Premul(
+        width.value.toInt(),
+        height.value.toInt()
+    )
+
+    /**
+     * The number of frames that have been rendered so far.
+     */
+    private var frames = 0L
+
+    init {
+        scene.constraints = with(density) {
+            Constraints(maxWidth = width.roundToPx(), maxHeight = height.roundToPx())
+        }
+        scene.setContent {
+            MaterialTheme {
+                content()
+            }
+        }
+        render()
+    }
+
+    /**
+     * The size that the content occupies.
+     */
+    val contentSize: IntSize
+        get() = scene.contentSize
+
+    /**
+     * Renders the next frame, which applies all the state changes that have
+     * been made since the previous one.
+     */
+    fun render() {
+        frames += 1
+        scene.render(surface.canvas, frames * FrameIntervalNanos)
+    }
+
+    /**
+     * Clicks at the given coordinates within the scene.
+     *
+     * @param x The horizontal coordinate to click at.
+     * @param y The vertical coordinate to click at.
+     */
+    fun click(x: Dp, y: Dp) {
+        click(with(density) { Offset(x.toPx(), y.toPx()) })
+    }
+
+    /**
+     * Clicks at the given position within the scene.
+     *
+     * @param position The position to click at, in pixels.
+     */
+    fun click(position: Offset) {
+        scene.sendPointerEvent(Press, position)
+        scene.sendPointerEvent(Release, position)
+    }
+
+    /**
+     * Presses the given key, and delivers the respective event to the content
+     * that is currently focused.
+     *
+     * @param keyCode The code of the key being pressed, as defined by
+     *   [java.awt.event.KeyEvent].
+     * @param modifiers The mask of the modifier keys that are held while the
+     *   key is pressed, as defined by [java.awt.event.KeyEvent].
+     */
+    fun pressKey(keyCode: Int, modifiers: Int = NoModifierKeys) {
+        scene.sendKeyEvent(keyEvent(KEY_PRESSED, keyCode, modifiers))
+    }
+
+    /**
+     * Releases the given key, and delivers the respective event to the content
+     * that is currently focused.
+     *
+     * @param keyCode The code of the key being released, as defined by
+     *   [java.awt.event.KeyEvent].
+     * @param modifiers The mask of the modifier keys that are held while the
+     *   key is released, as defined by [java.awt.event.KeyEvent].
+     */
+    fun releaseKey(keyCode: Int, modifiers: Int = NoModifierKeys) {
+        scene.sendKeyEvent(keyEvent(KEY_RELEASED, keyCode, modifiers))
+    }
+
+    /**
+     * Returns the color of the pixel that is displayed at the given
+     * coordinates as of the latest [render] call.
+     *
+     * @param x The horizontal coordinate of the pixel.
+     * @param y The vertical coordinate of the pixel.
+     * @return The pixel's color, in the ARGB format.
+     */
+    fun pixelAt(x: Dp, y: Dp): Int {
+        val bitmap = Bitmap()
+        bitmap.allocN32Pixels(surface.width, surface.height)
+        check(surface.readPixels(bitmap, 0, 0)) {
+            "Cannot read the pixels rendered by the test scene."
+        }
+        return bitmap.getColor(x.value.toInt(), y.value.toInt())
+    }
+
+    /**
+     * Closes the scene along with the surface that it renders onto.
+     */
+    override fun close() {
+        scene.close()
+        surface.close()
+    }
+
+    /**
+     * The defaults that a scene is created with.
+     */
+    private companion object {
+
+        /**
+         * The width available to the scene's content by default.
+         */
+        val DefaultSceneWidth = 800.dp
+
+        /**
+         * The height available to the scene's content by default.
+         */
+        val DefaultSceneHeight = 800.dp
+
+        /**
+         * The time between the frames that the scene renders, which imitates
+         * the frame rate of a running application.
+         */
+        const val FrameIntervalNanos = 16_000_000L
+
+    }
+}
+
+/**
+ * The mask that states that no modifier key is held.
+ */
+internal const val NoModifierKeys: Int = 0
+
+/**
+ * The time that is reported for the emulated key events.
+ *
+ * None of the components under test inspects it.
+ */
+private const val EventTimestamp: Long = 0L
+
+/**
+ * Creates a key event of the given type, as if it was triggered by
+ * a keyboard of a running application.
+ *
+ * @param eventType The type of the AWT event to create, which is either
+ *   [KEY_PRESSED] or [KEY_RELEASED].
+ * @param keyCode The code of the key that triggered the event, as defined by
+ *   [java.awt.event.KeyEvent].
+ * @param modifiers The mask of the modifier keys held at that moment, as
+ *   defined by [java.awt.event.KeyEvent].
+ * @return The created event.
+ */
+internal fun keyEvent(
+    eventType: Int,
+    keyCode: Int,
+    modifiers: Int = NoModifierKeys
+): KeyEvent = KeyEvent(
+    java.awt.event.KeyEvent(
+        Panel(), eventType, EventTimestamp, modifiers, keyCode, CHAR_UNDEFINED
+    )
+)

--- a/core/src/test/kotlin/io/spine/chords/core/layout/WizardSpec.kt
+++ b/core/src/test/kotlin/io/spine/chords/core/layout/WizardSpec.kt
@@ -26,16 +26,49 @@
 
 package io.spine.chords.core.layout
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import io.kotest.matchers.shouldBe
+import io.spine.chords.core.TestApplication
+import java.awt.event.KeyEvent.ALT_DOWN_MASK
+import java.awt.event.KeyEvent.CTRL_DOWN_MASK
+import java.awt.event.KeyEvent.VK_A
+import java.awt.event.KeyEvent.VK_ENTER
+import java.awt.event.KeyEvent.VK_LEFT
+import java.awt.event.KeyEvent.VK_RIGHT
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
+/**
+ * Tests the way that a wizard is cancelled, and the way that it blocks its
+ * page while its submission is in progress.
+ */
+@DisplayName("`Wizard` should")
 internal class WizardSpec {
 
+    /**
+     * A cancellation that the guard permits closes the wizard.
+     */
     @Test
     fun `close the wizard when the cancellation guard allows it`() {
         val wizard = TestWizard()
@@ -47,6 +80,10 @@ internal class WizardSpec {
         wizard.closeRequests shouldBe 1
     }
 
+    /**
+     * A guard that rejects the cancellation keeps the wizard open along with
+     * the data that has been entered in it.
+     */
     @Test
     fun `keep the wizard open when the cancellation guard rejects cancellation`() {
         val wizard = TestWizard().apply {
@@ -60,6 +97,10 @@ internal class WizardSpec {
         wizard.closeRequests shouldBe 0
     }
 
+    /**
+     * The guard suspends while a confirmation is displayed, and the wizard
+     * cannot be closed before that confirmation is answered.
+     */
     @Test
     fun `keep the wizard open while the cancellation guard is pending`() {
         val confirmation = CompletableDeferred<Boolean>()
@@ -81,6 +122,10 @@ internal class WizardSpec {
         wizard.closeRequests shouldBe 1
     }
 
+    /**
+     * A successful submission closes the wizard directly, so the confirmation
+     * that guards the cancellation is not displayed after it.
+     */
     @Test
     fun `close the wizard without consulting the cancellation guard on submission`() {
         var guardInvoked = false
@@ -98,8 +143,177 @@ internal class WizardSpec {
     }
 
     /**
+     * The page of a wizard that is not submitting anything is navigated and
+     * operated as usual, which is what the cases below observe the absence of
+     * while the wizard is submitting.
+     */
+    @Test
+    fun `let its page be operated when it is not submitting`() {
+        val wizard = TestWizard()
+
+        wizardScene(wizard).use { scene ->
+            scene.releaseKey(VK_RIGHT, ALT_DOWN_MASK)
+            scene.render()
+
+            wizard.pageIndex shouldBe 1
+
+            scene.releaseKey(VK_LEFT, ALT_DOWN_MASK)
+            scene.render()
+
+            wizard.pageIndex shouldBe 0
+
+            scene.click(wizard.clickTarget)
+
+            wizard.pageClicks shouldBe 1
+        }
+    }
+
+    /**
+     * A key event must not reach the covered page while the wizard is
+     * submitting, so that the page's editors cannot be operated with
+     * the keyboard.
+     */
+    @Test
+    fun `prevent its page from receiving key events while it is submitting`() {
+        val wizard = TestWizard()
+
+        wizardScene(wizard).use { scene ->
+            wizard.submittingInternal = true
+            scene.render()
+            scene.pressKey(VK_A)
+
+            wizard.pageKeyEvents shouldBe 0
+
+            wizard.submittingInternal = false
+            scene.render()
+            scene.pressKey(VK_A)
+
+            wizard.pageKeyEvents shouldBe 1
+        }
+    }
+
+    /**
+     * The overlay that a submitting wizard displays above its page has to
+     * prevent that page from being edited with a pointing device, and the page
+     * has to become operable again once the submission completes.
+     */
+    @Test
+    fun `prevent its page from being clicked while it is submitting`() {
+        val wizard = TestWizard()
+
+        wizardScene(wizard).use { scene ->
+            wizard.submittingInternal = true
+            scene.render()
+            scene.click(wizard.clickTarget)
+
+            wizard.pageClicks shouldBe 0
+
+            wizard.submittingInternal = false
+            scene.render()
+            scene.click(wizard.clickTarget)
+
+            wizard.pageClicks shouldBe 1
+        }
+    }
+
+    /**
+     * Navigating away from the page whose submission is in progress would
+     * display a page that the wizard is not submitting, so the navigation
+     * shortcuts have to be inactive while the wizard is submitting.
+     */
+    @Test
+    fun `not navigate its pages while it is submitting`() {
+        val wizard = TestWizard()
+
+        wizardScene(wizard).use { scene ->
+            scene.releaseKey(VK_RIGHT, ALT_DOWN_MASK)
+            scene.render()
+            wizard.submittingInternal = true
+            scene.render()
+
+            scene.releaseKey(VK_LEFT, ALT_DOWN_MASK)
+            scene.render()
+
+            wizard.pageIndex shouldBe 1
+
+            scene.releaseKey(VK_RIGHT, ALT_DOWN_MASK)
+            scene.render()
+
+            wizard.pageIndex shouldBe 1
+        }
+    }
+
+    /**
+     * The submission shortcut is what could otherwise submit a wizard whose
+     * submission is already in progress.
+     */
+    @Test
+    fun `not submit its page again while it is submitting`() {
+        val wizard = TestWizard()
+
+        wizardScene(wizard).use { scene ->
+            scene.releaseKey(VK_RIGHT, ALT_DOWN_MASK)
+            scene.render()
+            wizard.submittingInternal = true
+            scene.render()
+
+            scene.releaseKey(VK_ENTER, CTRL_DOWN_MASK)
+            scene.render()
+
+            wizard.submissions shouldBe 0
+
+            wizard.submittingInternal = false
+            scene.render()
+            scene.releaseKey(VK_ENTER, CTRL_DOWN_MASK)
+            scene.render()
+
+            wizard.submissions shouldBe 1
+        }
+    }
+
+    /**
+     * The "Finish" button is disabled while the wizard is submitting, but that
+     * only takes effect in the next composition, so the button that the
+     * previous frame rendered can still invoke its handler. The handler
+     * therefore has to check the live submission state itself.
+     */
+    @Test
+    fun `not submit itself again from the navigation panel while it is submitting`() {
+        val wizard = TestWizard()
+
+        wizardScene(wizard).use { scene ->
+            scene.releaseKey(VK_RIGHT, ALT_DOWN_MASK)
+            scene.render()
+
+            wizard.handleFinishClickInternal()
+            scene.render()
+
+            wizard.submissions shouldBe 1
+
+            // The state is changed without an intervening frame, so the
+            // "Finish" button is still the enabled one that was rendered
+            // before the submission started.
+            wizard.submittingInternal = true
+            wizard.handleFinishClickInternal()
+            scene.render()
+
+            wizard.submissions shouldBe 1
+        }
+    }
+
+    /**
+     * Displays the given wizard the way that its host does.
+     *
+     * @param wizard The wizard to be displayed.
+     * @return The scene that displays the wizard.
+     */
+    private fun wizardScene(wizard: TestWizard): TestScene = TestScene {
+        wizard.Content()
+    }
+
+    /**
      * A minimal [Wizard] implementation, which counts the close requests it
-     * has made.
+     * has made, and the interactions that its pages have received.
      */
     private class TestWizard : Wizard() {
 
@@ -109,25 +323,133 @@ internal class WizardSpec {
         var closeRequests: Int = 0
             private set
 
+        /**
+         * The number of times this wizard has been submitted.
+         */
+        var submissions: Int = 0
+            private set
+
+        /**
+         * The number of clicks that the currently displayed page has received.
+         */
+        var pageClicks: Int = 0
+            private set
+
+        /**
+         * The number of key events that the currently displayed page
+         * has received.
+         */
+        var pageKeyEvents: Int = 0
+            private set
+
+        /**
+         * The position that a test has to click at in order to click the
+         * clickable area of the currently displayed page.
+         */
+        var clickTarget: Offset = Offset.Zero
+            private set
+
+        /**
+         * Exposes the [submitting] property, which is `protected` in [Wizard],
+         * so that a test can imitate the submission that a real wizard's
+         * implementation reports.
+         */
+        var submittingInternal: Boolean
+            get() = submitting
+            set(value) { submitting = value }
+
+        /**
+         * The zero-based index of the page that is displayed currently.
+         */
+        val pageIndex: Int
+            get() = pages.indexOf(currentPage)
+
         override val title: String = "Test"
 
         init {
             onCloseRequest = { closeRequests += 1 }
         }
 
-        override fun createPages(): List<WizardPage> = listOf(TestPage(this))
+        override fun createPages(): List<WizardPage> =
+            listOf(TestPage(this), TestPage(this))
 
-        override suspend fun submit(): Unit = Unit
+        override suspend fun submit() {
+            submissions += 1
+        }
+
+        /**
+         * Renders the content that every page of this wizard displays, which
+         * registers the clicks that it receives, and holds the focus that
+         * the wizard's keyboard shortcuts require.
+         */
+        @Composable
+        fun PageContent() {
+            val focusRequester = remember { FocusRequester() }
+            Column {
+                Box(
+                    Modifier
+                        .size(PageContentWidth, PageControlHeight)
+                        .onGloballyPositioned {
+                            clickTarget = it.boundsInWindow().center
+                        }
+                        .clickable { pageClicks += 1 }
+                )
+                Box(
+                    Modifier
+                        .size(PageContentWidth, PageControlHeight)
+                        .focusRequester(focusRequester)
+                        .focusable()
+                        .onKeyEvent {
+                            pageKeyEvents += 1
+                            false
+                        }
+                )
+            }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
     }
 
     /**
-     * A wizard page with no content, which is valid at all times.
+     * A wizard page, which is valid at all times, and displays the content
+     * that the wizard under test observes the interactions with.
      */
-    private class TestPage(wizard: Wizard) : AbstractWizardPage(wizard) {
+    private class TestPage(private val testWizard: TestWizard) : AbstractWizardPage(testWizard) {
 
         @Composable
-        override fun content(): Unit = Unit
+        override fun content() {
+            testWizard.PageContent()
+        }
 
         override fun validate(): Boolean = true
+    }
+
+    /**
+     * The dimensions of the page content of the wizard under test, and the
+     * environment that composing that wizard requires.
+     */
+    private companion object {
+
+        /**
+         * The width of the content that every page of the wizard under test
+         * displays.
+         */
+        val PageContentWidth: Dp = 300.dp
+
+        /**
+         * The height of each of the two controls that the content of every
+         * page of the wizard under test consists of.
+         */
+        val PageControlHeight: Dp = 100.dp
+
+        /**
+         * Assigns the application instance that a composed component requires.
+         */
+        @JvmStatic
+        @BeforeAll
+        fun setUpApplication() {
+            TestApplication.install()
+        }
     }
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 04 13:22:49 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 05 11:53:54 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Tue Aug 04 13:22:49 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 04 13:22:51 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 05 11:53:55 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Tue Aug 04 13:22:51 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 04 13:22:52 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 05 11:53:56 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Tue Aug 04 13:22:52 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 04 13:22:53 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 05 11:53:57 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Tue Aug 04 13:22:53 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 04 13:22:54 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 05 11:53:58 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Tue Aug 04 13:22:54 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 04 13:22:55 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 05 11:53:59 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.104</version>
+<version>2.0.0-SNAPSHOT.105</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.104")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.105")


### PR DESCRIPTION
## Summary

`CommandDialog` and `CommandWizard` set the inherited `submitting` state while a command is being posted and its consequences are pending, but gave no visual indication that work was in progress.

This adds a reusable blocking progress overlay to `core`, and applies it automatically to the editable content of `Dialog` and `Wizard` while they are submitting. `CommandDialog` and `CommandWizard` receive the behaviour through their existing `postingState` → `submitting` wiring, so their usage sites need no changes.

## Changes

- Added `ProgressOverlay` to `io.spine.chords.core.layout`. It wraps arbitrary content and, while active, covers it with a semitransparent layer that displays a centered progress indicator and consumes the pointer input within its bounds. The background and the indicator are customizable, and wrapping the content does not change the way that the content is measured.
- Applied the overlay to the content section of `Dialog` and to the page area of `Wizard` whenever their `submitting` property is `true`. The dialog's buttons section and the wizard's navigation panel are left uncovered, so that cancelling stays possible while a submission is in progress.
- Blocked the keyboard access to the covered region, letting the cancellation shortcut through, so that neither the covered content nor a shortcut declared within it can be reached, while `Escape` keeps cancelling.
- Made the submission and navigation entry points check the live `submitting` state: `Dialog.submit()`, the dialog's submission shortcut, and the wizard's page-advance and "Finish" paths are no-ops while a submission is in progress. The wizard's "Next" button is disabled during submission, alongside "Back" and "Finish".
- Documented the new API and the automatic dialog and wizard behaviour in `core/README.md`, `client/README.md`, and the respective KDoc, including the way that a caller can wrap a standalone `CommandMessageForm` and drive the overlay from its own state.

Fixes #82
