### PR TITLE
`MoneyField` should ignore `.` for currencies without decimal places

### DIFF
--- a/.agents/skills/pair-workflow/SKILL.md
+++ b/.agents/skills/pair-workflow/SKILL.md
@@ -595,9 +595,11 @@ had enough. Guards:
 
 That creates the working document from the issue if it does not exist yet, then
 drives turns to a terminal state. `start` creates without running, `step` takes
-one turn, and `status` reports. A run stopped on questions resumes by running
-the same command again, once the answers are in the document. The slug defaults
-to `issue-<number>`, and every command accepts either form.
+one turn, and `status` reports the assigned engines, current work, rounds, and
+manual-testing decision without exposing internal review baselines. A run
+stopped on questions resumes by running the same command again, once the
+answers are in the document. The slug defaults to `issue-<number>`, and every
+command accepts either form.
 
 By default the driver uses Claude's `acceptEdits` permission mode with project
 settings only and Codex's `workspace-write` sandbox with user configuration

--- a/.agents/workflows/pair-test.sh
+++ b/.agents/workflows/pair-test.sh
@@ -524,10 +524,46 @@ check() { # check <name> <0|1 condition-result>
 sandbox
 run "$R" 7;         want "full run reaches done" 0 "is done"
 run "$R" status 7;  want "status reports done"   0 "status: done"
+check "done status reports no current agent work" \
+    "$(printf '%s' "$OUT" | grep -qx 'work: complete' && echo 0 || echo 1)"
+check "done status explains manual testing" \
+    "$(printf '%s' "$OUT" | grep -qx 'manual testing: not required' && echo 0 || echo 1)"
 transcript_count="$(find "$R/.agents/work/issue-7/turns" -name '*.log' | wc -l)"
 check "five transcripts kept" "$([[ "$transcript_count" -eq 5 ]] && echo 0 || echo 1)"
 check "first turn writes the required Task" \
     "$(grep -q 'Implement the issue' "$R/.agents/work/issue-7/plan.md" && echo 0 || echo 1)"
+cleanup
+
+# --- user-facing status ---------------------------------------------------
+sandbox
+export AGENT1_CMD="${SANDBOX}/bin/claude"
+export AGENT2_CMD="${SANDBOX}/bin/codex"
+run "$R" start 7
+want "status fixture starts" 0
+run "$R" status 7
+want "status reports both agent engines" 0 "agents: agent1=claude, agent2=codex"
+check "status describes the planning work" \
+    "$(printf '%s' "$OUT" | grep -qx 'work: agent1 — planning' \
+        && echo 0 || echo 1)"
+check "status explains an undecided manual check" \
+    "$(printf '%s' "$OUT" | grep -qx \
+        'manual testing: undecided until completion' && echo 0 || echo 1)"
+check "status hides the internal base commit" \
+    "$(! printf '%s' "$OUT" | grep -q '^base:' && echo 0 || echo 1)"
+TZ=America/New_York run "$R" status 7
+check "status renders the update time in the client timezone" \
+    "$(printf '%s' "$OUT" | grep -Eq \
+        '^updated: [A-Z][a-z]{2} [0-9]{2}, [0-9]{4} at [0-9]{2}:[0-9]{2} E[DS]T$' \
+        && echo 0 || echo 1)"
+run "$R" step 7
+want "planner advances status fixture" 0
+run "$R" status 7
+want "status describes plan review" 0 "work: agent2 — reviewing the plan"
+run "$R" step 7
+want "reviewer advances status fixture" 0
+run "$R" status 7
+want "status describes implementation work" 0 \
+    "work: agent1 — addressing plan review, then implementing"
 cleanup
 
 # --- agent selection -----------------------------------------------------

--- a/.agents/workflows/pair.sh
+++ b/.agents/workflows/pair.sh
@@ -1339,19 +1339,107 @@ cmd_status() {
     local slug; slug="$(resolve_slug "${1:-}")" || exit "$EXIT_ERROR"
     local doc; doc="$(doc_for "$slug")"
     require_doc "$doc"
-    local status_format
-    status_format='status: %s\nturn:   %s\nrounds: plan %s/%s, '
-    status_format+='implementation %s/%s\nbase:   %s\nmanual: %s\nupdated:%s\n'
-    printf "$status_format" \
-        "$(frontmatter "$doc" status)" \
-        "$(frontmatter "$doc" turn)" \
+    local status turn agent1 agent2 work manual
+    status="$(frontmatter "$doc" status)"
+    turn="$(frontmatter "$doc" turn)"
+    agent1="$(frontmatter "$doc" agent1)"
+    agent2="$(frontmatter "$doc" agent2)"
+    work="$(status_work "$doc" "$status" "$turn")"
+    manual="$(status_manual_testing "$(frontmatter "$doc" manual_testing)")"
+    printf 'status: %s\nagents: agent1=%s, agent2=%s\nwork: %s\n' \
+        "$status" \
+        "$(status_agent_name "$agent1")" \
+        "$(status_agent_name "$agent2")" \
+        "$work"
+    printf 'rounds: plan %s/%s, implementation %s/%s\n' \
         "$(frontmatter "$doc" plan_round)" \
         "$(frontmatter "$doc" max_rounds)" \
         "$(frontmatter "$doc" impl_round)" \
-        "$(frontmatter "$doc" max_rounds)" \
-        "$(frontmatter "$doc" base_commit)" \
-        "$(frontmatter "$doc" manual_testing)" \
-        "$(frontmatter "$doc" updated)"
+        "$(frontmatter "$doc" max_rounds)"
+    printf 'manual testing: %s\nupdated: %s\n' \
+        "$manual" \
+        "$(status_local_time "$(frontmatter "$doc" updated)")"
+}
+
+# Shortens a recorded executable path to the engine or wrapper name a person
+# recognizes in status output.
+status_agent_name() {
+    local executable="$1"
+    printf '%s' "${executable##*/}"
+}
+
+# Describes the work belonging to the current state instead of exposing only
+# the protocol's role token. A status snapshot cannot distinguish running work
+# from the next queued turn, so the wording remains valid in either case.
+status_work() {
+    local doc="$1" status="$2" turn="$3"
+    local description verdict
+
+    case "$status" in
+        plan-requested)
+            description="planning" ;;
+        plan-review-requested)
+            description="reviewing the plan" ;;
+        plan-reviewed)
+            verdict="$(review_verdict "$doc" \
+                "Plan Review — Round $(frontmatter "$doc" plan_round)")"
+            if [[ "$verdict" == "REQUEST CHANGES" ]]; then
+                description="revising the plan"
+            else
+                description="addressing plan review, then implementing"
+            fi
+            ;;
+        implementation-review-requested)
+            description="reviewing the implementation" ;;
+        implementation-reviewed)
+            verdict="$(review_verdict "$doc" \
+                "Implementation Review — Round $(frontmatter "$doc" impl_round)")"
+            if [[ "$verdict" == "REQUEST CHANGES" ]]; then
+                description="revising the implementation"
+            else
+                description="addressing implementation review, then finishing"
+            fi
+            ;;
+        questions-pending)
+            description="answering the implementer's questions" ;;
+        blocked)
+            description="resolving a blocker" ;;
+        done)
+            printf 'complete'
+            return
+            ;;
+        *)
+            description="waiting at ${status}" ;;
+    esac
+    printf '%s — %s' "$turn" "$description"
+}
+
+# Translates the protocol value into the decision a user needs from status.
+status_manual_testing() {
+    case "$1" in
+        unknown)  printf 'undecided until completion' ;;
+        none)     printf 'not required' ;;
+        required) printf 'required' ;;
+        *)        printf 'undecided (%s)' "${1:-not recorded}" ;;
+    esac
+}
+
+# Converts the driver's UTC timestamp to the workstation's local timezone.
+# GNU date and BSD date parse UTC differently, so use their native forms and
+# retain the recorded value only when neither implementation accepts it.
+status_local_time() {
+    local timestamp="$1" formatted epoch
+    if formatted="$(date -d "$timestamp" '+%b %d, %Y at %H:%M %Z' 2>/dev/null)"; then
+        printf '%s' "$formatted"
+        return
+    fi
+    if epoch="$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' \
+        "$timestamp" '+%s' 2>/dev/null)" \
+        && formatted="$(date -r "$epoch" '+%b %d, %Y at %H:%M %Z' 2>/dev/null)"; then
+        printf '%s' "$formatted"
+        return
+    fi
+    printf '%s' "$timestamp"
 }
 
 # A finished task whose acceptance criteria cannot be settled by automated

--- a/PAIR_AGENTS_RUN_GUIDE.md
+++ b/PAIR_AGENTS_RUN_GUIDE.md
@@ -246,7 +246,11 @@ number, then run the command again.
   `.agents/workflows/pair.sh run <issue>` — set up on the first call and resume
   on later calls.
 - `.agents/workflows/pair.sh status <issue>` — report the current state; safe
-  during a run.
+  during a run. The output names both assigned engines and describes the work
+  owned by the current turn. `manual testing` remains `undecided until
+  completion`, then becomes `not required` or `required`; when required, the
+  finished run prints the actionable manual test plan. The update time is
+  shown in the local timezone of the workstation running the command.
 - `.agents/workflows/pair.sh step <issue>` — attempt one workflow step, then
   stop.
 - `.agents/workflows/pair.sh start <issue>` — set up without running.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.107`
+# Dependencies of `io.spine.chords:spine-chords-client:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -1104,12 +1104,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 05 18:24:24 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 06 12:48:28 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.107`
+# Dependencies of `io.spine.chords:spine-chords-codegen-tests:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1899,12 +1899,12 @@ This report was generated on **Wed Aug 05 18:24:24 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 05 18:24:26 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 06 12:48:30 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.107`
+# Dependencies of `io.spine.chords:spine-chords-core:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.
@@ -2938,12 +2938,12 @@ This report was generated on **Wed Aug 05 18:24:26 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 05 18:24:27 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 06 12:48:31 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.107`
+# Dependencies of `io.spine.chords:spine-chords-proto:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : cafe.adriel.voyager. **Name** : voyager-core. **Version** : 1.0.1.**No license information found**
@@ -3976,12 +3976,12 @@ This report was generated on **Wed Aug 05 18:24:27 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 05 18:24:29 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 06 12:48:32 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.107`
+# Dependencies of `io.spine.chords:spine-chords-proto-values:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4775,12 +4775,12 @@ This report was generated on **Wed Aug 05 18:24:29 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 05 18:24:30 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 06 12:48:33 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.107`
+# Dependencies of `io.spine.chords:spine-chords-runtime:2.0.0-SNAPSHOT.108`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5544,4 +5544,4 @@ This report was generated on **Wed Aug 05 18:24:30 EEST 2026** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 05 18:24:31 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 06 12:48:34 EEST 2026** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords</artifactId>
-<version>2.0.0-SNAPSHOT.107</version>
+<version>2.0.0-SNAPSHOT.108</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
+++ b/proto/src/main/kotlin/io/spine/chords/proto/money/MoneyField.kt
@@ -307,9 +307,12 @@ internal class MoneyFieldReviser(
         return sanitizeMoneyField(current, updatedCandidate)
     }
 
-    override fun filterKeyEvent(keyEvent: KeyEvent): Boolean {
-        return keyEvent matches (!Digit and !decimalSeparator.key and !'.'.key).typed
-    }
+    override fun filterKeyEvent(keyEvent: KeyEvent): Boolean =
+        if (currency.options.exponentDigits == 0) {
+            keyEvent matches (!Digit).typed
+        } else {
+            keyEvent matches (!Digit and !decimalSeparator.key and !'.'.key).typed
+        }
 
     /**
      * Updates user's input when entered text replaces the one selected by user.

--- a/proto/src/test/kotlin/io/spine/chords/proto/money/MoneyFieldSpec.kt
+++ b/proto/src/test/kotlin/io/spine/chords/proto/money/MoneyFieldSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,12 @@
 
 package io.spine.chords.proto.money
 
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.text.TextRange
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.DisplayName
 import io.kotest.matchers.shouldBe
 import io.spine.chords.core.RawTextContent
+import io.spine.chords.proto.value.money.options
 import io.spine.money.Currency
 import io.spine.money.Currency.BIF
 import io.spine.money.Currency.IQD
@@ -39,15 +40,29 @@ import io.spine.money.Currency.PYG
 import io.spine.money.Currency.TZS
 import io.spine.money.Currency.UAH
 import io.spine.money.Currency.USD
+import io.spine.money.Currency.VND
 import io.spine.money.Currency.ZWL
+import java.awt.Panel
+import java.awt.event.KeyEvent.KEY_TYPED
+import java.awt.event.KeyEvent.VK_UNDEFINED
 import java.text.DecimalFormatSymbols
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
+/**
+ * The decimal separator used by the current JVM locale.
+ */
 private val decimalSeparator get() = DecimalFormatSymbols.getInstance().decimalSeparator
 
+/**
+ * Tests input revision and key filtering for [MoneyField].
+ */
 @DisplayName("`MoneyField` should")
 internal class MoneyFieldSpec {
 
+    /**
+     * Money text is normalized to the precision and character set of its currency.
+     */
     @Test
     fun `revise money field content`() {
         val sanitizingSamples = getSanitizingSamples()
@@ -70,6 +85,48 @@ internal class MoneyFieldSpec {
         }
     }
 
+    /**
+     * Fractional currencies must continue admitting a period for decimal input.
+     */
+    @Test
+    fun `admit period for currency with fractional digits`() {
+        USD.options.exponentDigits shouldBe 2
+        val reviser = MoneyFieldReviser(USD)
+
+        val consumed = reviser.filterKeyEvent(typedKeyEvent('.'))
+
+        consumed shouldBe false
+    }
+
+    /**
+     * Filtering a separator before text revision prevents zero-decimal amounts from truncating.
+     */
+    @Test
+    fun `preserve zero-decimal amount and caret when separator is typed`() {
+        VND.options.exponentDigits shouldBe 0
+        val reviser = MoneyFieldReviser(VND)
+        val amount = "1234567"
+        val separators = setOf('.', decimalSeparator)
+        val caretPositions = listOf(3, 0, amount.length)
+
+        separators.forEach { separator ->
+            caretPositions.forEach { position ->
+                withClue("Typing '$separator' at caret position $position") {
+                    val current = RawTextContent(amount, TextRange(position))
+
+                    val result = applyTypedCharacter(reviser, current, separator)
+
+                    result shouldBe current
+                }
+            }
+        }
+    }
+
+    /**
+     * Defines representative valid and invalid money strings for the sanitizer.
+     *
+     * @return Samples paired with their expected sanitized values.
+     */
     private fun getSanitizingSamples() = mapOf(
         // Valid dollar amounts.
         CurrencyAmount("0,00", USD) to "0,00",
@@ -147,4 +204,49 @@ internal class MoneyFieldSpec {
     )
 }
 
+/**
+ * A money string paired with the currency whose formatting rules apply to it.
+ *
+ * @property amount The raw money amount.
+ * @property currency The currency that defines the amount precision.
+ */
 private data class CurrencyAmount(val amount: String, val currency: Currency)
+
+/**
+ * Creates a Compose key event for typing [character] on a desktop keyboard.
+ *
+ * @param character The character emitted by the event.
+ * @return A Compose wrapper around a valid AWT `KEY_TYPED` event.
+ */
+private fun typedKeyEvent(character: Char): KeyEvent = KeyEvent(
+    java.awt.event.KeyEvent(
+        Panel(), KEY_TYPED, 0L, 0, VK_UNDEFINED, character
+    )
+)
+
+/**
+ * Models the preview-key filter followed by the text-change revision pipeline.
+ *
+ * @param reviser The reviser that filters and normalizes the typed character.
+ * @param current The amount text and collapsed caret before typing.
+ * @param character The character inserted at the current caret when admitted.
+ * @return The unchanged [current] content if the key is consumed, or the revised candidate.
+ */
+private fun applyTypedCharacter(
+    reviser: MoneyFieldReviser,
+    current: RawTextContent,
+    character: Char
+): RawTextContent {
+    if (reviser.filterKeyEvent(typedKeyEvent(character))) {
+        return current
+    }
+    require(current.selection.collapsed) {
+        "Typing is modelled only for a collapsed caret."
+    }
+    val caretPosition = current.selection.start
+    val candidateText = current.text.substring(0, caretPosition) +
+            character +
+            current.text.substring(caretPosition)
+    val candidate = RawTextContent(candidateText, TextRange(caretPosition + 1))
+    return reviser.reviseRawTextContent(current, candidate)
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of all Chords libraries.
  */
-val chordsVersion: String by extra("2.0.0-SNAPSHOT.107")
+val chordsVersion: String by extra("2.0.0-SNAPSHOT.108")


### PR DESCRIPTION
## Summary

Prevent `MoneyField` from truncating a zero-decimal currency amount when a
period is typed, preserving both the amount and caret without changing
fractional-currency behavior.

Make paired-agent status output identify the assigned engines and describe the
current work without exposing internal review metadata.

## Changes

- Consume typed non-digit events before text revision for currencies with no
  fractional digits.
- Preserve the existing separator-key handling for fractional currencies.
- Correct `MoneyFieldSpec` to use the active JUnit Jupiter `DisplayName`
  annotation.
- Report both paired-agent assignments and the phase-specific work owned by the
  current turn.
- Explain the manual-testing decision, hide the internal review baseline, and
  display update times in the workstation local timezone.
- Document the user-facing pair status output.
- Increment Chords to `2.0.0-SNAPSHOT.108` and refresh the generated dependency
  reports.

Fixes #122